### PR TITLE
Make instance type a variable for mapit

### DIFF
--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -57,6 +57,12 @@ variable "elb_internal_certname" {
   description = "The ACM cert domain name to find the ARN of"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "The type of EC2 instance to use for both ASGs."
+  default     = "t2.medium"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -129,7 +135,7 @@ module "mapit-1" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_1_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "${var.instance_type}"
   create_instance_key           = false
   instance_key_name             = "${var.stackname}-mapit"
   instance_public_key           = "${var.ssh_public_key}"
@@ -161,7 +167,7 @@ module "mapit-2" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-2")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_2_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.micro"
+  instance_type                 = "${var.instance_type}"
   create_instance_key           = false
   instance_key_name             = "${var.stackname}-mapit"
   instance_public_key           = "${var.ssh_public_key}"


### PR DESCRIPTION
Start using a variable to configure instance type for Mapit. This will
likely need to be done eventually (to allow larger instances in
production/staging) and this means that the two ASGs will both use the
same instance type.