### PR TITLE
Add EBS volume to mirrorer

### DIFF
--- a/terraform/projects/app-mirrorer/additional_policy.json
+++ b/terraform/projects/app-mirrorer/additional_policy.json
@@ -1,0 +1,18 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1499854881000",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AttachVolume",
+                "ec2:DetachVolume",
+                "ec2:DescribeVolumeStatus",
+                "ec2:DescribeVolumes"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
The mirrorer needs a large disk to store the static website prior to
upload. This adds a 100GB EBS volume to the instance.

This could, in theory, be done using a larger root volume but this would
mean that if the instance went away progress would be lost. This would
likely limit the usefulness of the static images if it had to repeat
large amounts of work.