### PR TITLE
Allow ssh from carrenza integration

### DIFF
--- a/terraform/data/common/integration/common.tfvars
+++ b/terraform/data/common/integration/common.tfvars
@@ -18,6 +18,10 @@ office_ips = [
   "213.86.153.237/32",
 ]
 
+carrenza_integration_ips = [
+  "31.210.245.96/28",
+]
+
 user_data_snippets = [
   "00-base",
   "20-puppet-client",

--- a/terraform/projects/infra-security-groups/offsite_ssh.tf
+++ b/terraform/projects/infra-security-groups/offsite_ssh.tf
@@ -26,7 +26,7 @@ resource "aws_security_group_rule" "allow_offsite_ssh" {
   from_port   = 22
   to_port     = 22
   protocol    = "tcp"
-  cidr_blocks = ["${var.office_ips}"]
+  cidr_blocks = ["${concat(var.office_ips, var.carrenza_integration_ips)}"]
 
   security_group_id = "${aws_security_group.offsite_ssh.id}"
 }

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -28,3 +28,8 @@ variable "office_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will be allowed offsite access."
 }
+
+variable "carrenza_integration_ips" {
+  type        = "list"
+  description = "An array of CIDR blocks that will be allowed to SSH to the jumpbox."
+}


### PR DESCRIPTION
This allows SSH from the carrenza integration environment for the
purpose of syncing data