### PR TITLE
Update asset-master security rules

### DIFF
--- a/terraform/projects/infra-security-groups/asset-master.tf
+++ b/terraform/projects/infra-security-groups/asset-master.tf
@@ -7,7 +7,8 @@
 #
 # === Outputs:
 # sg_asset-master_id
-
+# sg_asset-master-efs_id
+#
 resource "aws_security_group" "asset-master" {
   name        = "${var.stackname}_asset-master_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
@@ -16,4 +17,56 @@ resource "aws_security_group" "asset-master" {
   tags {
     Name = "${var.stackname}_asset-master_access"
   }
+}
+
+resource "aws_security_group" "asset-master-efs" {
+  name        = "${var.stackname}_asset-master-efs_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Security group for asset-master EFS share"
+
+  tags {
+    Name = "${var.stackname}_asset-master-efs_access"
+  }
+}
+
+# Allow both TCP and UDP for NFS
+resource "aws_security_group_rule" "allow_asset-master-efs_from_asset-master" {
+  type      = "ingress"
+  from_port = 111
+  to_port   = 111
+  protocol  = "all"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.asset-master-efs.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.asset-master.id}"
+}
+
+# Allow both TCP and UDP for NFS
+resource "aws_security_group_rule" "allow_asset-master-efs_from_backend" {
+  type      = "ingress"
+  from_port = 111
+  to_port   = 111
+  protocol  = "all"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.asset-master-efs.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.backend.id}"
+}
+
+# Allow both TCP and UDP for NFS
+resource "aws_security_group_rule" "allow_asset-master-efs_from_whitehall-backend" {
+  type      = "ingress"
+  from_port = 111
+  to_port   = 111
+  protocol  = "all"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.asset-master-efs.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.whitehall-backend.id}"
 }


### PR DESCRIPTION
Backend and whitehall-backend both need access to the EFS share over tcp/udp 111.