### PR TITLE
Set a default for parameter_group_name

### DIFF
--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -106,6 +106,7 @@ variable "replicate_source_db" {
 variable "parameter_group_name" {
   type        = "string"
   description = "Name of the parameter group to make the instance a member of."
+  default     = ""
 }
 
 # Resources


### PR DESCRIPTION
There needs to be a default otherwise terraform errors.