### PR TITLE
Prometheus tests

### DIFF
--- a/terraform/projects/app-monitortest/main.tf
+++ b/terraform/projects/app-monitortest/main.tf
@@ -94,36 +94,6 @@ resource "aws_elb" "monitortest_external_elb" {
   tags = "${map("Name", "${var.stackname}-monitortest", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "monitortest")}"
 }
 
-resource "aws_elb" "monitortest_internal_elb" {
-  name            = "${var.stackname}-monitortest-internal"
-  subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_monitortest_internal_elb_id}"]
-  internal        = "true"
-
-  listener {
-    instance_port     = 5667
-    instance_protocol = "tcp"
-    lb_port           = 5667
-    lb_protocol       = "tcp"
-  }
-
-  health_check {
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-    timeout             = 3
-
-    target   = "TCP:5667"
-    interval = 30
-  }
-
-  cross_zone_load_balancing   = true
-  idle_timeout                = 400
-  connection_draining         = true
-  connection_draining_timeout = 400
-
-  tags = "${map("Name", "${var.stackname}-monitortest", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "monitortest")}"
-}
-
 module "monitortest" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-monitortest"
@@ -136,7 +106,7 @@ module "monitortest" {
   instance_key_name             = "${var.stackname}-monitortest"
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
-  instance_elb_ids              = ["${aws_elb.monitortest_external_elb.id}", "${aws_elb.monitortest_internal_elb.id}"]
+  instance_elb_ids              = ["${aws_elb.monitortest_external_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
 }
 
@@ -148,18 +118,6 @@ resource "aws_route53_record" "external_service_record" {
   alias {
     name                   = "${aws_elb.monitortest_external_elb.dns_name}"
     zone_id                = "${aws_elb.monitortest_external_elb.zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_route53_record" "internal_service_record" {
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
-  name    = "monitortest.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${aws_elb.monitortest_internal_elb.dns_name}"
-    zone_id                = "${aws_elb.monitortest_internal_elb.zone_id}"
     evaluate_target_health = true
   }
 }

--- a/terraform/projects/infra-security-groups/monitortest.tf
+++ b/terraform/projects/infra-security-groups/monitortest.tf
@@ -34,19 +34,6 @@ resource "aws_security_group_rule" "allow_monitortest_external_elb_in" {
   source_security_group_id = "${aws_security_group.monitortest_external_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_monitortest_internal_elb_in" {
-  type      = "ingress"
-  from_port = 5667
-  to_port   = 5667
-  protocol  = "tcp"
-
-  # Which security group is the rule assigned to
-  security_group_id = "${aws_security_group.monitortest.id}"
-
-  # Which security group can use this rule
-  source_security_group_id = "${aws_security_group.monitortest_internal_elb.id}"
-}
-
 resource "aws_security_group" "monitortest_external_elb" {
   name        = "${var.stackname}_monitortest_external_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
@@ -77,34 +64,18 @@ resource "aws_security_group_rule" "allow_monitortest_external_elb_egress" {
   security_group_id = "${aws_security_group.monitortest_external_elb.id}"
 }
 
-resource "aws_security_group" "monitortest_internal_elb" {
-  name        = "${var.stackname}_monitortest_internal_elb_access"
-  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  description = "Access the monitortest ELB"
-
-  tags {
-    Name = "${var.stackname}_monitortest_internal_elb_access"
-  }
-}
-
-resource "aws_security_group_rule" "allow_management_to_monitortest_internal_elb_ncsa" {
+## MANAGEMENT RULES
+resource "aws_security_group_rule" "allow_node_exporter_ingress_from_monitortest" {
   type      = "ingress"
-  from_port = 5667
-  to_port   = 5667
+  from_port = 9091
+  to_port   = 9091
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.monitortest_internal_elb.id}"
-  source_security_group_id = "${aws_security_group.management.id}"
-}
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.management.id}"
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_monitortest_internal_elb_egress" {
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.monitortest_internal_elb.id}"
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.monitortest.id}"
 }
 
 output "sg_monitortest_id" {
@@ -113,8 +84,4 @@ output "sg_monitortest_id" {
 
 output "sg_monitortest_external_elb_id" {
   value = "${aws_security_group.monitortest_external_elb.id}"
-}
-
-output "sg_monitortest_internal_elb_id" {
-  value = "${aws_security_group.monitortest_internal_elb.id}"
 }


### PR DESCRIPTION
Update management security group to enable access from monitortest
to the node_exporter port.

Remove unused internal ELB on monitortest project.