### PR TITLE
Add an external ELB to whitehall

### DIFF
--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -9,7 +9,8 @@
 # aws_environment
 # ssh_public_key
 # instance_ami_filter_name
-# elb_certname
+# elb_internal_certname
+# elb_external_certname
 # app_service_records
 #
 # === Outputs:
@@ -42,7 +43,12 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
-variable "elb_certname" {
+variable "elb_internal_certname" {
+  type        = "string"
+  description = "The ACM cert domain name to find the ARN of"
+}
+
+variable "elb_external_certname" {
   type        = "string"
   description = "The ACM cert domain name to find the ARN of"
 }
@@ -64,15 +70,20 @@ provider "aws" {
   region = "${var.aws_region}"
 }
 
-data "aws_acm_certificate" "elb_cert" {
-  domain   = "${var.elb_certname}"
+data "aws_acm_certificate" "elb_external_cert" {
+  domain   = "${var.elb_external_certname}"
   statuses = ["ISSUED"]
 }
 
-resource "aws_elb" "whitehall-backend_elb" {
+data "aws_acm_certificate" "elb_internal_cert" {
+  domain   = "${var.elb_internal_certname}"
+  statuses = ["ISSUED"]
+}
+
+resource "aws_elb" "whitehall-backend_internal_elb" {
   name            = "${var.stackname}-whitehall-backend"
   subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_elb_id}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_internal_elb_id}"]
   internal        = "true"
 
   listener {
@@ -81,7 +92,7 @@ resource "aws_elb" "whitehall-backend_elb" {
     lb_port           = 443
     lb_protocol       = "https"
 
-    ssl_certificate_id = "${data.aws_acm_certificate.elb_cert.arn}"
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_internal_cert.arn}"
   }
 
   health_check {
@@ -100,24 +111,67 @@ resource "aws_elb" "whitehall-backend_elb" {
   tags = "${map("Name", "${var.stackname}-whitehall-backend", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "whitehall_backend")}"
 }
 
-resource "aws_route53_record" "service_record" {
+resource "aws_route53_record" "internal_service_record" {
   zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
   name    = "whitehall-backend.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
   type    = "A"
 
   alias {
-    name                   = "${aws_elb.whitehall-backend_elb.dns_name}"
-    zone_id                = "${aws_elb.whitehall-backend_elb.zone_id}"
+    name                   = "${aws_elb.whitehall-backend_internal_elb.dns_name}"
+    zone_id                = "${aws_elb.whitehall-backend_internal_elb.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_elb" "whitehall-backend_external_elb" {
+  name            = "${var.stackname}-whitehall-backend-external"
+  subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_external_elb_id}"]
+  internal        = "false"
+
+  listener {
+    instance_port     = 80
+    instance_protocol = "http"
+    lb_port           = 443
+    lb_protocol       = "https"
+
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    target              = "TCP:80"
+    interval            = 30
+  }
+
+  cross_zone_load_balancing   = true
+  idle_timeout                = 400
+  connection_draining         = true
+  connection_draining_timeout = 400
+
+  tags = "${map("Name", "${var.stackname}-whitehall-backend", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "whitehall_backend")}"
+}
+
+resource "aws_route53_record" "external_service_record" {
+  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
+  name    = "whitehall-backend.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_elb.whitehall-backend_external_elb.dns_name}"
+    zone_id                = "${aws_elb.whitehall-backend_external_elb.zone_id}"
     evaluate_target_health = true
   }
 }
 
 resource "aws_route53_record" "app_service_records" {
   count   = "${length(var.app_service_records)}"
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
-  name    = "${element(var.app_service_records, count.index)}.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
+  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
+  name    = "${element(var.app_service_records, count.index)}.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
   type    = "CNAME"
-  records = ["whitehall-backend.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"]
+  records = ["whitehall-backend.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"]
   ttl     = "300"
 }
 
@@ -133,7 +187,7 @@ module "whitehall-backend" {
   instance_key_name             = "${var.stackname}-whitehall-backend"
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
-  instance_elb_ids              = ["${aws_elb.whitehall-backend_elb.id}"]
+  instance_elb_ids              = ["${aws_elb.whitehall-backend_internal_elb.id}", "${aws_elb.whitehall-backend_external_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
@@ -143,12 +197,22 @@ module "whitehall-backend" {
 # Outputs
 # --------------------------------------------------------------
 
-output "whitehall-backend_elb_address" {
-  value       = "${aws_elb.whitehall-backend_elb.dns_name}"
+output "whitehall-backend_internal_elb_address" {
+  value       = "${aws_elb.whitehall-backend_internal_elb.dns_name}"
   description = "AWS' internal DNS name for the whitehall-backend ELB"
 }
 
-output "service_dns_name" {
-  value       = "${aws_route53_record.service_record.name}"
+output "internal_service_dns_name" {
+  value       = "${aws_route53_record.internal_service_record.name}"
   description = "DNS name to access the node service"
+}
+
+output "whitehall-backend_external_elb_address" {
+  value       = "${aws_elb.whitehall-backend_external_elb.dns_name}"
+  description = "AWS' external DNS name for the whitehall-backend ELB"
+}
+
+output "external_service_dns_name" {
+  value       = "${aws_route53_record.external_service_record.name}"
+  description = "DNS name to access the external node service"
 }

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -338,8 +338,12 @@ output "sg_offsite_ssh_id" {
   value = "${aws_security_group.offsite_ssh.id}"
 }
 
-output "sg_whitehall-backend_elb_id" {
-  value = "${aws_security_group.whitehall-backend_elb.id}"
+output "sg_whitehall-backend_external_elb_id" {
+  value = "${aws_security_group.whitehall-backend_external_elb.id}"
+}
+
+output "sg_whitehall-backend_internal_elb_id" {
+  value = "${aws_security_group.whitehall-backend_internal_elb.id}"
 }
 
 output "sg_whitehall-backend_id" {

--- a/terraform/projects/infra-security-groups/whitehall-backend.tf
+++ b/terraform/projects/infra-security-groups/whitehall-backend.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "whitehall-backend" {
   }
 }
 
-resource "aws_security_group_rule" "allow_whitehall-backend_elb_in" {
+resource "aws_security_group_rule" "allow_whitehall-backend_internal_elb_in" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -31,36 +31,78 @@ resource "aws_security_group_rule" "allow_whitehall-backend_elb_in" {
   security_group_id = "${aws_security_group.whitehall-backend.id}"
 
   # Which security group can use this rule
-  source_security_group_id = "${aws_security_group.whitehall-backend_elb.id}"
+  source_security_group_id = "${aws_security_group.whitehall-backend_internal_elb.id}"
 }
 
-resource "aws_security_group" "whitehall-backend_elb" {
+resource "aws_security_group_rule" "allow_whitehall-backend_external_elb_in" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.whitehall-backend.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.whitehall-backend_external_elb.id}"
+}
+
+resource "aws_security_group" "whitehall-backend_internal_elb" {
   name        = "${var.stackname}_whitehall-backend_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access the whitehall-backend ELB"
 
   tags {
-    Name = "${var.stackname}_whitehall-backend_elb_access"
+    Name = "${var.stackname}_whitehall-backend_internal_elb_access"
   }
 }
 
 # TODO: replace this with ingress from the LBs when we build them.
-resource "aws_security_group_rule" "allow_management_to_whitehall-backend_elb" {
+resource "aws_security_group_rule" "allow_management_to_whitehall-backend_internal_elb" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.whitehall-backend_elb.id}"
+  security_group_id        = "${aws_security_group.whitehall-backend_internal_elb.id}"
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
 # TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_whitehall-backend_elb_egress" {
+resource "aws_security_group_rule" "allow_whitehall-backend_internal_elb_egress" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.whitehall-backend_elb.id}"
+  security_group_id = "${aws_security_group.whitehall-backend_internal_elb.id}"
+}
+
+resource "aws_security_group" "whitehall-backend_external_elb" {
+  name        = "${var.stackname}_whitehall-backend_external_elb_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access the whitehall-backend external ELB"
+
+  tags {
+    Name = "${var.stackname}_whitehall-backend_external_elb_access"
+  }
+}
+
+resource "aws_security_group_rule" "allow_public_to_whitehall-backend_external_elb" {
+  type              = "ingress"
+  to_port           = 443
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.whitehall-backend_external_elb.id}"
+  cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}"]
+}
+
+# TODO test whether egress rules are needed on ELBs
+resource "aws_security_group_rule" "allow_whitehall-backend_external_elb_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.whitehall-backend_external_elb.id}"
 }


### PR DESCRIPTION
The current whitehall backend lives behind the backend load balancers,
this PR changes this in terraform and makes it available as an external resource.