### PR TITLE
Update tag for volume

### DIFF
--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -122,7 +122,7 @@ resource "aws_ebs_volume" "mapit-1" {
   tags {
     Name            = "${var.stackname}-mapit"
     Project         = "${var.stackname}"
-    aws_hostname    = "mapit"
+    aws_hostname    = "mapit-1"
     aws_migration   = "mapit"
     aws_stackname   = "${var.stackname}"
     aws_environment = "${var.aws_environment}"
@@ -153,7 +153,7 @@ resource "aws_ebs_volume" "mapit-2" {
   tags {
     Name            = "${var.stackname}-mapit"
     Project         = "${var.stackname}"
-    aws_hostname    = "mapit"
+    aws_hostname    = "mapit-2"
     aws_migration   = "mapit"
     aws_stackname   = "${var.stackname}"
     aws_environment = "${var.aws_environment}"


### PR DESCRIPTION
While this didn't error in the plan or apply, having the incorrect tag assigned to the volume meant that the volume didn't get mounted when the instances were started.