### PR TITLE
Add Prometheus Alertmanager resources

### DIFF
--- a/terraform/projects/app-monitortest/main.tf
+++ b/terraform/projects/app-monitortest/main.tf
@@ -94,6 +94,62 @@ resource "aws_elb" "monitortest_external_elb" {
   tags = "${map("Name", "${var.stackname}-monitortest", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "monitortest")}"
 }
 
+resource "aws_route53_record" "external_service_record" {
+  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
+  name    = "monitortest.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_elb.monitortest_external_elb.dns_name}"
+    zone_id                = "${aws_elb.monitortest_external_elb.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_elb" "monitortest_external_elb_alertmanager" {
+  name            = "${var.stackname}-alertmanager-external"
+  subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_monitortest_external_elb_id}"]
+  internal        = "false"
+
+  listener {
+    instance_port     = 9093
+    instance_protocol = "http"
+    lb_port           = 443
+    lb_protocol       = "https"
+
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+
+    target   = "TCP:9093"
+    interval = 30
+  }
+
+  cross_zone_load_balancing   = true
+  idle_timeout                = 400
+  connection_draining         = true
+  connection_draining_timeout = 400
+
+  tags = "${map("Name", "${var.stackname}-monitortest", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "monitortest")}"
+}
+
+resource "aws_route53_record" "external_alertmanager_service_record" {
+  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
+  name    = "alertmanager.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_elb.monitortest_external_elb_alertmanager.dns_name}"
+    zone_id                = "${aws_elb.monitortest_external_elb_alertmanager.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
 module "monitortest" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-monitortest"
@@ -106,20 +162,8 @@ module "monitortest" {
   instance_key_name             = "${var.stackname}-monitortest"
   instance_public_key           = "${var.ssh_public_key}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
-  instance_elb_ids              = ["${aws_elb.monitortest_external_elb.id}"]
+  instance_elb_ids              = ["${aws_elb.monitortest_external_elb.id}", "${aws_elb.monitortest_external_elb_alertmanager.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
-}
-
-resource "aws_route53_record" "external_service_record" {
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
-  name    = "monitortest.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${aws_elb.monitortest_external_elb.dns_name}"
-    zone_id                = "${aws_elb.monitortest_external_elb.zone_id}"
-    evaluate_target_health = true
-  }
 }
 
 # Outputs

--- a/terraform/projects/infra-security-groups/monitortest.tf
+++ b/terraform/projects/infra-security-groups/monitortest.tf
@@ -34,6 +34,19 @@ resource "aws_security_group_rule" "allow_monitortest_external_elb_in" {
   source_security_group_id = "${aws_security_group.monitortest_external_elb.id}"
 }
 
+resource "aws_security_group_rule" "allow_monitortest_external_elb_alertmanager_in" {
+  type      = "ingress"
+  from_port = 9093
+  to_port   = 9093
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.monitortest.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.monitortest_external_elb.id}"
+}
+
 resource "aws_security_group" "monitortest_external_elb" {
   name        = "${var.stackname}_monitortest_external_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"


### PR DESCRIPTION
The Prometheus Alertmanager service can run on the same Prometheus instance.
We can enable the service externally to access the web UI, that runs on
port 9093. The monitortest project will need a secondary ELB to manage the
Alertmanager endpoint.