### PR TITLE
Add Puppet CSR extensions and update certname

### DIFF
--- a/terraform/userdata/20-puppet-client
+++ b/terraform/userdata/20-puppet-client
@@ -16,6 +16,15 @@ cat <<EOF >/etc/puppet/puppet.conf
   [agent]
   report = false
   configtimeout = 600
+  certname = $(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+EOF
+
+cat <<EOF >/etc/puppet/csr_attributes.yaml
+extension_requests:
+ pp_instance_id: $(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+ pp_image_name: $(curl -s http://169.254.169.254/latest/meta-data/ami-id)
+ 1.3.6.1.4.1.34380.1.1.13: $(facter aws_migration)
+ 1.3.6.1.4.1.34380.1.1.18:  $(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//')
 EOF
 
 puppet agent --pluginsync --configtimeout 600 --test --waitforcert 60


### PR DESCRIPTION
Use a unique certificate name to avoid issues when DHCP ips are reassigned.
Add CSR extensions to Puppet certificates to enable policy based autosigning
and easier clean up.