### PR TITLE
Remove govuk-delivery

### DIFF
--- a/doc/guides/redeploying-applications-on-rebuild.md
+++ b/doc/guides/redeploying-applications-on-rebuild.md
@@ -28,7 +28,6 @@ content-performance-manager
 content-tagger
 email-alert-api
 email-alert-service
-govuk-delivery
 hmrc-manuals-api
 imminence
 link-checker-api


### PR DESCRIPTION
govuk-delivery is no longer deployed to backend boxes (or any boxes for
that matter).

This commit removes it from the docs.