### PR TITLE
Fix Gemstash internal access

### DIFF
--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -136,6 +136,13 @@ resource "aws_elb" "apt_internal_elb" {
     ssl_certificate_id = "${data.aws_acm_certificate.elb_internal_cert.arn}"
   }
 
+  listener {
+    instance_port     = 80
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+
   health_check {
     healthy_threshold   = 2
     unhealthy_threshold = 2

--- a/terraform/projects/infra-security-groups/apt.tf
+++ b/terraform/projects/infra-security-groups/apt.tf
@@ -98,6 +98,16 @@ resource "aws_security_group_rule" "allow_management_to_apt_elb" {
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
+resource "aws_security_group_rule" "allow_management_to_apt_elb_80" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  security_group_id        = "${aws_security_group.apt_internal_elb.id}"
+  source_security_group_id = "${aws_security_group.management.id}"
+}
+
 resource "aws_security_group_rule" "allow_apt_internal_elb_egress" {
   type              = "egress"
   from_port         = 0


### PR DESCRIPTION
Put access to Gemstash back, after removing in previous Apt changes. We
need internal access to Apt ELB on port 80.