### PR TITLE
Add JSON check tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,8 @@
       entry: tools/terraform-format.sh
       language: script
       files: \.tf$
+    - id: json-lint
+      name: ===> Make sure JSON is valid
+      entry: tools/json-check.sh
+      language: script
+      files: \.json$

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,10 @@ node ("terraform") {
       sh "find . -name '*.tf' |xargs tools/terraform-validate.sh"
     }
 
+    stage("JSON check") {
+      sh "find . -name '*.json' |xargs tools/json-check.sh"
+    }
+
     if (env.BRANCH_NAME == 'master'){
       stage("Push release tag") {
         echo 'Pushing tag'

--- a/tools/json-check.sh
+++ b/tools/json-check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eu
+
+for file in "$@"; do
+  lint=$(cat $file |jq -r '.' >/dev/null 2>/dev/null || echo "failed")
+
+  if [[ $lint == "failed" ]]; then
+    echo "${file} has invalid JSON"
+    exit 1
+  fi
+done


### PR DESCRIPTION
Check that JSON is valid using `jq`. This is a lightweight way to ensure that any IAM policies that are being submitted are valid JSON which will hopefully save a little time or pain.