### PR TITLE
Allow backend machines to access Mongo machines

### DIFF
--- a/terraform/projects/infra-security-groups/mongo.tf
+++ b/terraform/projects/infra-security-groups/mongo.tf
@@ -80,6 +80,17 @@ resource "aws_security_group_rule" "allow_frontend_to_mongo_elb" {
   source_security_group_id = "${aws_security_group.frontend.id}"
 }
 
+resource "aws_security_group_rule" "allow_backend_to_mongo_elb" {
+  type      = "ingress"
+  from_port = 27017
+  to_port   = 27017
+  protocol  = "tcp"
+
+  security_group_id = "${aws_security_group.mongo_elb.id}"
+
+  source_security_group_id = "${aws_security_group.backend.id}"
+}
+
 resource "aws_security_group_rule" "allow_mongo_elb_egress" {
   type              = "egress"
   from_port         = 0


### PR DESCRIPTION
- The security group wasn't configured, which made backend apps eg
  Maslow and Imminence sad when deploying them as they couldn't access
  `mongo-1`.