### PR TITLE
Add artefact bucket

### DIFF
--- a/terraform/projects/infra-artefact-bucket/integration.govuk.backend
+++ b/terraform/projects/infra-artefact-bucket/integration.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "govuk/artefact-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-artefact-bucket/main.tf
+++ b/terraform/projects/infra-artefact-bucket/main.tf
@@ -1,0 +1,101 @@
+# == Manifest: projects:: Artefact-bucket :: buckets
+#
+# This creates 3 s3 buckets
+#
+# * artefact -- The bucket that will hold the artefacts
+# * artefact_access_logs -- Bucket for logs to go to
+# * artefact_replication_destination -- Bucket in another region to replicate to
+#
+# === Variables:
+#
+# aws_region
+# aws_secondary_region
+# aws_environment
+#
+# === Outputs:
+#
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "aws_secondary_region" {
+  type        = "string"
+  description = "Secondary region for cross-replication"
+  default     = "eu-west-2"
+}
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+# Set up the backend & provider for each region
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.9.10"
+}
+
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+provider "aws" {
+  alias  = "secondary"
+  region = "${var.aws_secondary_region}"
+}
+
+# Create the buckets
+# Logs bucket
+resource "aws_s3_bucket" "artefact_access_logs" {
+  bucket = "govuk-${var.aws_environment}-artefact-access-logs"
+  acl    = "log-delivery-write"
+
+  versioning {
+    enabled = true
+  }
+}
+
+# Replication bucket (different region to the other buckets)
+resource "aws_s3_bucket" "artefact_replication_destination" {
+  provider = "aws.secondary"
+  bucket   = "govuk-${var.aws_environment}-artefact-replication-destination"
+
+  versioning {
+    enabled = true
+  }
+}
+
+# Main bucket
+resource "aws_s3_bucket" "artefact" {
+  bucket = "govuk-${var.aws_environment}-artefact"
+
+  tags {
+    Name            = "govuk-${var.aws_environment}-artefact"
+    aws_environment = "${var.aws_environment}"
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    target_bucket = "${aws_s3_bucket.artefact_access_logs.id}"
+    target_prefix = "log/"
+  }
+
+  replication_configuration {
+    role = "${aws_iam_role.artefact_replication.arn}"
+
+    rules {
+      status = "Enabled"
+      prefix = ""
+
+      destination {
+        bucket = "${aws_s3_bucket.artefact_replication_destination.arn}"
+      }
+    }
+  }
+}

--- a/terraform/projects/infra-artefact-bucket/reader.tf
+++ b/terraform/projects/infra-artefact-bucket/reader.tf
@@ -1,0 +1,48 @@
+# == Manifest: projects:: Artefact-bucket :: reader
+#
+# Create a policy that allows reading of the artefacts bucket. This
+# doesn't create a role as the calling instance is assumed to already
+# have one which should be attached to this policy.
+#
+# This does create a user that can be used by external services (e.g. from
+# deploy in Carrenza).
+#
+# === Variables:
+#
+# === Outputs:
+#
+# read_artefact_bucket_policy_arn
+#
+
+resource "aws_iam_policy" "artefact_reader" {
+  name        = "govuk-${var.aws_environment}-artefact-reader-policy"
+  policy      = "${data.aws_iam_policy_document.artefact_reader.json}"
+  description = "Allows reading of the artefacts bucket"
+}
+
+resource "aws_iam_user" "artefact_reader" {
+  name = "govuk-${var.aws_environment}-artefact-reader"
+}
+
+resource "aws_iam_policy_attachment" "artefact_reader" {
+  name       = "artefact-reader-policy-attachment"
+  users      = ["${aws_iam_user.artefact_reader.name}"]
+  policy_arn = "${aws_iam_policy.artefact_reader.arn}"
+}
+
+data "aws_iam_policy_document" "artefact_reader" {
+  statement {
+    sid     = "ReadGovukArtefact"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.artefact.id}",
+      "arn:aws:s3:::${aws_s3_bucket.artefact.id}/*",
+    ]
+  }
+}
+
+output "read_artefact_bucket_policy_arn" {
+  value       = "${aws_iam_policy.artefact_reader.arn}"
+  description = "ARN of the read artefact-bucket policy"
+}

--- a/terraform/projects/infra-artefact-bucket/replication-role.tf
+++ b/terraform/projects/infra-artefact-bucket/replication-role.tf
@@ -1,0 +1,69 @@
+# == Manifest: projects:: Artefact-bucket :: replication-role
+#
+# Creates a role with attached policy to enable replication of the
+# artefacts bucket.
+#
+# === Variables:
+#
+# === Outputs:
+#
+
+resource "aws_iam_role" "artefact_replication" {
+  name               = "govuk-${var.aws_environment}-artefact-replication-role"
+  description        = "Allows replication of the artefacts bucket"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+resource "aws_iam_policy" "artefact_replication" {
+  name        = "govuk-${var.aws_environment}-artefact-replication-policy"
+  policy      = "${data.aws_iam_policy_document.artefact_replication.json}"
+  description = "Allows replication of the artefacts bucket"
+}
+
+resource "aws_iam_policy_attachment" "artefact_replication" {
+  name       = "govuk-${var.aws_environment}-artefact-replication-policy-attachment"
+  roles      = ["${aws_iam_role.artefact_replication.name}"]
+  policy_arn = "${aws_iam_policy.artefact_replication.arn}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "artefact_replication" {
+  statement {
+    actions = [
+      "s3:GetReplicationConfiguration",
+      "s3:ListBucket",
+    ]
+
+    resources = ["${aws_s3_bucket.artefact.arn}"]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionAcl",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.artefact.arn}/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:ReplicateObject",
+      "s3:ReplicateDelete",
+    ]
+
+    resources = ["${aws_s3_bucket.artefact_replication_destination.arn}/*"]
+  }
+}

--- a/terraform/projects/infra-artefact-bucket/writer.tf
+++ b/terraform/projects/infra-artefact-bucket/writer.tf
@@ -1,0 +1,63 @@
+# == Manifest: projects:: Artefact-bucket :: writer
+#
+# Create a policy that allows writing of the artefacts bucket. This
+# doesn't create a role as the calling instance is assumed to already
+# have one which should be attached to this policy.
+#
+# This does create a user that can be used by external services (e.g. from
+# deploy in Carrenza).
+#
+# === Variables:
+#
+# === Outputs:
+#
+# write_artefact_bucket_policy_arn
+#
+
+resource "aws_iam_policy" "artefact_writer" {
+  name        = "govuk-${var.aws_environment}-artefact-writer-policy"
+  policy      = "${data.aws_iam_policy_document.artefact_writer.json}"
+  description = "Allows writing of the artefacts bucket"
+}
+
+resource "aws_iam_user" "artefact_writer" {
+  name = "govuk-${var.aws_environment}-artefact-writer"
+}
+
+resource "aws_iam_policy_attachment" "artefact_writer" {
+  name       = "artefact-writer-policy-attachment"
+  users      = ["${aws_iam_user.artefact_writer.name}"]
+  policy_arn = "${aws_iam_policy.artefact_writer.arn}"
+}
+
+data "aws_iam_policy_document" "artefact_writer" {
+  statement {
+    sid = "ReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    # In theory  should work but it doesn't so use * instead
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    sid     = "WriteGovukArtefact"
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.artefact.id}",
+      "arn:aws:s3:::${aws_s3_bucket.artefact.id}/*",
+    ]
+  }
+}
+
+output "write_artefact_bucket_policy_arn" {
+  value       = "${aws_iam_policy.artefact_writer.arn}"
+  description = "ARN of the write artefact-bucket policy"
+}


### PR DESCRIPTION
This adds a project to build an artefact bucket. This is intended to
be written to by CI in Carrenza and read from by the deploy machines.
This means that we will not need to give AWS deploy machines access to
Carrenza (it would also simplify any bootstrapping process).