### PR TITLE
Increase resources of Puppetmaster

### DIFF
--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -132,7 +132,7 @@ module "puppetmaster" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "puppetmaster", "aws_hostname", "puppetmaster-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_puppetmaster_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "t2.large"
   create_instance_key           = true
   instance_key_name             = "${var.stackname}-puppetmaster_bootstrap"
   instance_public_key           = "${var.ssh_public_key}"


### PR DESCRIPTION
I had an instance where the Puppetmaster ran out of memory, and it's a
pain for the Puppetmaster to struggle of resources when we're testing
things.

This doubles the amount of memory.