### PR TITLE
Set max_allowed_packet to 1GB for mysql in RDS

### DIFF
--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -103,6 +103,11 @@ variable "replicate_source_db" {
   default     = "false"
 }
 
+variable "parameter_group_name" {
+  type        = "string"
+  description = "Name of the parameter group to make the instance a member of."
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -128,6 +133,7 @@ resource "aws_db_instance" "db_instance_replica" {
   db_subnet_group_name   = "${aws_db_subnet_group.subnet_group.name}"
   vpc_security_group_ids = ["${var.security_group_ids}"]
   replicate_source_db    = "${var.replicate_source_db}"
+  parameter_group_name   = "${var.parameter_group_name}"
 
   # TODO in production we probably want to re-enable this, possibly using:
   # final_snapshot_identifier = "${var.name}-final-snapshot"
@@ -151,6 +157,7 @@ resource "aws_db_instance" "db_instance" {
   db_subnet_group_name   = "${aws_db_subnet_group.subnet_group.name}"
   vpc_security_group_ids = ["${var.security_group_ids}"]
   multi_az               = "${var.multi_az}"
+  parameter_group_name   = "${var.parameter_group_name}"
 
   # TODO in production we probably want to re-enable this, possibly using:
   # final_snapshot_identifier = "${var.name}-final-snapshot"

--- a/terraform/projects/app-mysql-primary/main.tf
+++ b/terraform/projects/app-mysql-primary/main.tf
@@ -49,17 +49,32 @@ provider "aws" {
 }
 
 module "mysql_primary_rds_instance" {
-  source             = "../../modules/aws/rds_instance"
-  name               = "${var.stackname}-mysql-primary"
-  engine_name        = "mysql"
-  engine_version     = "5.6.27"
-  default_tags       = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mysql-primary")}"
-  subnet_ids         = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
-  username           = "${var.username}"
-  password           = "${var.password}"
-  allocated_storage  = "30"
-  instance_class     = "db.m4.xlarge"
-  security_group_ids = ["${data.terraform_remote_state.infra_security_groups.sg_mysql-primary_id}"]
+  source               = "../../modules/aws/rds_instance"
+  name                 = "${var.stackname}-mysql-primary"
+  engine_name          = "mysql"
+  engine_version       = "5.6.27"
+  default_tags         = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mysql-primary")}"
+  subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
+  username             = "${var.username}"
+  password             = "${var.password}"
+  allocated_storage    = "30"
+  instance_class       = "db.m4.xlarge"
+  security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mysql-primary_id}"]
+  parameter_group_name = "${aws_db_parameter_group.mysql-primary.name}"
+}
+
+resource "aws_db_parameter_group" "mysql-primary" {
+  name_prefix = "mysql-primary"
+  family      = "mysql5.6"
+
+  parameter {
+    name  = "max_allowed_packet"
+    value = 1073741824
+  }
+
+  tags {
+    aws_stackname = "${var.stackname}"
+  }
 }
 
 resource "aws_route53_record" "service_record" {


### PR DESCRIPTION
This creates a parameter group for the mysql-primary RDS instance that
sets the `max_allowed_packet` to 1GB. The default AWS value is 4MB
which means database restores of databases with large blobs (e.g.
whitehall) will fail (with `ERROR 2006 (HY000) at line 8500: MySQL
server has gone away`).

As the parameter group name needs to be added to the `db_instance`
resource this adds a new variable to the RDS module,
`parameter_group_name` which passes this value to both the instance and
replica resources..