### PR TITLE
Remove elb_certname references

### DIFF
--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -9,7 +9,8 @@
 # aws_environment
 # ssh_public_key
 # instance_ami_filter_name
-# elb_certname
+# elb_external_certname
+# elb_internal_certname
 # app_service_records
 # asg_max_size
 # asg_min_size

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -9,7 +9,7 @@
 # aws_environment
 # ssh_public_key
 # instance_ami_filter_name
-# elb_certname
+# elb_internal_certname
 # asg_max_size
 # asg_min_size
 # asg_desired_capacity

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -9,7 +9,7 @@
 # aws_environment
 # ssh_public_key
 # instance_ami_filter_name
-# elb_certname
+# elb_external_certname
 #
 # === Outputs:
 #

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -9,7 +9,7 @@
 # aws_environment
 # ssh_public_key
 # instance_ami_filter_name
-# elb_certname
+# elb_internal_certname
 #
 # === Outputs:
 #

--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -9,7 +9,7 @@
 # aws_environment
 # ssh_public_key
 # instance_ami_filter_name
-# elb_certname
+# elb_external_certname
 #
 # === Outputs:
 #
@@ -41,7 +41,7 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
-variable "elb_certname" {
+variable "elb_external_certname" {
   type        = "string"
   description = "The ACM cert domain name to find the ARN of"
 }
@@ -57,8 +57,8 @@ provider "aws" {
   region = "${var.aws_region}"
 }
 
-data "aws_acm_certificate" "elb_cert" {
-  domain   = "${var.elb_certname}"
+data "aws_acm_certificate" "elb_external_cert" {
+  domain   = "${var.elb_external_certname}"
   statuses = ["ISSUED"]
 }
 
@@ -74,7 +74,7 @@ resource "aws_elb" "monitoring_external_elb" {
     lb_port           = 443
     lb_protocol       = "https"
 
-    ssl_certificate_id = "${data.aws_acm_certificate.elb_cert.arn}"
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
   }
 
   health_check {

--- a/terraform/projects/app-monitortest/main.tf
+++ b/terraform/projects/app-monitortest/main.tf
@@ -9,7 +9,7 @@
 # aws_environment
 # ssh_public_key
 # instance_ami_filter_name
-# elb_certname
+# elb_external_certname
 #
 # === Outputs:
 #

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -9,7 +9,8 @@
 # aws_environment
 # ssh_public_key
 # instance_ami_filter_name
-# elb_certname
+# elb_external_certname
+# elb_internal_certname
 #
 # === Outputs:
 #


### PR DESCRIPTION
The `elb_certname` variable has been replaced with
`elb_external_certname` and `elb_internal_certname` to
ensure we use the correct domain on each case.

Update the code to remove comments and references to the
old variable and update with the right one.