### PR TITLE
Allow further backend services access

### DIFF
--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -65,7 +65,7 @@ data "aws_acm_certificate" "elb_cert" {
 resource "aws_elb" "whitehall-backend_elb" {
   name            = "${var.stackname}-whitehall-backend"
   subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_backend-lb_id}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_elb_id}"]
   internal        = "true"
 
   listener {

--- a/terraform/projects/infra-security-groups/backend-redis.tf
+++ b/terraform/projects/infra-security-groups/backend-redis.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "backend-redis" {
   }
 }
 
-resource "aws_security_group_rule" "allow_backend_in_redis" {
+resource "aws_security_group_rule" "allow_backend-redis_from_backend" {
   type      = "ingress"
   from_port = 6379
   to_port   = 6379
@@ -32,6 +32,32 @@ resource "aws_security_group_rule" "allow_backend_in_redis" {
 
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.backend.id}"
+}
+
+resource "aws_security_group_rule" "allow_backend-redis_from_whitehall-backend" {
+  type      = "ingress"
+  from_port = 6379
+  to_port   = 6379
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.backend-redis.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.whitehall-backend.id}"
+}
+
+resource "aws_security_group_rule" "allow_backend-redis_from_whitehall-frontend" {
+  type      = "ingress"
+  from_port = 6379
+  to_port   = 6379
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.backend-redis.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.whitehall-frontend.id}"
 }
 
 resource "aws_security_group_rule" "allow_publishing_api_in_redis" {

--- a/terraform/projects/infra-security-groups/mongo.tf
+++ b/terraform/projects/infra-security-groups/mongo.tf
@@ -80,6 +80,17 @@ resource "aws_security_group_rule" "allow_frontend_to_mongo_elb" {
   source_security_group_id = "${aws_security_group.frontend.id}"
 }
 
+resource "aws_security_group_rule" "allow_calculators-frontend_to_mongo_elb" {
+  type      = "ingress"
+  from_port = 27017
+  to_port   = 27017
+  protocol  = "tcp"
+
+  security_group_id = "${aws_security_group.mongo_elb.id}"
+
+  source_security_group_id = "${aws_security_group.calculators-frontend.id}"
+}
+
 resource "aws_security_group_rule" "allow_backend_to_mongo_elb" {
   type      = "ingress"
   from_port = 27017

--- a/terraform/projects/infra-security-groups/mysql-primary.tf
+++ b/terraform/projects/infra-security-groups/mysql-primary.tf
@@ -18,7 +18,7 @@ resource "aws_security_group" "mysql-primary" {
   }
 }
 
-resource "aws_security_group_rule" "allow_mysql-primary_clients_in" {
+resource "aws_security_group_rule" "allow_mysql-primary_from_backend" {
   type      = "ingress"
   from_port = 3306
   to_port   = 3306
@@ -29,6 +29,32 @@ resource "aws_security_group_rule" "allow_mysql-primary_clients_in" {
 
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.backend.id}"
+}
+
+resource "aws_security_group_rule" "allow_mysql-primary_from_whitehall-backend" {
+  type      = "ingress"
+  from_port = 3306
+  to_port   = 3306
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.mysql-primary.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.whitehall-backend.id}"
+}
+
+resource "aws_security_group_rule" "allow_mysql-primary_from_whitehall-frontend" {
+  type      = "ingress"
+  from_port = 3306
+  to_port   = 3306
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.mysql-primary.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.whitehall-frontend.id}"
 }
 
 resource "aws_security_group_rule" "allow_mysql-primary_db-admin_in" {


### PR DESCRIPTION
The whitehall machines and calculators-frontend needed access to some backend services. This opens up the security groups to allow them to do so.

https://trello.com/c/DS5stwo8/730-fix-frontend-flows