### PR TITLE
Allow calling https://draft-router-api

### DIFF
--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -41,7 +41,7 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
-variable "elb_certname" {
+variable "elb_internal_certname" {
   type        = "string"
   description = "The ACM cert domain name to find the ARN of"
 }
@@ -57,8 +57,8 @@ provider "aws" {
   region = "${var.aws_region}"
 }
 
-data "aws_acm_certificate" "elb_cert" {
-  domain   = "${var.elb_certname}"
+data "aws_acm_certificate" "elb_internal_cert" {
+  domain   = "${var.elb_internal_certname}"
   statuses = ["ISSUED"]
 }
 
@@ -74,7 +74,7 @@ resource "aws_elb" "draft-cache_elb" {
     lb_port           = 443
     lb_protocol       = "https"
 
-    ssl_certificate_id = "${data.aws_acm_certificate.elb_cert.arn}"
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_internal_cert.arn}"
   }
 
   health_check {

--- a/terraform/projects/infra-security-groups/draft-cache.tf
+++ b/terraform/projects/infra-security-groups/draft-cache.tf
@@ -59,6 +59,20 @@ resource "aws_security_group" "draft-cache_elb" {
   }
 }
 
+# This is required to commit routes using router-api at the end of the data sync
+resource "aws_security_group_rule" "allow_draft-cache_from_draft-content-store" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.draft-cache_elb.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.draft-content-store.id}"
+}
+
 # TODO test whether egress rules are needed on ELBs
 resource "aws_security_group_rule" "allow_draft-cache_elb_egress" {
   type              = "egress"


### PR DESCRIPTION
At the end of the router data sync, the script calls router-api from draft-content-store.