### PR TITLE
Refactor Puppetmaster for Puppetserver

### DIFF
--- a/terraform/projects/app-puppetmaster/additional_policy.json
+++ b/terraform/projects/app-puppetmaster/additional_policy.json
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1499854881000",
+            "Effect": "Allow",
+            "Action": [
+              "ec2:CreateTags"
+            ],
+            "Resource": [
+              "arn:aws:ec2:*"
+            ]
+        }
+    ]
+}

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -138,6 +138,18 @@ module "puppetmaster" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.puppetmaster_bootstrap_elb.id}", "${aws_elb.puppetmaster_internal_elb.id}"]
+  root_block_device_volume_size = "50"
+}
+
+resource "aws_iam_policy" "puppetmaster_iam_policy" {
+  name   = "${var.stackname}-puppetmaster-additional"
+  path   = "/"
+  policy = "${file("${path.module}/additional_policy.json")}"
+}
+
+resource "aws_iam_role_policy_attachment" "puppetmaster_iam_role_policy_attachment" {
+  role       = "${module.puppetmaster.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.puppetmaster_iam_policy.arn}"
 }
 
 # Outputs

--- a/terraform/userdata/20-puppetmaster
+++ b/terraform/userdata/20-puppetmaster
@@ -4,20 +4,18 @@
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START SNIPPET: puppetmaster"
 
-echo "127.0.0.1 puppet" >> /etc/hosts 
-
-# Enable autosigning of everything
-echo '*' > /etc/puppet/autosign.conf
-
 useradd deploy -m -s /bin/bash 
 mkdir -p /etc/puppet /usr/share/puppet/production/releases /usr/share/puppet/production/shared/cached-copy
 chown -R deploy: /usr/share/puppet/*
 apt-get -y install ruby-bundler
 
-# For Puppetdb
-apt-get -y install openjdk-7-jre-headless
-
-gem install --no-ri --no-rdoc hiera-eyaml-gpg gpgme
+cat <<EOF >/etc/puppet/csr_attributes.yaml
+extension_requests:
+ pp_instance_id: $(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+ pp_image_name: $(curl -s http://169.254.169.254/latest/meta-data/ami-id)
+ 1.3.6.1.4.1.34380.1.1.13: $(facter aws_migration)
+ 1.3.6.1.4.1.34380.1.1.18:  $(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//')
+EOF
 
 # on the machine run a verify
 puppet apply -e 'notify { "Hello from Puppet": }'

--- a/tools/aws-copy-puppet-setup.sh
+++ b/tools/aws-copy-puppet-setup.sh
@@ -54,6 +54,8 @@ mkdir -p -m 0700 /etc/puppet/gpg
 gpg --homedir /etc/puppet/gpg --allow-secret-key-import --import gpgkey
 chown -R puppet: /etc/puppet/gpg
 
+gem install --no-ri --no-rdoc hiera-eyaml-gpg gpgme
+
 puppet apply --verbose --trusted_node_data --hiera_config=/usr/share/puppet/production/current/hiera_aws.yml --modulepath=/usr/share/puppet/production/current/modules:/usr/share/puppet/production/current/vendor/modules/ --manifestdir=/usr/share/puppet/production/current/manifests /usr/share/puppet/production/current/manifests/site.pp
 
 chown -R deploy:deploy /usr/share/puppet/production/releases/${RELEASENAME}


### PR DESCRIPTION
Refactor the Puppetmaster project to move to puppetserver and support
policy-based autosign with AWS certificate extensions:
- Add additional policy to create tags on instances when the client
certificate is signed
- Increase puppetmaster root volume size
- Update puppetmaster userdata snippet to remove unrestricted autosign, as
we are going to use policies. The policy script will be installed in govuk-puppet
- Move openjdk package installation to govuk-puppet and gpg related gems to
bootstrap script. govuk-puppet is going to ensure these gems are absent after
installing the puppetserver package, as puppetserver uses its own gem tool.