### PR TITLE
Remove un-needed whitespace and double quotes

### DIFF
--- a/terraform/data/app-exception-handler/integration/common.tfvars
+++ b/terraform/data/app-exception-handler/integration/common.tfvars
@@ -1,5 +1,4 @@
-
-"user_data_snippets" = [
+user_data_snippets = [
   "00-base",
   "10-attach-volumes",
   "20-puppet-client",

--- a/terraform/data/app-exception-handler/integration/delana.tfvars
+++ b/terraform/data/app-exception-handler/integration/delana.tfvars
@@ -1,2 +1,1 @@
-
-"exception_handler_subnet" = "govuk_private_c"
+exception_handler_subnet = "govuk_private_c"

--- a/terraform/data/app-exception-handler/integration/issam.tfvars
+++ b/terraform/data/app-exception-handler/integration/issam.tfvars
@@ -1,2 +1,1 @@
-
-"exception_handler_subnet" = "govuk_private_c"
+exception_handler_subnet = "govuk_private_c"

--- a/terraform/data/app-graphite/integration/common.tfvars
+++ b/terraform/data/app-graphite/integration/common.tfvars
@@ -1,5 +1,4 @@
-
-"user_data_snippets" = [
+user_data_snippets = [
   "00-base",
   "10-attach-volumes",
   "20-puppet-client",

--- a/terraform/data/app-graphite/integration/delana.tfvars
+++ b/terraform/data/app-graphite/integration/delana.tfvars
@@ -1,2 +1,1 @@
-
-"graphite_1_subnet" = "govuk_private_a"
+graphite_1_subnet = "govuk_private_a"

--- a/terraform/data/app-logs-elasticsearch/integration/common.tfvars
+++ b/terraform/data/app-logs-elasticsearch/integration/common.tfvars
@@ -1,5 +1,4 @@
-
-"user_data_snippets" = [
+user_data_snippets = [
   "00-base",
   "10-attach-volumes",
   "20-puppet-client",

--- a/terraform/data/app-logs-elasticsearch/integration/delana.tfvars
+++ b/terraform/data/app-logs-elasticsearch/integration/delana.tfvars
@@ -1,4 +1,3 @@
-
-"logs_elasticsearch_1_subnet" = "govuk_private_a"
-"logs_elasticsearch_2_subnet" = "govuk_private_b"
-"logs_elasticsearch_3_subnet" = "govuk_private_c"
+logs_elasticsearch_1_subnet = "govuk_private_a"
+logs_elasticsearch_2_subnet = "govuk_private_b"
+logs_elasticsearch_3_subnet = "govuk_private_c"

--- a/terraform/data/app-mysql-primary/integration/common.tfvars
+++ b/terraform/data/app-mysql-primary/integration/common.tfvars
@@ -1,3 +1,2 @@
-
-"username" = "changeme"
-"password" = "thisisatest"
+username = "changeme"
+password = "thisisatest"

--- a/terraform/data/app-puppetmaster/integration/common.tfvars
+++ b/terraform/data/app-puppetmaster/integration/common.tfvars
@@ -1,5 +1,4 @@
-
-"user_data_snippets" = [
+user_data_snippets = [
   "00-base",
   "20-puppetmaster",
 ]

--- a/terraform/data/common/integration/common.tfvars
+++ b/terraform/data/common/integration/common.tfvars
@@ -1,12 +1,12 @@
-"aws_region" = "eu-west-1"
+aws_region = "eu-west-1"
 
-"aws_environment" = "integration"
+aws_environment = "integration"
 
-"remote_state_bucket" = "govuk-terraform-steppingstone-integration"
+remote_state_bucket = "govuk-terraform-steppingstone-integration"
 
-"ssh_public_key" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCqNd3w1dljlYl1SK8ey5cU80hACnfjZE13vJV49t1Zx+me/5dDnkoEASNB2HZgHlZeQb9sJmDl+MQdugcZy5/SfxohkxPUT+H+YXyERSsxv0iskkh9+HPTCQDWudom/4klRc4+OYY/vBgS6kUnBnTYdniWpL8XCWJOBrHQRzMcryeEI1705f45aEBpVxpgMD7LtHp/Tp+Pf4Qkvj9IFX9CnixltUpT5JgZI6qc1H4eE7QYlL0zko3N85IvaoMY8utM3Xmk5zkSJ/5VgnRFovgySCLzWqpoYA3CBYOZ6uEsj+6+2FCOxhO7y6NbIOmXMtQCGqclVusQQvwHoqbXRdUFPNU6M0xfOK9EN1CdnMJWcXXwrtkDhdmhtif7uanbJ4LlP6sE/Kxl3Aqb9ftff1Wk9DqYebznlfct2jE61jSZSfLrZc+7hbEV+EcexS2RPG5QTOoKvZsowAcXicpUY9ujq48XtQGjQwvoflrhe1ObPdLfI+/fVdKlBGDN2pcaxAKgRumWnhDHIBEXVS3tNpIatnx4IRbHJSs0hElRzsN6Btq80YaLZGcnio4Kq+A0pFzQrxCCvg/Zgz196WRC7XzMMiudI6FPfTRUfQxsU7+lqznb5AfpdVRqmgmW4ogOLbo1xvF3XmTsvkyaw8TvKbWmnIBJ53104V9rBZls0RAVNw== govuk"
+ssh_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCqNd3w1dljlYl1SK8ey5cU80hACnfjZE13vJV49t1Zx+me/5dDnkoEASNB2HZgHlZeQb9sJmDl+MQdugcZy5/SfxohkxPUT+H+YXyERSsxv0iskkh9+HPTCQDWudom/4klRc4+OYY/vBgS6kUnBnTYdniWpL8XCWJOBrHQRzMcryeEI1705f45aEBpVxpgMD7LtHp/Tp+Pf4Qkvj9IFX9CnixltUpT5JgZI6qc1H4eE7QYlL0zko3N85IvaoMY8utM3Xmk5zkSJ/5VgnRFovgySCLzWqpoYA3CBYOZ6uEsj+6+2FCOxhO7y6NbIOmXMtQCGqclVusQQvwHoqbXRdUFPNU6M0xfOK9EN1CdnMJWcXXwrtkDhdmhtif7uanbJ4LlP6sE/Kxl3Aqb9ftff1Wk9DqYebznlfct2jE61jSZSfLrZc+7hbEV+EcexS2RPG5QTOoKvZsowAcXicpUY9ujq48XtQGjQwvoflrhe1ObPdLfI+/fVdKlBGDN2pcaxAKgRumWnhDHIBEXVS3tNpIatnx4IRbHJSs0hElRzsN6Btq80YaLZGcnio4Kq+A0pFzQrxCCvg/Zgz196WRC7XzMMiudI6FPfTRUfQxsU7+lqznb5AfpdVRqmgmW4ogOLbo1xvF3XmTsvkyaw8TvKbWmnIBJ53104V9rBZls0RAVNw== govuk"
 
-"office_ips" = [
+office_ips = [
   "80.194.77.90/32",
   "80.194.77.100/32",
   "85.133.67.244/32",
@@ -18,7 +18,7 @@
   "213.86.153.237/32",
 ]
 
-"user_data_snippets" = [
+user_data_snippets = [
   "00-base",
   "20-puppet-client",
 ]

--- a/terraform/data/common/integration/delana.tfvars
+++ b/terraform/data/common/integration/delana.tfvars
@@ -1,6 +1,5 @@
+stackname = "delana"
 
-"stackname" = "delana"
-
-"remote_state_infra_vpc_key_stack" = "govuk"
-"remote_state_infra_networking_key_stack" = "govuk"
+remote_state_infra_vpc_key_stack = "govuk"
+remote_state_infra_networking_key_stack = "govuk"
 

--- a/terraform/data/common/integration/issam.tfvars
+++ b/terraform/data/common/integration/issam.tfvars
@@ -1,5 +1,4 @@
-"stackname" = "issam"
+stackname = "issam"
 
-"remote_state_infra_vpc_key_stack" = "govuk"
-"remote_state_infra_networking_key_stack" = "govuk"
-
+remote_state_infra_vpc_key_stack = "govuk"
+remote_state_infra_networking_key_stack = "govuk"

--- a/terraform/data/infra-networking/integration/govuk.tfvars
+++ b/terraform/data/infra-networking/integration/govuk.tfvars
@@ -1,58 +1,57 @@
+stackname = "govuk"
+remote_state_infra_vpc_key_stack = "govuk"
 
-"stackname" = "govuk"
-"remote_state_infra_vpc_key_stack" = "govuk"
-
-"public_subnet_cidrs" = {
+public_subnet_cidrs = {
   "govuk_public_a" = "10.1.1.0/24"
   "govuk_public_b" = "10.1.2.0/24"
   "govuk_public_c" = "10.1.3.0/24"
 }
 
-"public_subnet_availability_zones" = {
+public_subnet_availability_zones = {
   "govuk_public_a" = "eu-west-1a"
   "govuk_public_b" = "eu-west-1b"
   "govuk_public_c" = "eu-west-1c"
 }
 
-"public_subnet_nat_gateway_enable" = [ "govuk_public_a", "govuk_public_b", "govuk_public_c" ]
+public_subnet_nat_gateway_enable = [ "govuk_public_a", "govuk_public_b", "govuk_public_c" ]
 
-"private_subnet_cidrs" = {
+private_subnet_cidrs = {
   "govuk_private_a" = "10.1.4.0/24"
   "govuk_private_b" = "10.1.5.0/24"
   "govuk_private_c" = "10.1.6.0/24"
 }
 
-"private_subnet_elasticache_cidrs" = {
+private_subnet_elasticache_cidrs = {
   "govuk_elasticache_private_a" = "10.1.7.0/24"
   "govuk_elasticache_private_b" = "10.1.8.0/24"
   "govuk_elasticache_private_c" = "10.1.9.0/24"
 }
 
-"private_subnet_availability_zones" = {
+private_subnet_availability_zones = {
   "govuk_private_a" = "eu-west-1a"
   "govuk_private_b" = "eu-west-1b"
   "govuk_private_c" = "eu-west-1c"
 }
 
-"private_subnet_elasticache_availability_zones" = {
+private_subnet_elasticache_availability_zones = {
   "govuk_elasticache_private_a" = "eu-west-1a"
   "govuk_elasticache_private_b" = "eu-west-1b"
   "govuk_elasticache_private_c" = "eu-west-1c"
 }
 
-"private_subnet_nat_gateway_association" = {
+private_subnet_nat_gateway_association = {
   "govuk_private_a" = "govuk_public_a"
   "govuk_private_b" = "govuk_public_b"
   "govuk_private_c" = "govuk_public_c"
 }
 
-"private_subnet_rds_cidrs" = {
+private_subnet_rds_cidrs = {
   "govuk_rds_private_a" = "10.1.10.0/24"
   "govuk_rds_private_b" = "10.1.11.0/24"
   "govuk_rds_private_c" = "10.1.12.0/24"
 }
 
-"private_subnet_rds_availability_zones" = {
+private_subnet_rds_availability_zones = {
   "govuk_rds_private_a" = "eu-west-1a"
   "govuk_rds_private_b" = "eu-west-1b"
   "govuk_rds_private_c" = "eu-west-1c"

--- a/terraform/data/infra-root-dns-zones/integration/govuk.tfvars
+++ b/terraform/data/infra-root-dns-zones/integration/govuk.tfvars
@@ -1,9 +1,8 @@
+stackname = "govuk"
+remote_state_infra_vpc_key_stack = "govuk"
 
-"stackname" = "govuk"
-"remote_state_infra_vpc_key_stack" = "govuk"
+root_domain_internal_name = "integration.govuk-internal.digital."
+root_domain_external_name = "integration.govuk.digital."
 
-"root_domain_internal_name" = "integration.govuk-internal.digital."
-"root_domain_external_name" = "integration.govuk.digital."
-
-"create_internal_zone" = true
-"create_external_zone" = true
+create_internal_zone = true
+create_external_zone = true

--- a/terraform/data/infra-stack-dns-zones/integration/delana.tfvars
+++ b/terraform/data/infra-stack-dns-zones/integration/delana.tfvars
@@ -1,4 +1,3 @@
-
-"root_domain_internal_name" = "integration.govuk-internal.digital."
-"root_domain_external_name" = "integration.govuk.digital."
+root_domain_internal_name = "integration.govuk-internal.digital."
+root_domain_external_name = "integration.govuk.digital."
 

--- a/terraform/data/infra-stack-dns-zones/integration/issam.tfvars
+++ b/terraform/data/infra-stack-dns-zones/integration/issam.tfvars
@@ -1,4 +1,3 @@
-
-"root_domain_internal_name" = "integration.govuk-internal.digital."
-"root_domain_external_name" = "integration.govuk.digital."
+root_domain_internal_name = "integration.govuk-internal.digital."
+root_domain_external_name = "integration.govuk.digital."
 

--- a/terraform/data/infra-vpc/integration/govuk.tfvars
+++ b/terraform/data/infra-vpc/integration/govuk.tfvars
@@ -1,6 +1,4 @@
+stackname = "govuk"
 
-"stackname" = "govuk"
-
-"vpc_name" = "govuk-integration"
-"vpc_cidr" = "10.1.0.0/16"
-
+vpc_name = "govuk-integration"
+vpc_cidr = "10.1.0.0/16"


### PR DESCRIPTION
Many tfvars files have a leading empty line or variable names surrounded
by double quotes, these aren't needed so remove them.