### PR TITLE
Use private EIPs rather than ELBs on mongo

### DIFF
--- a/terraform/projects/app-mongo/additional_policy.json
+++ b/terraform/projects/app-mongo/additional_policy.json
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1499854881000",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:AttachNetworkInterface"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -99,6 +99,16 @@ variable "private_subnet_rds_availability_zones" {
   description = "Map containing private rds subnet names and availability zones associated"
 }
 
+variable "private_subnet_reserved_ips_cidrs" {
+  type        = "map"
+  description = "Map containing private ENI subnet names and CIDR associated"
+}
+
+variable "private_subnet_reserved_ips_availability_zones" {
+  type        = "map"
+  description = "Map containing private ENI subnet names and availability zones associated"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -188,6 +198,15 @@ module "infra_private_subnet_rds" {
   subnet_nat_gateways_length = "0"
 }
 
+module "infra_private_subnet_reserved_ips" {
+  source                     = "../../modules/aws/network/private_subnet"
+  vpc_id                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  default_tags               = "${map("Project", var.stackname, "aws_migration", "eni")}"
+  subnet_cidrs               = "${var.private_subnet_reserved_ips_cidrs}"
+  subnet_availability_zones  = "${var.private_subnet_reserved_ips_availability_zones}"
+  subnet_nat_gateways_length = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 output "vpc_id" {
@@ -263,5 +282,24 @@ output "private_subnet_rds_names_azs_map" {
 
 output "private_subnet_rds_names_route_tables_map" {
   value       = "${module.infra_private_subnet_rds.subnet_names_route_tables_map}"
+  description = "Map containing the name of each private subnet and route_table ID associated"
+}
+
+output "private_subnet_reserved_ips_ids" {
+  value       = "${module.infra_private_subnet_reserved_ips.subnet_ids}"
+  description = "List of private subnet IDs"
+}
+
+output "private_subnet_reserved_ips_names_ids_map" {
+  value       = "${module.infra_private_subnet_reserved_ips.subnet_names_ids_map}"
+  description = "Map containing the pair name-id for each private subnet created"
+}
+
+output "private_subnet_reserved_ips_names_azs_map" {
+  value = "${var.private_subnet_reserved_ips_availability_zones}"
+}
+
+output "private_subnet_reserved_ips_names_route_tables_map" {
+  value       = "${module.infra_private_subnet_reserved_ips.subnet_names_route_tables_map}"
   description = "Map containing the name of each private subnet and route_table ID associated"
 }

--- a/terraform/projects/infra-security-groups/mongo.tf
+++ b/terraform/projects/infra-security-groups/mongo.tf
@@ -35,100 +35,57 @@ resource "aws_security_group_rule" "allow_mongo_cluster_in" {
   source_security_group_id = "${aws_security_group.mongo.id}"
 }
 
-resource "aws_security_group_rule" "mongo_elb_in" {
+resource "aws_security_group_rule" "allow_frontend_to_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
   protocol  = "tcp"
 
-  # Which security group is the rule assigned to
   security_group_id = "${aws_security_group.mongo.id}"
-
-  # Which security group can use this rule
-  source_security_group_id = "${aws_security_group.mongo_elb.id}"
-}
-
-resource "aws_security_group" "mongo_elb" {
-  name        = "${var.stackname}_mongo_elb_access"
-  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  description = "Access the Router Mongo cluster"
-
-  tags {
-    Name = "${var.stackname}_mongo_elb_access"
-  }
-}
-
-resource "aws_security_group_rule" "allow_mongo_to_mongo_elb" {
-  type      = "ingress"
-  from_port = 27017
-  to_port   = 27017
-  protocol  = "tcp"
-
-  security_group_id = "${aws_security_group.mongo_elb.id}"
-
-  source_security_group_id = "${aws_security_group.mongo.id}"
-}
-
-resource "aws_security_group_rule" "allow_frontend_to_mongo_elb" {
-  type      = "ingress"
-  from_port = 27017
-  to_port   = 27017
-  protocol  = "tcp"
-
-  security_group_id = "${aws_security_group.mongo_elb.id}"
 
   source_security_group_id = "${aws_security_group.frontend.id}"
 }
 
-resource "aws_security_group_rule" "allow_calculators-frontend_to_mongo_elb" {
+resource "aws_security_group_rule" "allow_calculators-frontend_to_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
   protocol  = "tcp"
 
-  security_group_id = "${aws_security_group.mongo_elb.id}"
+  security_group_id = "${aws_security_group.mongo.id}"
 
   source_security_group_id = "${aws_security_group.calculators-frontend.id}"
 }
 
-resource "aws_security_group_rule" "allow_backend_to_mongo_elb" {
+resource "aws_security_group_rule" "allow_backend_to_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
   protocol  = "tcp"
 
-  security_group_id = "${aws_security_group.mongo_elb.id}"
+  security_group_id = "${aws_security_group.mongo.id}"
 
   source_security_group_id = "${aws_security_group.backend.id}"
 }
 
-resource "aws_security_group_rule" "allow_content-store_to_mongo_elb" {
+resource "aws_security_group_rule" "allow_content-store_to_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
   protocol  = "tcp"
 
-  security_group_id = "${aws_security_group.mongo_elb.id}"
+  security_group_id = "${aws_security_group.mongo.id}"
 
   source_security_group_id = "${aws_security_group.content-store.id}"
 }
 
-resource "aws_security_group_rule" "allow_draft-content-store_to_mongo_elb" {
+resource "aws_security_group_rule" "allow_draft-content-store_to_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
   protocol  = "tcp"
 
-  security_group_id = "${aws_security_group.mongo_elb.id}"
+  security_group_id = "${aws_security_group.mongo.id}"
 
   source_security_group_id = "${aws_security_group.draft-content-store.id}"
-}
-
-resource "aws_security_group_rule" "allow_mongo_elb_egress" {
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.mongo_elb.id}"
 }

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -210,10 +210,6 @@ output "sg_mongo_id" {
   value = "${aws_security_group.mongo.id}"
 }
 
-output "sg_mongo_elb_id" {
-  value = "${aws_security_group.mongo_elb.id}"
-}
-
 output "sg_monitoring_id" {
   value = "${aws_security_group.monitoring.id}"
 }

--- a/terraform/userdata/10-associate-eni
+++ b/terraform/userdata/10-associate-eni
@@ -1,0 +1,66 @@
+#
+# Snippet: associate-eni
+#
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] START SNIPPET: associate-eni"
+
+# The environment variables INSTANCE_ID and REGION are set
+# in the base snippet
+#
+F_MIGRATION=$(facter aws_migration)
+F_STACKNAME=$(facter aws_stackname)
+F_HOSTNAME=$(facter aws_hostname)
+
+IFACE_TYPE="eth"
+IFACE_INDEX="1"
+IFACE="${IFACE_TYPE}${IFACE_INDEX}"
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: find network interface ID ..."
+if [[ -z $F_MIGRATION ]] || [[ -z $F_STACKNAME ]] || [[ -z F_HOSTNAME ]] ; then
+  echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: ERROR facts not found, skipping associate-eni"
+else
+  NETWORK_INTERFACE_ID=$(aws ec2 describe-network-interfaces --region=$REGION --filters "Name=tag:aws_migration,Values=$F_MIGRATION" "Name=tag:aws_hostname,Values=$F_HOSTNAME" "Name=tag:aws_stackname,Values=$F_STACKNAME" --output=json | jq -r '.NetworkInterfaces[] | .NetworkInterfaceId ')
+
+  if [[ -z $NETWORK_INTERFACE_ID ]] ; then
+    echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: ERROR ENI not found"
+  else
+    echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: attaching eni to instance ..."
+    aws ec2 attach-network-interface --region=$REGION --instance-id=$INSTANCE_ID --network-interface-id=$NETWORK_INTERFACE_ID --device-index ${IFACE_INDEX}
+
+    echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: waiting for ENI to attach..."
+    sleep 60
+  fi
+fi
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: getting ENI private address"
+
+IP_ADDR=$(aws ec2 describe-network-interfaces --region=$REGION --filters "Name=status,Values=in-use" "Name=tag:aws_migration,Values=$F_MIGRATION" "Name=tag:aws_hostname,Values=$F_HOSTNAME" "Name=tag:aws_stackname,Values=$F_STACKNAME" --output=json | jq '.NetworkInterfaces[0].PrivateIpAddresses[0].PrivateIpAddress'  | perl -ne 's/"//g; print')
+
+SUBNET=$(ruby -r ipaddr -e 'i = IPAddr.new(ARGV[0]); puts i.mask(24)' ${IP_ADDR})
+GATEWAY=$(ruby -r ipaddr -e 'i = IPAddr.new(ARGV[0]); puts i.mask(24).succ' ${IP_ADDR})
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: got IP ${IP_ADDR}. Assuming subnet is ${SUBNET}/24, gateway is ${GATEWAY}."
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: configuring routes and interface ${IFACE}"
+ROUTE_CFG="$(expr ${IFACE_INDEX} + 1) ${IFACE}_rt"
+grep -q "${ROUTE_CFG}" /etc/iproute2/rt_tables
+HAS_ROUTE_CONFIG=$?
+
+if [ $HAS_ROUTE_CONFIG != 0 ] ; then
+    echo "${ROUTE_CFG}" >> /etc/iproute2/rt_tables
+fi
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: configuring ${IFACE}"
+cat <<EOF > /etc/network/interfaces.d/${IFACE}.cfg
+auto ${IFACE}
+iface ${IFACE} inet dhcp
+up ip route add default via ${GATEWAY} dev ${IFACE} table ${IFACE}_rt
+up ip rule add from ${SUBNET}/24 lookup ${IFACE}_rt prio 1000
+EOF
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: cycling ${IFACE}"
+ifdown "${IFACE}"
+ifup "${IFACE}"
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] END SNIPPET: associate-eni"
+


### PR DESCRIPTION
We're seeing an issue where applications using the mongo cluster are unable to connect to the cluster despite it being available.

We believe it may be related to the dynamic nature of ELBs, and the mongo-ruby-driver currently being unable to handle DNS updates without a reload of the application.

This commit removes the load balancers, creates an ENI and an EIP, and attaches the ENI to the instance on boot using userdata.

As per the documentation, an IP associated with an ENI should follow the interface to any attached instance:

http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html

We can assign a DNS record to the IP address so the Puppet code underneath does not have to change.

https://trello.com/c/luBryWgW/748-change-the-way-mongo-in-aws-works