### PR TITLE
Add govuk-ssh wrapper

### DIFF
--- a/doc/ssh-configs/README.md
+++ b/doc/ssh-configs/README.md
@@ -2,3 +2,25 @@
 
 Add the configs found in this directory to ~/.ssh/config to access the named
 AWS stack.
+
+## govuk-ssh
+
+`govuk-ssh` is a wrapper script which uses a script found on jumpboxes to enable
+access to machines in our environments without long lists of SSH config.
+
+## Install
+
+Copy the script to `/usr/local/bin/govuk-ssh` and make executable.
+
+## Usage
+
+To jump to a specific Puppet role in a stack in an environment:
+
+`govuk-ssh integration delana jenkins`
+
+If more than one machine exists under a specific role it will select the first
+IP returned by the API.
+
+If you want to jump to a specific machine, use the IP:
+
+`govuk-ssh integration delana 1.2.3.4`

--- a/doc/ssh-configs/govuk-ssh
+++ b/doc/ssh-configs/govuk-ssh
@@ -1,0 +1,22 @@
+#!/bin/bash
+ENVIRONMENT=$1
+STACKNAME=$2
+PUPPET_ROLE=$3
+
+function usage() {
+  echo "Usage: "
+  echo "govuk-ssh <integration> <stackname> <puppet_role or IP>"
+  exit 1
+}
+
+if [[ $STACKNAME == "" ]] || [[ $PUPPET_ROLE == "" ]] || [[ $ENVIRONMENT == "" ]]; then
+  usage
+fi
+
+# SSH to specific machine if IP is specified
+if [[ $PUPPET_ROLE =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+  ssh -tA jumpbox.$STACKNAME.$ENVIRONMENT.govuk.digital "ssh ${PUPPET_ROLE}"
+else
+  # Otherwise hop to a machine for that puppet role
+  ssh -tA jumpbox.$STACKNAME.$ENVIRONMENT.govuk.digital "ssh-proxy ${STACKNAME} ${PUPPET_ROLE}"
+fi


### PR DESCRIPTION
We will probably be working in multiple environments with multiple stacks. I don't want to have to populate my SSH config with long lists of the different stacks, so I wrote a wrapper which calls a script on the jumpboxes to find the different machines I want to log into to.

This is an alternative to `ec2ssh`. It's main feature is that it does not require maintaining a configuration file; just specify and go!

Depends on https://github.com/alphagov/govuk-puppet/pull/6151