### PR TITLE
Update frontend and calculators-frontend DNS names

### DIFF
--- a/terraform/projects/app-frontend-lb/main.tf
+++ b/terraform/projects/app-frontend-lb/main.tf
@@ -41,7 +41,12 @@ variable "app_service_records" {
   default     = []
 }
 
-variable "elb_certname" {
+variable "elb_internal_certname" {
+  type        = "string"
+  description = "The ACM cert domain name to find the ARN of"
+}
+
+variable "elb_external_certname" {
   type        = "string"
   description = "The ACM cert domain name to find the ARN of"
 }
@@ -57,8 +62,13 @@ provider "aws" {
   region = "${var.aws_region}"
 }
 
-data "aws_acm_certificate" "elb_cert" {
-  domain   = "${var.elb_certname}"
+data "aws_acm_certificate" "elb_internal_cert" {
+  domain   = "${var.elb_internal_certname}"
+  statuses = ["ISSUED"]
+}
+
+data "aws_acm_certificate" "elb_external_cert" {
+  domain   = "${var.elb_external_certname}"
   statuses = ["ISSUED"]
 }
 
@@ -74,7 +84,7 @@ resource "aws_elb" "frontend-lb_elb" {
     lb_port           = 443
     lb_protocol       = "https"
 
-    ssl_certificate_id = "${data.aws_acm_certificate.elb_cert.arn}"
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_internal_cert.arn}"
   }
 
   health_check {
@@ -118,7 +128,7 @@ resource "aws_elb" "frontend-lb_external_elb" {
     lb_port           = 443
     lb_protocol       = "https"
 
-    ssl_certificate_id = "${data.aws_acm_certificate.elb_cert.arn}"
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
   }
 
   health_check {

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -9,6 +9,7 @@
 # aws_environment
 # ssh_public_key
 # elb_certname
+# app_service_records
 #
 # === Outputs:
 #
@@ -37,6 +38,12 @@ variable "ssh_public_key" {
 variable "elb_certname" {
   type        = "string"
   description = "The ACM cert domain name to find the ARN of"
+}
+
+variable "app_service_records" {
+  type        = "list"
+  description = "List of application service names that get traffic via this loadbalancer"
+  default     = []
 }
 
 # Resources
@@ -97,6 +104,15 @@ resource "aws_route53_record" "service_record" {
     zone_id                = "${aws_elb.frontend_elb.zone_id}"
     evaluate_target_health = true
   }
+}
+
+resource "aws_route53_record" "app_service_records" {
+  count   = "${length(var.app_service_records)}"
+  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
+  name    = "${element(var.app_service_records, count.index)}.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
+  type    = "CNAME"
+  records = ["frontend.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"]
+  ttl     = "300"
 }
 
 module "frontend" {


### PR DESCRIPTION
This adds the required DNS records and certificates to allow the cache instance to directly route requests to frontend and calculators-frontend, essentially bypassing frontend-lb.

This is something we wanted to do later on, and it makes sense to do it now because otherwise we will have conflicts in how we do DNS naming for apps and services.

It's also worth noting I fixed a bug where the wrong protocol was used with an LB listener, that meant that while requests were correctly being routed to tcp/80, they were still encrypted so nginx was unable to correctly parse the request.