### PR TITLE
Enable internal access to publishing-api

### DIFF
--- a/terraform/projects/infra-security-groups/publishing-api.tf
+++ b/terraform/projects/infra-security-groups/publishing-api.tf
@@ -24,6 +24,19 @@ resource "aws_security_group" "publishing-api" {
   }
 }
 
+resource "aws_security_group_rule" "allow_publishing-api_internal_elb_in" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.publishing-api.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.publishing-api_elb_internal.id}"
+}
+
 resource "aws_security_group_rule" "allow_publishing-api_external_elb_in" {
   type      = "ingress"
   from_port = 80
@@ -35,6 +48,41 @@ resource "aws_security_group_rule" "allow_publishing-api_external_elb_in" {
 
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.publishing-api_elb_external.id}"
+}
+
+resource "aws_security_group" "publishing-api_elb_internal" {
+  name        = "${var.stackname}_publishing-api_elb_internal_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access the publishing-api ELB"
+
+  tags {
+    Name = "${var.stackname}_publishing-api_elb_access"
+  }
+}
+
+# TODO: application machines need access to publishing-api - create an application
+# group that needs access?
+resource "aws_security_group_rule" "allow_management_to_publishing-api_https" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.publishing-api_elb_internal.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.management.id}"
+}
+
+# TODO: test whether egress rules are needed on elbs
+resource "aws_security_group_rule" "allow_publishing-api_elb_internal_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.publishing-api_elb_internal.id}"
 }
 
 resource "aws_security_group" "publishing-api_elb_external" {
@@ -58,44 +106,6 @@ resource "aws_security_group_rule" "allow_office_to_publishing-api_https" {
   cidr_blocks       = ["${var.office_ips}"]
 }
 
-resource "aws_security_group" "publishing-api_elb_internal" {
-  name        = "${var.stackname}_publishing-api_elb_internal_access"
-  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  description = "Access the publishing-api ELB"
-
-  tags {
-    Name = "${var.stackname}_publishing-api_elb_access"
-  }
-}
-
-resource "aws_security_group_rule" "allow_publishing-api_internal_elb_in" {
-  type      = "ingress"
-  from_port = 80
-  to_port   = 80
-  protocol  = "tcp"
-
-  # Which security group is the rule assigned to
-  security_group_id = "${aws_security_group.publishing-api.id}"
-
-  # Which security group can use this rule
-  source_security_group_id = "${aws_security_group.publishing-api_elb_internal.id}"
-}
-
-# TODO: application machines need access to publishing-api - create an application
-# group that needs access?
-resource "aws_security_group_rule" "allow_management_to_publishing-api_https" {
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  # Which security group is the rule assigned to
-  security_group_id = "${aws_security_group.publishing-api_elb_external.id}"
-
-  # Which security group can use this rule
-  source_security_group_id = "${aws_security_group.management.id}"
-}
-
 # TODO: test whether egress rules are needed on elbs
 resource "aws_security_group_rule" "allow_publishing-api_elb_external_egress" {
   type              = "egress"
@@ -104,14 +114,4 @@ resource "aws_security_group_rule" "allow_publishing-api_elb_external_egress" {
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.publishing-api_elb_external.id}"
-}
-
-# TODO: test whether egress rules are needed on elbs
-resource "aws_security_group_rule" "allow_publishing-api_elb_internal_egress" {
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.publishing-api_elb_internal.id}"
 }


### PR DESCRIPTION
Apps need internal access to publishing-api (frontend deployments are
failing). For now we are giving access to the management network.