### PR TITLE
Add env file for blue integration

### DIFF
--- a/.blue.integration.env
+++ b/.blue.integration.env
@@ -1,0 +1,3 @@
+export DATA_DIR=../govuk-aws-data/data
+export ENVIRONMENT=integration
+export STACKNAME=blue


### PR DESCRIPTION
When working with the build tool it's easier to source this file so you
don't have to pass in a bunch of parameters.

Overrides can still occur so it's a useful way of quickly setting up
your environment.