### PR TITLE
Remove old vpc data file

### DIFF
--- a/terraform/data/govuk-vpc/integration.tfvars
+++ b/terraform/data/govuk-vpc/integration.tfvars
@@ -1,4 +1,0 @@
-
-"vpc_name" = "govuk-deana"
-"vpc_cidr" = "10.4.0.0/16"
-


### PR DESCRIPTION
govuk-vpc became infra-vpc, we forgot to remove one file.