### PR TITLE
Update volume snippet and logs-elasticsearch

### DIFF
--- a/terraform/projects/app-logs-elasticsearch/integration.delana.backend
+++ b/terraform/projects/app-logs-elasticsearch/integration.delana.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "delana/app-logs-elasticsearch.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/app-logs-elasticsearch/main.tf
+++ b/terraform/projects/app-logs-elasticsearch/main.tf
@@ -137,6 +137,7 @@ resource "aws_ebs_volume" "logs-elasticsearch-1" {
     aws_environment = "${var.aws_environment}"
     aws_migration   = "logs_elasticsearch"
     aws_hostname    = "logs-elasticsearch-1"
+    Device          = "xvdf"
   }
 }
 

--- a/terraform/userdata/10-attach-volumes
+++ b/terraform/userdata/10-attach-volumes
@@ -21,26 +21,29 @@ else
     echo "[$(date '+%H:%M:%S %d-%m-%Y')] attach-volume: ERROR volume not found"
   fi
 
-  echo "[$(date '+%H:%M:%S %d-%m-%Y')] attach-volume: attaching volume ..."
-  aws ec2 attach-volume --volume-id $VOLUME_ID --instance-id $INSTANCE_ID --device /dev/xvdf --region $REGION
+  for I in $VOLUME_ID ; do
+    DEVICE=$(aws ec2 describe-volumes --region=$REGION --volume-id ${I} | jq -r '.Volumes[].Tags[] | select(.Key=="Device") | .Value ')
+    if [[ -z $DEVICE ]] ; then
+      DEVICE=xvdf
+    fi
 
-  for I in {1..10} ; do
-    if ! [[ -e /dev/xvdf ]] ; then
-      sleep 1
+    echo "[$(date '+%H:%M:%S %d-%m-%Y')] attach-volume: attaching volume to /dev/$DEVICE ..."
+    aws ec2 attach-volume --volume-id ${I} --instance-id $INSTANCE_ID --device /dev/$DEVICE --region $REGION
+  
+    for I in {1..10} ; do
+      if ! [[ -e /dev/$DEVICE ]] ; then
+        sleep 1
+      else
+        break
+      fi
+    done
+
+    if [[ $(file -s /dev/$DEVICE | grep "/dev/$DEVICE: data") ]] ; then
+      echo "[$(date '+%H:%M:%S %d-%m-%Y')] attach-volume: /dev/$DEVICE does not contain any partition, Puppet will format the disk"
     else
-      break
+      echo "[$(date '+%H:%M:%S %d-%m-%Y')] attach-volume: /dev/$DEVICE is already formatted: $(file -s /dev/$DEVICE)"
     fi
   done
-
-  if [[ $(file -s /dev/xvdf | grep "/dev/xvdf: data") ]] ; then
-    echo "[$(date '+%H:%M:%S %d-%m-%Y')] attach-volume: /dev/xvdf does not contain any partition, Puppet will format the disk"
-  else
-    echo "[$(date '+%H:%M:%S %d-%m-%Y')] attach-volume: /dev/xvdf is already formatted: $(file -s /dev/xvdf)"
-
-    # Puppet does not activate the LVM volume
-    echo "[$(date '+%H:%M:%S %d-%m-%Y')] attach-volume: Activating LVM ..."
-    lvchange -a y /dev/graphite/data
-  fi
 fi
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END SNIPPET: attach-volumes"


### PR DESCRIPTION
Update the attach-volume snippet to use a device tag so we can
attach several volumes to an instance and continue doing the
LVM management with Puppet.

The EBS TF resource needs to include a 'Device' tag so we can attach
the volume to the right device during the instance initialisation.

Puppet already manages the devices and LVM configuration, but we'll
need to update the lvm module in Puppet to use the puppetlabs version
instead of our fork, as it fixes several bugs that prevented a disk
already formatted from working properly when a new instance is running
Puppet the first time.