### PR TITLE
Upgrade logging machines

### DIFF
--- a/terraform/projects/app-logging/main.tf
+++ b/terraform/projects/app-logging/main.tf
@@ -92,7 +92,7 @@ module "logging" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "logging", "aws_hostname", "logging-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_logging_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.micro"
+  instance_type                 = "m4.large"
   create_instance_key           = true
   instance_key_name             = "${var.stackname}-logging"
   instance_public_key           = "${var.ssh_public_key}"


### PR DESCRIPTION
They're not that load intensive, but everything connects to them so they need more than t2.micro.