### PR TITLE
[DISCUSS] Rough sketch to removing old nodes

### DIFF
--- a/terraform/projects/app-puppetmaster/additional_policy.json
+++ b/terraform/projects/app-puppetmaster/additional_policy.json
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1499854881000",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeInstances"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -140,6 +140,20 @@ module "puppetmaster" {
   instance_elb_ids              = ["${aws_elb.puppetmaster_bootstrap_elb.id}", "${aws_elb.puppetmaster_internal_elb.id}"]
 }
 
+# TODO: This will allow Puppetmaster to describe instances so that
+# we can run a script as an adhoc task that will remove nodes from
+# puppetdb that do not exist
+resource "aws_iam_policy" "puppetmaster_iam_policy" {
+  name   = "${var.stackname}-puppetmaster-additional"
+  path   = "/"
+  policy = "${file("${path.module}/additional_policy.json")}"
+}
+
+resource "aws_iam_role_policy_attachment" "puppetmaster_iam_role_policy_attachment" {
+  role       = "${module.puppetmaster.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.puppetmaster_iam_policy.arn}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 


### PR DESCRIPTION
This allows the Puppetmaster to query what instances are running in the estate (and other things that we should discuss).

It is possible to query the nodes in puppetdb using `govuk_node_list`, although this does require a manual DNS entry in `/etc/hosts` (in the future this could be done properly).

The idea is to compare what is in puppetdb and what the API states in running in the stack, and to remove a node if it doesn't report back a match from the API.

I do not think this should be the long term way to remove nodes, but it is a quick and dirty way to complete the task while we're testing.

I started thinking about this as I made changes to Icinga configuration. Puppet gets extremely upset with Icinga if nodes do not exist, and so I needed to deactivate some old ones.

This is the script I wrote to run every now and then to delete old ones:
```
#!/bin/bash
#
# Simple script to deactivate old nodes in PuppetDB
#
for node in $(govuk_node_list); do
  if [[ $(aws ec2 --region=eu-west-1 describe-instances --filters "Name=tag:aws_stackname,Values=delana" | jq -r ' .Reservations[] | .Instances[] | .PrivateDnsName' |grep $node) == "" ]]; then
    govuk_node_clean $node
  fi
done
```

In practice this could be run every 30 minutes which would ensure nodes are taken out of monitoring etc, but I think there are better ways to do this in Production using lifecycle events.