### PR TITLE
Add certname to puppet main section

### DIFF
--- a/terraform/userdata/20-puppetmaster
+++ b/terraform/userdata/20-puppetmaster
@@ -17,7 +17,7 @@ extension_requests:
  1.3.6.1.4.1.34380.1.1.18:  $(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//')
 EOF
 
-puppet config set certname $(curl -s http://169.254.169.254/latest/meta-data/instance-id) --section master
+puppet config set certname $(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 
 # on the machine run a verify
 puppet apply -e 'notify { "Hello from Puppet": }'


### PR DESCRIPTION
We need the certname on the Puppet main section to make sure nothing
tries to use the hostname.