### PR TITLE
Add s3 bucket for wraith output

### DIFF
--- a/terraform/projects/infra-wraith-bucket/integration.govuk.backend
+++ b/terraform/projects/infra-wraith-bucket/integration.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "govuk/wraith-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-wraith-bucket/main.tf
+++ b/terraform/projects/infra-wraith-bucket/main.tf
@@ -1,0 +1,66 @@
+# == Manifest: projects:: Wraith-bucket :: buckets
+#
+# This creates 2 s3 buckets
+#
+# * wraith-logs -- The bucket that will hold the logs produced by wraith
+# * wraith_access_logs -- Bucket for logs to go to
+#
+# === Variables:
+#
+# aws_region
+# aws_environment
+#
+# === Outputs:
+#
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+# Set up the backend & provider for each region
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.9.10"
+}
+
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+# Create the buckets
+# Logs bucket
+resource "aws_s3_bucket" "wraith_access_logs" {
+  bucket = "govuk-${var.aws_environment}-wraith-access-logs"
+  acl    = "log-delivery-write"
+
+  versioning {
+    enabled = true
+  }
+}
+
+# Main bucket
+resource "aws_s3_bucket" "wraith" {
+  bucket = "govuk-${var.aws_environment}-wraith"
+  acl    = "public-read"
+
+  tags {
+    Name            = "govuk-${var.aws_environment}-wraith"
+    aws_environment = "${var.aws_environment}"
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    target_bucket = "${aws_s3_bucket.wraith_access_logs.id}"
+    target_prefix = "log/"
+  }
+}

--- a/terraform/projects/infra-wraith-bucket/writer.tf
+++ b/terraform/projects/infra-wraith-bucket/writer.tf
@@ -1,0 +1,61 @@
+# == Manifest: projects:: wraith-bucket :: writer
+#
+# Create a user that has full read/write access to the wraith bucket. Access
+# keys will need to be generated separately via the UI.
+#
+# This doesn't create a role as the calling instance is assumed to already
+# have one which should be attached to this policy.
+#
+# === Variables:
+#
+# === Outputs:
+#
+# write_wraith_bucket_policy_arn
+#
+
+resource "aws_iam_user" "wraith_writer" {
+  name = "govuk-${var.aws_environment}-wraith-writer"
+}
+
+resource "aws_iam_policy" "wraith_writer" {
+  name        = "govuk-${var.aws_environment}-wraith-writer-policy"
+  policy      = "${data.aws_iam_policy_document.wraith_writer.json}"
+  description = "Allows writing of the wraith bucket"
+}
+
+resource "aws_iam_policy_attachment" "wraith_writer" {
+  name       = "wraith-writer-policy-attachment"
+  users      = ["${aws_iam_user.wraith_writer.name}"]
+  policy_arn = "${aws_iam_policy.wraith_writer.arn}"
+}
+
+data "aws_iam_policy_document" "wraith_writer" {
+  statement {
+    sid = "ReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    sid     = "WriteGovukWraith"
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.wraith.id}",
+      "arn:aws:s3:::${aws_s3_bucket.wraith.id}/*",
+    ]
+  }
+}
+
+output "write_wraith_bucket_policy_arn" {
+  value       = "${aws_iam_policy.wraith_writer.arn}"
+  description = "ARN of the write wraith-bucket policy"
+}


### PR DESCRIPTION
This is a world-readable bucket which will store the output of wraith
visual regression tests for frontend work. The bucket is writable only
by the created wraith_writer user. Access keys for this user need to be
generated separately.