### PR TITLE
Add CloudWatchReadOnlyAccess policy to graphite role

### DIFF
--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -237,6 +237,11 @@ resource "aws_iam_role_policy_attachment" "graphite_1_iam_role_policy_attachment
   policy_arn = "${aws_iam_policy.graphite_1_iam_policy.arn}"
 }
 
+resource "aws_iam_role_policy_attachment" "graphite_1_iam_role_policy_cloudwatch_attachment" {
+  role       = "${module.graphite-1.instance_iam_role_name}"
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
+}
+
 # Outputs
 # --------------------------------------------------------------
 


### PR DESCRIPTION
In order to use the CloudWatch datasource in Grafana, the graphite
instance needs access to the CloudWatch API. The CloudWatchReadOnlyAccess
managed policy already provides all the permissions that we need, so
we don't need to provide a custom policy.

This change attaches the managed policy to the graphite role.