### PR TITLE
Allow all managed machines to connect to logs redis

### DIFF
--- a/terraform/projects/infra-security-groups/logs-redis.tf
+++ b/terraform/projects/infra-security-groups/logs-redis.tf
@@ -46,3 +46,16 @@ resource "aws_security_group_rule" "allow_logging_in" {
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.logging.id}"
 }
+
+resource "aws_security_group_rule" "allow_management_to_logging_redis" {
+  type      = "ingress"
+  from_port = 6379
+  to_port   = 6379
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.logs-redis.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.management.id}"
+}


### PR DESCRIPTION
The logship program connects directly to redis and so
needs this access