### PR TITLE
Add certs to publishing-api

### DIFF
--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# elb_certname
 #
 # === Outputs:
 #
@@ -33,6 +34,11 @@ variable "ssh_public_key" {
   description = "publishing-api default public key material"
 }
 
+variable "elb_certname" {
+  type        = "string"
+  description = "The ACM cert domain name to find the ARN of"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -44,6 +50,11 @@ provider "aws" {
   region = "${var.aws_region}"
 }
 
+data "aws_acm_certificate" "elb_cert" {
+  domain   = "${var.elb_certname}"
+  statuses = ["ISSUED"]
+}
+
 resource "aws_elb" "publishing-api_elb" {
   name            = "${var.stackname}-publishing-api"
   subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
@@ -51,17 +62,19 @@ resource "aws_elb" "publishing-api_elb" {
   internal        = "true"
 
   listener {
-    instance_port     = "443"
-    instance_protocol = "tcp"
+    instance_port     = 80
+    instance_protocol = "http"
     lb_port           = "443"
-    lb_protocol       = "tcp"
+    lb_protocol       = "https"
+
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_cert.arn}"
   }
 
   health_check {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:443"
+    target              = "TCP:80"
     interval            = 30
   }
 

--- a/terraform/projects/infra-security-groups/publishing-api.tf
+++ b/terraform/projects/infra-security-groups/publishing-api.tf
@@ -23,8 +23,8 @@ resource "aws_security_group" "publishing-api" {
 
 resource "aws_security_group_rule" "allow_publishing-api_elb_in" {
   type      = "ingress"
-  from_port = 443
-  to_port   = 443
+  from_port = 80
+  to_port   = 80
   protocol  = "tcp"
 
   # Which security group is the rule assigned to


### PR DESCRIPTION
This acts like a backend machine, so needs certificates.

Currently only listening on HTTP so LB will show as down, so apps are unable to speak to it.