### PR TITLE
Add a clustering option to redis module

### DIFF
--- a/terraform/projects/app-backend-redis/main.tf
+++ b/terraform/projects/app-backend-redis/main.tf
@@ -27,6 +27,12 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "enable_clustering" {
+  type        = "string"
+  description = "Enable clustering"
+  default     = false
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -48,6 +54,7 @@ resource "aws_route53_record" "service_record" {
 
 module "backend_redis_cluster" {
   source             = "../../modules/aws/elasticache_redis_cluster"
+  enable_clustering  = "${var.enable_clustering}"
   name               = "${var.stackname}-backend-redis"
   default_tags       = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend-redis")}"
   subnet_ids         = "${data.terraform_remote_state.infra_networking.private_subnet_elasticache_ids}"


### PR DESCRIPTION
We are seeing errors with publishing-api which seem to be related with redis.

Update the module so you can choose either clustered or non-clustered. If non-clustered is chosen, then a master with a read replica is created on redis 3.2.