### PR TITLE
Run init on every run

### DIFF
--- a/doc/architecture/step-by-step.md
+++ b/doc/architecture/step-by-step.md
@@ -29,7 +29,6 @@ aws --region eu-west-1 s3 mb "s3://govuk-terraform-steppingstone-${ENVIRONMENT}"
 # environment variables.
 export DATA_DIR=~/govuk-aws-data/data
 export STACKNAME=govuk
-./tools/build-terraform-project.sh -c init -p infra-vpc
 ./tools/build-terraform-project.sh -c plan -p infra-vpc
 ./tools/build-terraform-project.sh -c apply -p infra-vpc
 ```
@@ -38,7 +37,6 @@ export STACKNAME=govuk
 
 ```
 export STACKNAME=govuk
-./tools/build-terraform-project.sh -c init -p infra-networking
 ./tools/build-terraform-project.sh -c plan -p infra-networking
 ./tools/build-terraform-project.sh -c apply -p infra-networking
 ```
@@ -47,7 +45,6 @@ export STACKNAME=govuk
 
 ```
 export STACKNAME=govuk
-./tools/build-terraform-project.sh -c init -p infra-root-dns-zones
 ./tools/build-terraform-project.sh -c plan -p infra-root-dns-zones
 ./tools/build-terraform-project.sh -c apply -p infra-root-dns-zones
 ```
@@ -57,7 +54,6 @@ export STACKNAME=govuk
 ```
 # Most of these commands are carried out in the 'blue' application stack
 export STACKNAME=blue
-./tools/build-terraform-project.sh -c init -p infra-stack-dns-zones
 ./tools/build-terraform-project.sh -c plan -p infra-stack-dns-zones
 ./tools/build-terraform-project.sh -c apply -p infra-stack-dns-zones
 ```
@@ -67,7 +63,6 @@ export STACKNAME=blue
 ```
 # Note that security groups are in the 'govuk' stack
 export STACKNAME=govuk
-./tools/build-terraform-project.sh -c init -p infra-security-groups
 ./tools/build-terraform-project.sh -c plan -p infra-security-groups
 ./tools/build-terraform-project.sh -c apply -p infra-security-groups
 ```
@@ -76,7 +71,6 @@ export STACKNAME=govuk
 
 ```
 export STACKNAME=blue
-./tools/build-terraform-project.sh -c init -p app-puppetmaster
 ./tools/build-terraform-project.sh -c plan -p app-puppetmaster
 ./tools/build-terraform-project.sh -c apply -p app-puppetmaster
 ```
@@ -131,7 +125,6 @@ sudo ./aws-copy-puppet-setup.sh -e integration -s blue
 
 ```
 export STACKNAME=blue
- $ ./tools/build-terraform-project.sh -c init -p app-jumpbox
  $ ./tools/build-terraform-project.sh -c plan -p app-jumpbox
  $ ./tools/build-terraform-project.sh -c apply -p app-jumpbox
 ```
@@ -140,7 +133,6 @@ export STACKNAME=blue
 
 ```
 export STACKNAME=blue
- $ ./tools/build-terraform-project.sh -c init -p app-monitoring
  $ ./tools/build-terraform-project.sh -c plan -p app-monitoring
  $ ./tools/build-terraform-project.sh -c apply -p app-monitoring
 ```
@@ -149,7 +141,6 @@ export STACKNAME=blue
 
 ```
 export STACKNAME=blue
- $ ./tools/build-terraform-project.sh -c init -p app-deploy
  $ ./tools/build-terraform-project.sh -c plan -p app-deploy
  $ ./tools/build-terraform-project.sh -c apply -p app-deploy
 ```

--- a/doc/guides/environment-provisioning.md
+++ b/doc/guides/environment-provisioning.md
@@ -79,15 +79,13 @@ $ aws s3api put-bucket-versioning  \
 
 ## Provision the base infrastructure
 
-There are several Terraform projects that need to be run to set up the base infrastructure. For each of these you should run `init`, `plan` and `apply` in the build script. If you're setting up a new stack you'll also need to create `.backend` files for each project (see [below](#creating-backend-files-for-a-new-stack)), otherwise you should use an existing one (e.g. `integration-green` or `deana`).
+There are several Terraform projects that need to be run to set up the base infrastructure. For each of these you should run `plan` and `apply` in the build script. If you're setting up a new stack you'll also need to create `.backend` files for each project (see [below](#creating-backend-files-for-a-new-stack)), otherwise you should use an existing one (e.g. `integration-green` or `deana`).
 
 ```
 $ export DATA_DIR=<path to govuk-aws-data repository>/data
 $ export STACKNAME=<stackname>
 # NOTE: the ENVIRONMENT variable also needs to be set or passed to this script.
 
-$ tools/build-terraform-project.sh -c init -p name>
-...terraform output...
 $ tools/build-terraform-project.sh -c plan -p name>
 ...terraform output...
 $ tools/build-terraform-project.sh -c apply -p project name>
@@ -122,8 +120,6 @@ Now run
 
 ```
 # Make sure STACKNAME & ENVIRONMENT are set
-$ tools/build-terraform-project.sh -c init -p app-puppetmaster
-...terraform output...
 $ tools/build-terraform-project.sh -c plan -p app-puppetmaster
 ...terraform output...
 $ tools/build-terraform-project.sh -c apply -p app-puppetmaster
@@ -185,8 +181,6 @@ Notice: Finished catalog run in 0.01 seconds
 
 You now need to build the deploy Jenkins:
 ```
-$ tools/build-terraform-project.sh -c init -p app-deploy
-...terraform output...
 $ tools/build-terraform-project.sh -c plan -p app-deploy
 ...terraform output...
 $ tools/build-terraform-project.sh -c apply -p app-deploy

--- a/tools/build-terraform-project.sh
+++ b/tools/build-terraform-project.sh
@@ -124,33 +124,36 @@ fi
 # Run everything from the appropriate project
 cd "$PROJECT_DIR"
 
+
+
 # Actually run the command
-if [[ $CMD == "init" ]]; then
+function init() {
   rm -rf .terraform && \
   rm -rf terraform.tfstate.backup && \
-  terraform "$CMD" \
+  terraform init \
             -backend-config "$BACKEND_FILE"
-else
-  # Build the command to run
-  TO_RUN="terraform $CMD"
-  # Append which ever tfvar files exist
-  for TFVAR_FILE in "$COMMON_DATA" \
-                    "$STACK_COMMON_DATA" \
-                    "$COMMON_PROJECT_DATA" \
-                    "$SECRET_COMMON_PROJECT_DATA" \
-                    "$STACK_PROJECT_DATA" \
-                    "$SECRET_PROJECT_DATA"
-  do
-    if [[ -f $TFVAR_FILE ]] &&
-       (
-        [[ "$TFVAR_FILE" == "$SECRET_PROJECT_DATA" ]] ||
-        [[ "$TFVAR_FILE" == "$SECRET_COMMON_PROJECT_DATA" ]]
-       ) ; then
-      TO_RUN="$TO_RUN -var-file <(sops -d $TFVAR_FILE)"
-    elif [[ -f $TFVAR_FILE ]]; then
-      TO_RUN="$TO_RUN -var-file $TFVAR_FILE"
-    fi
-  done
+}
 
-  eval "$TO_RUN $@"
-fi
+# Build the command to run
+TO_RUN="init && terraform $CMD"
+# Append which ever tfvar files exist
+for TFVAR_FILE in "$COMMON_DATA" \
+                  "$STACK_COMMON_DATA" \
+                  "$COMMON_PROJECT_DATA" \
+                  "$SECRET_COMMON_PROJECT_DATA" \
+                  "$STACK_PROJECT_DATA" \
+                  "$SECRET_PROJECT_DATA"
+do
+  if [[ -f $TFVAR_FILE ]] &&
+     (
+      [[ "$TFVAR_FILE" == "$SECRET_PROJECT_DATA" ]] ||
+      [[ "$TFVAR_FILE" == "$SECRET_COMMON_PROJECT_DATA" ]]
+     ) ; then
+    TO_RUN="$TO_RUN -var-file <(sops -d $TFVAR_FILE)"
+  elif [[ -f $TFVAR_FILE ]]; then
+    TO_RUN="$TO_RUN -var-file $TFVAR_FILE"
+  fi
+done
+
+eval "$TO_RUN $@"
+

--- a/tools/build-terraform-project.sh
+++ b/tools/build-terraform-project.sh
@@ -156,4 +156,3 @@ do
 done
 
 eval "$TO_RUN $@"
-


### PR DESCRIPTION
Update the build tool to run init on each run of the command. This is for safety reasons to ensure the modules and backend are correctly refreshed.