### PR TITLE
Add variable to override default instance AMI

### DIFF
--- a/terraform/projects/app-api-lb/main.tf
+++ b/terraform/projects/app-api-lb/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_certname
 #
 # === Outputs:
@@ -32,6 +33,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "app_service_records" {
@@ -171,6 +178,7 @@ module "api-lb" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.api-lb_elb.id}", "${aws_elb.api-lb_external_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"

--- a/terraform/projects/app-api-mongo/main.tf
+++ b/terraform/projects/app-api-mongo/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # api-mongo_1_subnet
 # api-mongo_2_subnet
 # api-mongo_3_subnet
@@ -37,6 +38,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "api-mongo_1_subnet" {
@@ -125,6 +132,7 @@ module "api-mongo-1" {
   instance_key_name             = "${var.stackname}-api-mongo"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.api_mongo_1_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "220"
 }
 
@@ -183,6 +191,7 @@ module "api-mongo-2" {
   instance_key_name             = "${var.stackname}-api-mongo"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.api_mongo_2_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "220"
 }
 
@@ -241,6 +250,7 @@ module "api-mongo-3" {
   instance_key_name             = "${var.stackname}-api-mongo"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.api_mongo_3_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "220"
 }
 

--- a/terraform/projects/app-api/main.tf
+++ b/terraform/projects/app-api/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_certname
 #
 # === Outputs:
@@ -32,6 +33,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "api default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_certname" {
@@ -111,6 +118,7 @@ module "api" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.api_external_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"

--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -8,6 +8,7 @@
 # aws_region
 # stackname
 # ssh_public_key
+# instance_ami_filter_name
 # apt_1_subnet
 #
 # === Outputs:
@@ -32,6 +33,12 @@ variable "stackname" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "apt_1_subnet" {
@@ -147,6 +154,7 @@ module "apt" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.apt_internal_elb.id}", "${aws_elb.apt_external_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 

--- a/terraform/projects/app-backend-lb/main.tf
+++ b/terraform/projects/app-backend-lb/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # app_service_records
 #
 # === Outputs:
@@ -32,6 +33,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "app_service_records" {
@@ -171,6 +178,7 @@ module "backend-lb" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.backend-lb_elb.id}", "${aws_elb.backend-lb_external_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 #
 # === Outputs:
 #
@@ -31,6 +32,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "backend default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_certname" {
@@ -110,6 +117,7 @@ module "backend" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.backend_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"

--- a/terraform/projects/app-backup/main.tf
+++ b/terraform/projects/app-backup/main.tf
@@ -5,9 +5,11 @@
 # === Variables:
 #
 # aws_region
-# remote_state_govuk_vpc_key
-# remote_state_govuk_vpc_bucket
+# aws_environment
 # stackname
+# ssh_public_key
+# instance_ami_filter_name
+# backup_subnet
 #
 # === Outputs:
 #
@@ -31,6 +33,12 @@ variable "stackname" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "backup_subnet" {
@@ -104,6 +112,7 @@ module "backup" {
   instance_key_name             = "${var.stackname}-backup"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.backup_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 

--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 #
 # === Outputs:
 #
@@ -31,6 +32,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "bouncer default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 # Resources
@@ -98,6 +105,7 @@ module "bouncer" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.bouncer_external_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_certname
 # app_service_records
 # asg_max_size
@@ -36,6 +37,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_internal_certname" {
@@ -231,6 +238,7 @@ module "cache" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.cache_elb.id}", "${aws_elb.cache_external_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "${var.asg_max_size}"
   asg_min_size                  = "${var.asg_min_size}"
   asg_desired_capacity          = "${var.asg_desired_capacity}"

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_certname
 # asg_max_size
 # asg_min_size
@@ -36,6 +37,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_internal_certname" {
@@ -149,6 +156,7 @@ module "calculators-frontend" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.calculators-frontend_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "${var.asg_max_size}"
   asg_min_size                  = "${var.asg_min_size}"
   asg_desired_capacity          = "${var.asg_desired_capacity}"

--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_external_certname
 #
 # === Outputs:
@@ -32,6 +33,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "content-store default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_external_certname" {
@@ -164,6 +171,7 @@ module "content-store" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.content-store_external_elb.id}", "${aws_elb.content-store_internal_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 #
 # === Outputs:
 #
@@ -31,6 +32,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 # Resources
@@ -87,6 +94,7 @@ module "db-admin" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.db-admin_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "1"
   asg_min_size                  = "1"
   asg_desired_capacity          = "1"

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_certname
 #
 # === Outputs:
@@ -32,6 +33,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_certname" {
@@ -118,6 +125,7 @@ module "deploy" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.deploy_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
 }
 
 resource "aws_route53_record" "service_record" {

--- a/terraform/projects/app-docker-management/main.tf
+++ b/terraform/projects/app-docker-management/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 #
 # === Outputs:
 #
@@ -31,6 +32,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 # Resources
@@ -101,6 +108,7 @@ module "docker_management" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.docker_management_etcd_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
 }
 
 # Outputs

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_certname
 #
 # === Outputs:
@@ -32,6 +33,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_certname" {
@@ -124,6 +131,7 @@ module "draft-cache" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.draft-cache_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_certname
 #
 # === Outputs:
@@ -32,6 +33,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "draft-content-store default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_certname" {
@@ -111,6 +118,7 @@ module "draft-content-store" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.draft-content-store_external_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_certname
 #
 # === Outputs:
@@ -32,6 +33,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_certname" {
@@ -112,6 +119,7 @@ module "draft-frontend" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.draft-frontend_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"

--- a/terraform/projects/app-elasticsearch/main.tf
+++ b/terraform/projects/app-elasticsearch/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elasticsearch_1_subnet
 # elasticsearch_2_subnet
 # elasticsearch_3_subnet
@@ -37,6 +38,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elasticsearch_1_subnet" {
@@ -130,6 +137,7 @@ module "elasticsearch-1" {
   instance_key_name             = "${var.stackname}-elasticsearch"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.elasticsearch_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 
@@ -162,6 +170,7 @@ module "elasticsearch-2" {
   instance_key_name             = "${var.stackname}-elasticsearch"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.elasticsearch_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 
@@ -194,6 +203,7 @@ module "elasticsearch-3" {
   instance_key_name             = "${var.stackname}-elasticsearch"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.elasticsearch_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 

--- a/terraform/projects/app-exception-handler/main.tf
+++ b/terraform/projects/app-exception-handler/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # exception_handler_subnet
 # elb_certname
 #
@@ -35,6 +36,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "exception_handler_subnet" {
@@ -128,6 +135,7 @@ module "exception_handler" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.exception_handler_internal_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 

--- a/terraform/projects/app-frontend-lb/main.tf
+++ b/terraform/projects/app-frontend-lb/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # app_service_records
 # elb_certname
 #
@@ -33,6 +34,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "app_service_records" {
@@ -182,6 +189,7 @@ module "frontend-lb" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.frontend-lb_elb.id}", "${aws_elb.frontend-lb_external_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_internal_certname
 # app_service_records
 #
@@ -33,6 +34,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_internal_certname" {
@@ -128,6 +135,7 @@ module "frontend" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.frontend_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # graphite_1_subnet
 # elb_external_certname
 # elb_internal_certname
@@ -34,6 +35,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "graphite_1_subnet" {
@@ -199,6 +206,7 @@ module "graphite-1" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.graphite_internal_elb.id}", "${aws_elb.graphite_external_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 #
 # === Outputs:
 #
@@ -31,6 +32,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Jumpbox default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 # Resources
@@ -98,6 +105,7 @@ module "jumpbox" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.jumpbox_external_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "64"
 }
 

--- a/terraform/projects/app-logging/main.tf
+++ b/terraform/projects/app-logging/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 #
 # === Outputs:
 #
@@ -31,6 +32,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "logging default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 # Resources
@@ -98,6 +105,7 @@ module "logging" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.logging_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "50"
   asg_max_size                  = "2"
   asg_min_size                  = "2"

--- a/terraform/projects/app-logs-cdn/main.tf
+++ b/terraform/projects/app-logs-cdn/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # logs_cdn_subnet
 #
 # === Outputs:
@@ -34,6 +35,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "logs-cdn default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "logs_cdn_subnet" {
@@ -120,6 +127,7 @@ module "logs-cdn" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.logs-cdn_external_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "1"
   asg_min_size                  = "1"
   asg_desired_capacity          = "1"

--- a/terraform/projects/app-logs-elasticsearch/main.tf
+++ b/terraform/projects/app-logs-elasticsearch/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # logs_elasticsearch_1_subnet
 # logs_elasticsearch_2_subnet
 # logs_elasticsearch_3_subnet
@@ -37,6 +38,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "logs_elasticsearch_1_subnet" {
@@ -130,6 +137,7 @@ module "logs-elasticsearch-1" {
   instance_key_name             = "${var.stackname}-logs-elasticsearch"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.logs_elasticsearch_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 
@@ -162,6 +170,7 @@ module "logs-elasticsearch-2" {
   instance_key_name             = "${var.stackname}-logs-elasticsearch"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.logs_elasticsearch_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 
@@ -194,6 +203,7 @@ module "logs-elasticsearch-3" {
   instance_key_name             = "${var.stackname}-logs-elasticsearch"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.logs_elasticsearch_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -8,6 +8,7 @@
 # aws_region
 # stackname
 # ssh_public_key
+# instance_ami_filter_name
 # mapit_1_subnet
 # mapit_2_subnet
 #
@@ -33,6 +34,12 @@ variable "stackname" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "mapit_1_subnet" {
@@ -116,6 +123,7 @@ module "mapit-1" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.mapit_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 
@@ -147,6 +155,7 @@ module "mapit-2" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.mapit_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 

--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 #
 # === Outputs:
 #
@@ -31,6 +32,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "mirrorer default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "mirrorer_subnet" {
@@ -62,6 +69,7 @@ module "mirrorer" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = []
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "1"
   asg_min_size                  = "1"
   asg_desired_capacity          = "1"

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # mongo_1_subnet
 # mongo_2_subnet
 # mongo_3_subnet
@@ -37,6 +38,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "mongo_1_subnet" {
@@ -125,6 +132,7 @@ module "mongo-1" {
   instance_key_name             = "${var.stackname}-mongo"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.mongo_1_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 
@@ -183,6 +191,7 @@ module "mongo-2" {
   instance_key_name             = "${var.stackname}-mongo"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.mongo_2_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 
@@ -241,6 +250,7 @@ module "mongo-3" {
   instance_key_name             = "${var.stackname}-mongo"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.mongo_3_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 

--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_certname
 #
 # === Outputs:
@@ -32,6 +33,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_certname" {
@@ -130,6 +137,7 @@ module "monitoring" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.monitoring_external_elb.id}", "${aws_elb.monitoring_internal_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
 }
 
 resource "aws_route53_record" "external_service_record" {

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_certname
 #
 # === Outputs:
@@ -32,6 +33,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "publishing-api default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_certname" {
@@ -111,6 +118,7 @@ module "publishing-api" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.publishing-api_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -8,6 +8,7 @@
 # aws_environment
 # stackname
 # ssh_public_key
+# instance_ami_filter_name
 #
 # === Outputs:
 #
@@ -31,6 +32,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Puppetmaster default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 # Resources
@@ -150,6 +157,7 @@ module "puppetmaster" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.puppetmaster_bootstrap_elb.id}", "${aws_elb.puppetmaster_internal_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "50"
 }
 

--- a/terraform/projects/app-rabbitmq/main.tf
+++ b/terraform/projects/app-rabbitmq/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 #
 # === Outputs:
 #
@@ -31,6 +32,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 # Resources
@@ -99,6 +106,7 @@ module "rabbitmq" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.rabbitmq_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
   asg_max_size                  = "3"
   asg_min_size                  = "3"

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # router-backend_1_subnet
 # router-backend_2_subnet
 # router-backend_3_subnet
@@ -38,6 +39,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "router-backend_1_subnet" {
@@ -180,6 +187,7 @@ module "router-backend-1" {
   instance_key_name             = "${var.stackname}-router-backend"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.router_backend_1_elb.id}", "${aws_elb.router_api_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 
@@ -238,6 +246,7 @@ module "router-backend-2" {
   instance_key_name             = "${var.stackname}-router-backend"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.router_backend_2_elb.id}", "${aws_elb.router_api_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 
@@ -296,6 +305,7 @@ module "router-backend-3" {
   instance_key_name             = "${var.stackname}-router-backend"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.router_backend_3_elb.id}", "${aws_elb.router_api_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
 }
 

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # asg_max_size
 # asg_min_size
 # asg_desired_capacity
@@ -36,6 +37,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "Default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "asg_max_size" {
@@ -149,6 +156,7 @@ module "search" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.search_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "${var.asg_max_size}"
   asg_min_size                  = "${var.asg_min_size}"
   asg_desired_capacity          = "${var.asg_desired_capacity}"

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_certname
 # app_service_records
 #
@@ -33,6 +34,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "whitehall-backend default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_certname" {
@@ -127,6 +134,7 @@ module "whitehall-backend" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.whitehall-backend_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -8,6 +8,7 @@
 # stackname
 # aws_environment
 # ssh_public_key
+# instance_ami_filter_name
 # elb_internal_certname
 #
 # === Outputs:
@@ -32,6 +33,12 @@ variable "aws_environment" {
 variable "ssh_public_key" {
   type        = "string"
   description = "whitehall-frontend default public key material"
+}
+
+variable "instance_ami_filter_name" {
+  type        = "string"
+  description = "Name to use to find AMI images"
+  default     = ""
 }
 
 variable "elb_internal_certname" {
@@ -111,6 +118,7 @@ module "whitehall-frontend" {
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.whitehall-frontend_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"


### PR DESCRIPTION
Currently the node_group module uses the `aws_ami` data source to determine the newest AMI ID
published by Ubuntu within a major version and use that in our launch configurations. This parameter
could be overriden in each project to set a specific image name, and this is going to be the needed
to avoid having to recreate the launch_configuration every time we get a new image patch.

This commit adds a new variable to all the projects to make sure we set the same image everywhere.
The default image version should be set in the common data file.