### PR TITLE
Remove infra blue stacks

### DIFF
--- a/terraform/projects/infra-networking/integration.blue.backend
+++ b/terraform/projects/infra-networking/integration.blue.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-integration"
-key     = "blue/infra-networking.tfstate"
-encrypt = true
-region  = "eu-west-1"

--- a/terraform/projects/infra-root-dns-zones/integration.backend
+++ b/terraform/projects/infra-root-dns-zones/integration.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-integration"
-key     = "integration/infra-root-dns-zones.tfstate"
-encrypt = true
-region  = "eu-west-1"

--- a/terraform/projects/infra-root-dns-zones/integration.blue.backend
+++ b/terraform/projects/infra-root-dns-zones/integration.blue.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-integration"
-key     = "blue/infra-root-dns-zones.tfstate"
-encrypt = true
-region  = "eu-west-1"

--- a/terraform/projects/infra-vpc/integration.blue.backend
+++ b/terraform/projects/infra-vpc/integration.blue.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-integration"
-key     = "blue/infra-vpc.tfstate"
-encrypt = true
-region  = "eu-west-1"


### PR DESCRIPTION
The app 'blue' stack will use the 'govuk' VPC, root DNS and network infra stacks,
so we don't need those 'blue' backend files.

Also, remove an old integration.backend, probably left behind during the last
code refactoring.