### PR TITLE
Purge terraform dir on init

### DIFF
--- a/tools/build-terraform-project.sh
+++ b/tools/build-terraform-project.sh
@@ -104,6 +104,7 @@ cd "$PROJECT_DIR"
 # Actually run the command
 if [[ $CMD == "init" ]]; then
   rm -rf .terraform && \
+  rm -rf terraform.tfstate.backup && \
   terraform "$CMD" \
             -backend-config "$BACKEND_FILE"
 else

--- a/tools/build-terraform-project.sh
+++ b/tools/build-terraform-project.sh
@@ -103,6 +103,7 @@ cd "$PROJECT_DIR"
 
 # Actually run the command
 if [[ $CMD == "init" ]]; then
+  rm -rf .terraform && \
   terraform "$CMD" \
             -backend-config "$BACKEND_FILE"
 else


### PR DESCRIPTION
This ensures that you don't accidentally copy local statefiles from other stacks.

There's an argument that a purge and init should happen for every plan and apply for safety.