### PR TITLE
[DISCUSS] Allow router-backend to cache

### DIFF
--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -70,6 +70,13 @@ resource "aws_elb" "cache_elb" {
     ssl_certificate_id = "${data.aws_acm_certificate.elb_cert.arn}"
   }
 
+  listener {
+    instance_port     = 3055
+    instance_protocol = "tcp"
+    lb_port           = 3055
+    lb_protocol       = "tcp"
+  }
+
   health_check {
     healthy_threshold   = 2
     unhealthy_threshold = 2

--- a/terraform/projects/infra-security-groups/cache.tf
+++ b/terraform/projects/infra-security-groups/cache.tf
@@ -44,6 +44,21 @@ resource "aws_security_group" "cache_elb" {
   }
 }
 
+# Router backend needs access to cache for router-api to communicate with
+# router to reload routes
+resource "aws_security_group_rule" "allow_router-backend_to_cache_elb" {
+  type      = "ingress"
+  from_port = 3055
+  to_port   = 3055
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.cache_elb.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.router-backend.id}"
+}
+
 # TODO test whether egress rules are needed on ELBs
 resource "aws_security_group_rule" "allow_cache_elb_egress" {
   type              = "egress"


### PR DESCRIPTION
router-api needs to communicate with the cache instances to reload routes.

This needs discussion because router needs to be able reload routes on each router instance, and if it goes through a load balancer then it will only do it on a single instance.

I suspect we may need to recode how we set the environment variable for "ROUTER_NODES" to look up router instances based upon tags.