### PR TITLE
Update logs_elasticsearch application

### DIFF
--- a/terraform/data/app-logs-elasticsearch/integration/delana.tfvars
+++ b/terraform/data/app-logs-elasticsearch/integration/delana.tfvars
@@ -1,3 +1,5 @@
 logs_elasticsearch_1_subnet = "govuk_private_a"
 logs_elasticsearch_2_subnet = "govuk_private_b"
 logs_elasticsearch_3_subnet = "govuk_private_c"
+
+cluster_name = "logs-elasticsearch-delana"

--- a/terraform/projects/app-logs-elasticsearch/additional_policy.json
+++ b/terraform/projects/app-logs-elasticsearch/additional_policy.json
@@ -8,7 +8,8 @@
                 "ec2:AttachVolume",
                 "ec2:DetachVolume",
                 "ec2:DescribeVolumeStatus",
-                "ec2:DescribeVolumes"
+                "ec2:DescribeVolumes",
+                "ec2:DescribeInstances"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
This commit updates the logs_elasticsearch to:

 - add instance 2 and 3 by repeating the work for instance 1
 - add a new tag called "cluster_name" that will be used by Puppet to
 join elasticsearch instances to a cluster using ec2 discovery
 - Amend IAM permissions to allow Elasticsearch to DescribeInstances