### PR TITLE
Increase disk space on jumpbox and db-admin machines

### DIFF
--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -90,6 +90,7 @@ module "db-admin" {
   asg_max_size                  = "1"
   asg_min_size                  = "1"
   asg_desired_capacity          = "1"
+  root_block_device_volume_size = "64"
 }
 
 # Outputs

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -98,6 +98,7 @@ module "jumpbox" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.jumpbox_external_elb.id}"]
+  root_block_device_volume_size = "64"
 }
 
 # Outputs


### PR DESCRIPTION
- Upon trying to scp over a 21G publishing-api database dump, the
  jumpbox ran out of disk space. Even compressed, when it gets to the
  db-admin machine, it won't have enough space to uncompress it ready
  for import, so increase the space available to 64G.