### PR TITLE
Increase postgres-primary storage to 120GB

### DIFF
--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -66,7 +66,7 @@ module "postgresql-primary_rds_instance" {
   subnet_ids         = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
   username           = "${var.username}"
   password           = "${var.password}"
-  allocated_storage  = "30"
+  allocated_storage  = "120"
   instance_class     = "db.m4.large"
   multi_az           = "${var.multi_az}"
   security_group_ids = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]


### PR DESCRIPTION
postgres-primary will host both existing postgres databases. Both of
these currently have 60GB each for data, this increases the storage in
RDS to give at least this much.