### PR TITLE
Allow dynamic autoscaling group values

### DIFF
--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -10,6 +10,9 @@
 # ssh_public_key
 # elb_certname
 # app_service_records
+# asg_max_size
+# asg_min_size
+# asg_desired_capacity
 #
 # === Outputs:
 #
@@ -44,6 +47,24 @@ variable "app_service_records" {
   type        = "list"
   description = "List of application service names that get traffic via this loadbalancer"
   default     = []
+}
+
+variable "asg_max_size" {
+  type        = "string"
+  description = "The maximum size of the autoscaling group"
+  default     = "2"
+}
+
+variable "asg_min_size" {
+  type        = "string"
+  description = "The minimum size of the autoscaling group"
+  default     = "2"
+}
+
+variable "asg_desired_capacity" {
+  type        = "string"
+  description = "The desired capacity of the autoscaling group"
+  default     = "2"
 }
 
 # Resources
@@ -172,9 +193,9 @@ module "cache" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.cache_elb.id}", "${aws_elb.cache_external_elb.id}"]
-  asg_max_size                  = "3"
-  asg_min_size                  = "3"
-  asg_desired_capacity          = "3"
+  asg_max_size                  = "${var.asg_max_size}"
+  asg_min_size                  = "${var.asg_min_size}"
+  asg_desired_capacity          = "${var.asg_desired_capacity}"
 }
 
 # Outputs

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -9,6 +9,9 @@
 # aws_environment
 # ssh_public_key
 # elb_certname
+# asg_max_size
+# asg_min_size
+# asg_desired_capacity
 #
 # === Outputs:
 #
@@ -37,6 +40,24 @@ variable "ssh_public_key" {
 variable "elb_certname" {
   type        = "string"
   description = "The ACM cert domain name to find the ARN of"
+}
+
+variable "asg_max_size" {
+  type        = "string"
+  description = "The maximum size of the autoscaling group"
+  default     = "2"
+}
+
+variable "asg_min_size" {
+  type        = "string"
+  description = "The minimum size of the autoscaling group"
+  default     = "2"
+}
+
+variable "asg_desired_capacity" {
+  type        = "string"
+  description = "The desired capacity of the autoscaling group"
+  default     = "2"
 }
 
 # Resources
@@ -112,9 +133,9 @@ module "calculators-frontend" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.calculators-frontend_elb.id}"]
-  asg_max_size                  = "3"
-  asg_min_size                  = "3"
-  asg_desired_capacity          = "3"
+  asg_max_size                  = "${var.asg_max_size}"
+  asg_min_size                  = "${var.asg_min_size}"
+  asg_desired_capacity          = "${var.asg_desired_capacity}"
 }
 
 # Outputs

--- a/terraform/projects/app-performance-backend/main.tf
+++ b/terraform/projects/app-performance-backend/main.tf
@@ -9,6 +9,9 @@
 # aws_environment
 # ssh_public_key
 # elb_certname
+# asg_max_size
+# asg_min_size
+# asg_desired_capacity
 #
 # === Outputs:
 #
@@ -37,6 +40,24 @@ variable "ssh_public_key" {
 variable "elb_certname" {
   type        = "string"
   description = "The ACM cert domain name to find the ARN of"
+}
+
+variable "asg_max_size" {
+  type        = "string"
+  description = "The maximum size of the autoscaling group"
+  default     = "2"
+}
+
+variable "asg_min_size" {
+  type        = "string"
+  description = "The minimum size of the autoscaling group"
+  default     = "2"
+}
+
+variable "asg_desired_capacity" {
+  type        = "string"
+  description = "The desired capacity of the autoscaling group"
+  default     = "2"
 }
 
 # Resources
@@ -112,9 +133,9 @@ module "performance-backend" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.performance-backend_elb.id}"]
-  asg_max_size                  = "3"
-  asg_min_size                  = "3"
-  asg_desired_capacity          = "3"
+  asg_max_size                  = "${var.asg_max_size}"
+  asg_min_size                  = "${var.asg_min_size}"
+  asg_desired_capacity          = "${var.asg_desired_capacity}"
 }
 
 # Outputs

--- a/terraform/projects/app-performance-frontend/main.tf
+++ b/terraform/projects/app-performance-frontend/main.tf
@@ -9,6 +9,9 @@
 # aws_environment
 # ssh_public_key
 # elb_certname
+# asg_max_size
+# asg_min_size
+# asg_desired_capacity
 #
 # === Outputs:
 #
@@ -37,6 +40,24 @@ variable "ssh_public_key" {
 variable "elb_certname" {
   type        = "string"
   description = "The ACM cert domain name to find the ARN of"
+}
+
+variable "asg_max_size" {
+  type        = "string"
+  description = "The maximum size of the autoscaling group"
+  default     = "2"
+}
+
+variable "asg_min_size" {
+  type        = "string"
+  description = "The minimum size of the autoscaling group"
+  default     = "2"
+}
+
+variable "asg_desired_capacity" {
+  type        = "string"
+  description = "The desired capacity of the autoscaling group"
+  default     = "2"
 }
 
 # Resources
@@ -112,9 +133,9 @@ module "performance-frontend" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.performance-frontend_elb.id}"]
-  asg_max_size                  = "3"
-  asg_min_size                  = "3"
-  asg_desired_capacity          = "3"
+  asg_max_size                  = "${var.asg_max_size}"
+  asg_min_size                  = "${var.asg_min_size}"
+  asg_desired_capacity          = "${var.asg_desired_capacity}"
 }
 
 # Outputs

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -8,6 +8,9 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# asg_max_size
+# asg_min_size
+# asg_desired_capacity
 #
 # === Outputs:
 #
@@ -31,6 +34,24 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "asg_max_size" {
+  type        = "string"
+  description = "The maximum size of the autoscaling group"
+  default     = "2"
+}
+
+variable "asg_min_size" {
+  type        = "string"
+  description = "The minimum size of the autoscaling group"
+  default     = "2"
+}
+
+variable "asg_desired_capacity" {
+  type        = "string"
+  description = "The desired capacity of the autoscaling group"
+  default     = "2"
 }
 
 # Resources
@@ -87,9 +108,9 @@ module "search" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.search_elb.id}"]
-  asg_max_size                  = "3"
-  asg_min_size                  = "3"
-  asg_desired_capacity          = "3"
+  asg_max_size                  = "${var.asg_max_size}"
+  asg_min_size                  = "${var.asg_min_size}"
+  asg_desired_capacity          = "${var.asg_desired_capacity}"
 }
 
 # Outputs


### PR DESCRIPTION
These ASGs should be resiable between environments. Also set the defaults
lower, we'll only run bigger groups in prod and perf test environments.