### PR TITLE
Add external and internal ELBs to content stores

### DIFF
--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -75,7 +75,7 @@ data "aws_acm_certificate" "elb_internal_cert" {
 resource "aws_elb" "content-store_external_elb" {
   name            = "${var.stackname}-content-store-external"
   subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_elb_id}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_external_elb_id}"]
   internal        = "false"
 
   listener {
@@ -117,8 +117,8 @@ resource "aws_route53_record" "external_service_record" {
 
 resource "aws_elb" "content-store_internal_elb" {
   name            = "${var.stackname}-content-store-internal"
-  subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_elb_id}"]
+  subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_internal_elb_id}"]
   internal        = "true"
 
   listener {

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -9,7 +9,7 @@
 # aws_environment
 # ssh_public_key
 # instance_ami_filter_name
-# elb_certname
+# elb_external_certname
 #
 # === Outputs:
 #
@@ -41,7 +41,12 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
-variable "elb_certname" {
+variable "elb_external_certname" {
+  type        = "string"
+  description = "The ACM cert domain name to find the ARN of"
+}
+
+variable "elb_internal_certname" {
   type        = "string"
   description = "The ACM cert domain name to find the ARN of"
 }
@@ -57,24 +62,29 @@ provider "aws" {
   region = "${var.aws_region}"
 }
 
-data "aws_acm_certificate" "elb_cert" {
-  domain   = "${var.elb_certname}"
+data "aws_acm_certificate" "elb_external_cert" {
+  domain   = "${var.elb_external_certname}"
+  statuses = ["ISSUED"]
+}
+
+data "aws_acm_certificate" "elb_internal_cert" {
+  domain   = "${var.elb_internal_certname}"
   statuses = ["ISSUED"]
 }
 
 resource "aws_elb" "draft-content-store_external_elb" {
-  name            = "${var.stackname}-draft-content-store"
+  name            = "${var.stackname}-draft-content-store-external"
   subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_offsite_ssh_id}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_draft-content-store_external_elb_id}"]
   internal        = "false"
 
   listener {
-    instance_port     = 80
+    instance_port     = "80"
     instance_protocol = "http"
-    lb_port           = 443
+    lb_port           = "443"
     lb_protocol       = "https"
 
-    ssl_certificate_id = "${data.aws_acm_certificate.elb_cert.arn}"
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
   }
 
   health_check {
@@ -93,9 +103,52 @@ resource "aws_elb" "draft-content-store_external_elb" {
   tags = "${map("Name", "${var.stackname}-draft-content-store", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "draft_content_store")}"
 }
 
-resource "aws_route53_record" "service_record" {
+resource "aws_route53_record" "external_service_record" {
   zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
   name    = "draft-content-store.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_elb.draft-content-store_external_elb.dns_name}"
+    zone_id                = "${aws_elb.draft-content-store_external_elb.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_elb" "draft-content-store_internal_elb" {
+  name            = "${var.stackname}-draft-content-store-internal"
+  subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_draft-content-store_internal_elb_id}"]
+  internal        = "true"
+
+  listener {
+    instance_port     = "80"
+    instance_protocol = "http"
+    lb_port           = "443"
+    lb_protocol       = "https"
+
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_internal_cert.arn}"
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    target              = "TCP:80"
+    interval            = 30
+  }
+
+  cross_zone_load_balancing   = true
+  idle_timeout                = 400
+  connection_draining         = true
+  connection_draining_timeout = 400
+
+  tags = "${map("Name", "${var.stackname}-draft-content-store", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "draft_content_store")}"
+}
+
+resource "aws_route53_record" "internal_service_record" {
+  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
+  name    = "draft-content-store.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
   type    = "A"
 
   alias {
@@ -117,7 +170,7 @@ module "draft-content-store" {
   instance_key_name             = "${var.stackname}-draft-content-store"
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
-  instance_elb_ids              = ["${aws_elb.draft-content-store_external_elb.id}"]
+  instance_elb_ids              = ["${aws_elb.draft-content-store_external_elb.id}", "${aws_elb.draft-content-store_internal_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
@@ -132,7 +185,12 @@ output "draft-content-store_elb_address" {
   description = "AWS' internal DNS name for the draft-content-store ELB"
 }
 
-output "service_dns_name" {
-  value       = "${aws_route53_record.service_record.name}"
+output "external_service_dns_name" {
+  value       = "${aws_route53_record.external_service_record.name}"
+  description = "DNS name to access the node service"
+}
+
+output "internal_service_dns_name" {
+  value       = "${aws_route53_record.internal_service_record.name}"
   description = "DNS name to access the node service"
 }

--- a/terraform/projects/infra-security-groups/content-store.tf
+++ b/terraform/projects/infra-security-groups/content-store.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "content-store" {
   }
 }
 
-resource "aws_security_group_rule" "allow_content-store_elb_in" {
+resource "aws_security_group_rule" "allow_content-store_internal_elb_in" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -31,36 +31,80 @@ resource "aws_security_group_rule" "allow_content-store_elb_in" {
   security_group_id = "${aws_security_group.content-store.id}"
 
   # Which security group can use this rule
-  source_security_group_id = "${aws_security_group.content-store_elb.id}"
+  source_security_group_id = "${aws_security_group.content-store_internal_elb.id}"
 }
 
-resource "aws_security_group" "content-store_elb" {
-  name        = "${var.stackname}_content-store_elb_access"
+resource "aws_security_group_rule" "allow_content-store_external_elb_in" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.content-store.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.content-store_external_elb.id}"
+}
+
+resource "aws_security_group" "content-store_internal_elb" {
+  name        = "${var.stackname}_content-store_internal_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  description = "Access the content-store ELB"
+  description = "Access the content-store internal ELB"
 
   tags {
-    Name = "${var.stackname}_content-store_elb_access"
+    Name = "${var.stackname}_content-store_internal_elb_access"
   }
 }
 
-# Content Store should be available externally
-resource "aws_security_group_rule" "allow_public_to_content-store_elb" {
+# Content Store should be available internally
+resource "aws_security_group_rule" "allow_management_to_content-store_internal_elb" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
   protocol  = "tcp"
 
-  security_group_id = "${aws_security_group.content-store_elb.id}"
-  cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}"]
+  security_group_id        = "${aws_security_group.content-store_internal_elb.id}"
+  source_security_group_id = "${aws_security_group.management.id}"
 }
 
 # TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_content-store_elb_egress" {
+resource "aws_security_group_rule" "allow_content-store_internal_elb_egress" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.content-store_elb.id}"
+  security_group_id = "${aws_security_group.content-store_internal_elb.id}"
+}
+
+resource "aws_security_group" "content-store_external_elb" {
+  name        = "${var.stackname}_content-store_external_elb_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access the content-store external ELB"
+
+  tags {
+    Name = "${var.stackname}_content-store_external_elb_access"
+  }
+}
+
+# Content Store should be available externally
+resource "aws_security_group_rule" "allow_public_to_content-store_external_elb" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id = "${aws_security_group.content-store_external_elb.id}"
+  cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}"]
+}
+
+# TODO test whether egress rules are needed on ELBs
+resource "aws_security_group_rule" "allow_content-store_external_elb_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.content-store_external_elb.id}"
 }

--- a/terraform/projects/infra-security-groups/draft-content-store.tf
+++ b/terraform/projects/infra-security-groups/draft-content-store.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "draft-content-store" {
   }
 }
 
-resource "aws_security_group_rule" "allow_draft-content-store_elb_in" {
+resource "aws_security_group_rule" "allow_draft-content-store_internal_elb_in" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -31,25 +31,80 @@ resource "aws_security_group_rule" "allow_draft-content-store_elb_in" {
   security_group_id = "${aws_security_group.draft-content-store.id}"
 
   # Which security group can use this rule
-  source_security_group_id = "${aws_security_group.draft-content-store_elb.id}"
+  source_security_group_id = "${aws_security_group.draft-content-store_internal_elb.id}"
 }
 
-resource "aws_security_group" "draft-content-store_elb" {
-  name        = "${var.stackname}_draft-content-store_elb_access"
+resource "aws_security_group_rule" "allow_draft-content-store_external_elb_in" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.draft-content-store.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.draft-content-store_external_elb.id}"
+}
+
+resource "aws_security_group" "draft-content-store_internal_elb" {
+  name        = "${var.stackname}_draft-content-store_internal_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  description = "Access the draft-content-store ELB"
+  description = "Access the draft-content-store internal ELB"
 
   tags {
-    Name = "${var.stackname}_draft-content-store_elb_access"
+    Name = "${var.stackname}_draft-content-store_internal_elb_access"
   }
 }
 
+# Content Store should be available internally
+resource "aws_security_group_rule" "allow_management_to_draft-content-store_internal_elb" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id        = "${aws_security_group.draft-content-store_internal_elb.id}"
+  source_security_group_id = "${aws_security_group.management.id}"
+}
+
 # TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_draft-content-store_elb_egress" {
+resource "aws_security_group_rule" "allow_draft-content-store_internal_elb_egress" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.draft-content-store_elb.id}"
+  security_group_id = "${aws_security_group.draft-content-store_internal_elb.id}"
+}
+
+resource "aws_security_group" "draft-content-store_external_elb" {
+  name        = "${var.stackname}_draft-content-store_external_elb_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access the draft-content-store external ELB"
+
+  tags {
+    Name = "${var.stackname}_draft-content-store_external_elb_access"
+  }
+}
+
+# Content Store should be available externally
+resource "aws_security_group_rule" "allow_public_to_draft-content-store_external_elb" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id = "${aws_security_group.draft-content-store_external_elb.id}"
+  cidr_blocks       = ["${var.office_ips}"]
+}
+
+# TODO test whether egress rules are needed on ELBs
+resource "aws_security_group_rule" "allow_draft-content-store_external_elb_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.draft-content-store_external_elb.id}"
 }

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -74,8 +74,12 @@ output "sg_calculators-frontend_id" {
   value = "${aws_security_group.calculators-frontend.id}"
 }
 
-output "sg_content-store_elb_id" {
-  value = "${aws_security_group.content-store_elb.id}"
+output "sg_content-store_external_elb_id" {
+  value = "${aws_security_group.content-store_external_elb.id}"
+}
+
+output "sg_content-store_internal_elb_id" {
+  value = "${aws_security_group.content-store_internal_elb.id}"
 }
 
 output "sg_content-store_id" {
@@ -114,8 +118,12 @@ output "sg_draft-cache_elb_id" {
   value = "${aws_security_group.draft-cache_elb.id}"
 }
 
-output "sg_draft-content-store_elb_id" {
-  value = "${aws_security_group.draft-content-store_elb.id}"
+output "sg_draft-content-store_external_elb_id" {
+  value = "${aws_security_group.draft-content-store_external_elb.id}"
+}
+
+output "sg_draft-content-store_internal_elb_id" {
+  value = "${aws_security_group.draft-content-store_internal_elb.id}"
 }
 
 output "sg_draft-content-store_id" {


### PR DESCRIPTION
Update content-store and draft-content-store to use an internal
and external ELB in both cases. Use dedicated security groups
for each type of ELB.