### PR TITLE
Add certname to puppetmaster userdata

### DIFF
--- a/terraform/userdata/20-puppetmaster
+++ b/terraform/userdata/20-puppetmaster
@@ -17,6 +17,8 @@ extension_requests:
  1.3.6.1.4.1.34380.1.1.18:  $(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//')
 EOF
 
+puppet config set certname $(curl -s http://169.254.169.254/latest/meta-data/instance-id) --section master
+
 # on the machine run a verify
 puppet apply -e 'notify { "Hello from Puppet": }'
 


### PR DESCRIPTION
The master section in the puppetmaster needs to configure the
certname to avoid having a certificate name with hostname instead
of instance Id.