### PR TITLE
Add access logs for all AWS ELBs

### DIFF
--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -84,6 +84,12 @@ resource "aws_elb" "apt_external_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_apt_external_elb_id}"]
   internal        = "false"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-apt-external-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"
@@ -127,6 +133,12 @@ resource "aws_elb" "apt_internal_elb" {
   subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_apt_internal_elb_id}"]
   internal        = "true"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-apt-internal-elb"
+    interval      = 60
+  }
 
   listener {
     instance_port     = 80

--- a/terraform/projects/app-apt/remote_state.tf
+++ b/terraform/projects/app-apt/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-asset-master/remote_state.tf
+++ b/terraform/projects/app-asset-master/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-backend-redis/remote_state.tf
+++ b/terraform/projects/app-backend-redis/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -84,6 +84,12 @@ resource "aws_elb" "backend_elb_external" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_backend_elb_external_id}"]
   internal        = "false"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-backend-external-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = "80"
     instance_protocol = "http"
@@ -135,6 +141,12 @@ resource "aws_elb" "backend_elb_internal" {
   subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_backend_elb_internal_id}"]
   internal        = "true"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-backend-internal-elb"
+    interval      = 60
+  }
 
   listener {
     instance_port     = "80"

--- a/terraform/projects/app-backend/remote_state.tf
+++ b/terraform/projects/app-backend/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-backup/remote_state.tf
+++ b/terraform/projects/app-backup/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -58,6 +58,12 @@ resource "aws_elb" "bouncer_external_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_offsite_ssh_id}"]
   internal        = "false"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-bouncer-external-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = "443"
     instance_protocol = "tcp"

--- a/terraform/projects/app-bouncer/remote_state.tf
+++ b/terraform/projects/app-bouncer/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -126,6 +126,12 @@ resource "aws_elb" "cache_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_cache_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-cache-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"
@@ -179,6 +185,12 @@ resource "aws_elb" "cache_external_elb" {
   subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_cache_external_elb_id}"]
   internal        = "false"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-cache-external-elb"
+    interval      = 60
+  }
 
   listener {
     instance_port     = 80

--- a/terraform/projects/app-cache/remote_state.tf
+++ b/terraform/projects/app-cache/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -97,6 +97,12 @@ resource "aws_elb" "calculators-frontend_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_calculators-frontend_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-calculators-frontend-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"

--- a/terraform/projects/app-calculators-frontend/remote_state.tf
+++ b/terraform/projects/app-calculators-frontend/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -79,6 +79,12 @@ resource "aws_elb" "content-store_external_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_external_elb_id}"]
   internal        = "false"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-content-store-external-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = "80"
     instance_protocol = "http"
@@ -121,6 +127,12 @@ resource "aws_elb" "content-store_internal_elb" {
   subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_internal_elb_id}"]
   internal        = "true"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-content-store-internal-elb"
+    interval      = 60
+  }
 
   listener {
     instance_port     = "80"

--- a/terraform/projects/app-content-store/remote_state.tf
+++ b/terraform/projects/app-content-store/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -58,6 +58,12 @@ resource "aws_elb" "db-admin_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_db-admin_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-db-admin-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 22
     instance_protocol = "tcp"

--- a/terraform/projects/app-db-admin/remote_state.tf
+++ b/terraform/projects/app-db-admin/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -92,6 +92,12 @@ resource "aws_elb" "deploy_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_deploy_elb_id}"]
   internal        = "false"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "AWSLogs/${var.stackname}-deploy_elb"
+    interval      = 5
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -94,8 +94,8 @@ resource "aws_elb" "deploy_elb" {
 
   access_logs {
     bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
-    bucket_prefix = "AWSLogs/${var.stackname}-deploy_elb"
-    interval      = 5
+    bucket_prefix = "${var.stackname}-deploy-external-elb"
+    interval      = 60
   }
 
   listener {

--- a/terraform/projects/app-deploy/remote_state.tf
+++ b/terraform/projects/app-deploy/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-deploy/remote_state.tf
+++ b/terraform/projects/app-deploy/remote_state.tf
@@ -88,7 +88,7 @@ data "terraform_remote_state" "infra_aws_logging" {
 
   config {
     bucket = "${var.remote_state_bucket}"
-    key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-docker-management/main.tf
+++ b/terraform/projects/app-docker-management/main.tf
@@ -58,6 +58,12 @@ resource "aws_elb" "docker_management_etcd_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_docker_management_etcd_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-docker-management-etcd-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 2379
     instance_protocol = "tcp"

--- a/terraform/projects/app-docker-management/remote_state.tf
+++ b/terraform/projects/app-docker-management/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -69,6 +69,12 @@ resource "aws_elb" "draft-cache_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_draft-cache_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-draft-cache-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"

--- a/terraform/projects/app-draft-cache/remote_state.tf
+++ b/terraform/projects/app-draft-cache/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -79,6 +79,12 @@ resource "aws_elb" "draft-content-store_external_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_draft-content-store_external_elb_id}"]
   internal        = "false"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-draft-content-store-external-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = "80"
     instance_protocol = "http"
@@ -121,6 +127,12 @@ resource "aws_elb" "draft-content-store_internal_elb" {
   subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_draft-content-store_internal_elb_id}"]
   internal        = "true"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-draft-content-store-internal-elb"
+    interval      = 60
+  }
 
   listener {
     instance_port     = "80"

--- a/terraform/projects/app-draft-content-store/remote_state.tf
+++ b/terraform/projects/app-draft-content-store/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -76,6 +76,12 @@ resource "aws_elb" "draft-frontend_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_draft-frontend_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-draft-frontend-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"

--- a/terraform/projects/app-draft-frontend/remote_state.tf
+++ b/terraform/projects/app-draft-frontend/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -76,6 +76,12 @@ resource "aws_elb" "frontend_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_frontend_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-frontend-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"

--- a/terraform/projects/app-frontend/remote_state.tf
+++ b/terraform/projects/app-frontend/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -86,6 +86,12 @@ resource "aws_elb" "graphite_external_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_graphite_external_elb_id}"]
   internal        = "false"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-graphite-external-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"
@@ -141,6 +147,12 @@ resource "aws_elb" "graphite_internal_elb" {
   subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_graphite_internal_elb_id}"]
   internal        = "true"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-graphite-internal-elb"
+    interval      = 60
+  }
 
   listener {
     instance_port     = 2003

--- a/terraform/projects/app-graphite/remote_state.tf
+++ b/terraform/projects/app-graphite/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -58,6 +58,12 @@ resource "aws_elb" "jumpbox_external_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_offsite_ssh_id}"]
   internal        = "false"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-jumpbox-external-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = "22"
     instance_protocol = "tcp"

--- a/terraform/projects/app-jumpbox/remote_state.tf
+++ b/terraform/projects/app-jumpbox/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-logs-cdn/main.tf
+++ b/terraform/projects/app-logs-cdn/main.tf
@@ -66,6 +66,12 @@ resource "aws_elb" "logs-cdn_external_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_offsite_ssh_id}"]
   internal        = "false"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-logs-cdn-external-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = "6514"
     instance_protocol = "tcp"

--- a/terraform/projects/app-logs-cdn/remote_state.tf
+++ b/terraform/projects/app-logs-cdn/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -86,6 +86,12 @@ resource "aws_elb" "mapit_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-mapit-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"

--- a/terraform/projects/app-mapit/remote_state.tf
+++ b/terraform/projects/app-mapit/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mirrorer/remote_state.tf
+++ b/terraform/projects/app-mirrorer/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mongo/remote_state.tf
+++ b/terraform/projects/app-mongo/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -69,6 +69,12 @@ resource "aws_elb" "monitoring_external_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_monitoring_external_elb_id}"]
   internal        = "false"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-monitoring-external-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"

--- a/terraform/projects/app-monitoring/remote_state.tf
+++ b/terraform/projects/app-monitoring/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-monitortest/remote_state.tf
+++ b/terraform/projects/app-monitortest/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mysql-primary/remote_state.tf
+++ b/terraform/projects/app-mysql-primary/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-postgresql/remote_state.tf
+++ b/terraform/projects/app-postgresql/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -80,6 +80,12 @@ resource "aws_elb" "publishing-api_elb_internal" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_publishing-api_elb_internal_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-publishing-api-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"
@@ -122,6 +128,12 @@ resource "aws_elb" "publishing-api_elb_external" {
   subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_publishing-api_elb_external_id}"]
   internal        = "false"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-publishing-api-external-elb"
+    interval      = 60
+  }
 
   listener {
     instance_port     = 80

--- a/terraform/projects/app-publishing-api/remote_state.tf
+++ b/terraform/projects/app-publishing-api/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -57,6 +57,12 @@ resource "aws_elb" "puppetmaster_bootstrap_elb" {
   subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_offsite_ssh_id}"]
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-puppetmaster-bootstrap-external-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 22
     instance_protocol = "tcp"
@@ -97,6 +103,12 @@ resource "aws_elb" "puppetmaster_internal_elb" {
   subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_puppetmaster_elb_id}"]
   internal        = "true"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-puppetmaster-internal-elb"
+    interval      = 60
+  }
 
   listener {
     instance_port     = "8140"

--- a/terraform/projects/app-puppetmaster/remote_state.tf
+++ b/terraform/projects/app-puppetmaster/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-rabbitmq/main.tf
+++ b/terraform/projects/app-rabbitmq/main.tf
@@ -58,6 +58,12 @@ resource "aws_elb" "rabbitmq_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_rabbitmq_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-rabbitmq-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 5672
     instance_protocol = "tcp"

--- a/terraform/projects/app-rabbitmq/remote_state.tf
+++ b/terraform/projects/app-rabbitmq/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -95,6 +95,12 @@ resource "aws_elb" "router_api_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_router-api_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-router-api-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"
@@ -139,6 +145,12 @@ resource "aws_elb" "router_backend_1_elb" {
   subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_router-backend_elb_id}"]
   internal        = "true"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-router-backend-1-internal-elb"
+    interval      = 60
+  }
 
   listener {
     instance_port     = 27017
@@ -199,6 +211,12 @@ resource "aws_elb" "router_backend_2_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_router-backend_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-router-backend-2-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 27017
     instance_protocol = "tcp"
@@ -257,6 +275,12 @@ resource "aws_elb" "router_backend_3_elb" {
   subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_router-backend_elb_id}"]
   internal        = "true"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-router-backend-3-internal-elb"
+    interval      = 60
+  }
 
   listener {
     instance_port     = 27017

--- a/terraform/projects/app-router-backend/remote_state.tf
+++ b/terraform/projects/app-router-backend/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-rummager-elasticsearch/main.tf
+++ b/terraform/projects/app-rummager-elasticsearch/main.tf
@@ -84,6 +84,12 @@ resource "aws_elb" "rummager-elasticsearch_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_rummager-elasticsearch_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-rummager-elasticsearch-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 9200
     instance_protocol = "tcp"

--- a/terraform/projects/app-rummager-elasticsearch/remote_state.tf
+++ b/terraform/projects/app-rummager-elasticsearch/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -97,6 +97,12 @@ resource "aws_elb" "search_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_search_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-search-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"

--- a/terraform/projects/app-search/remote_state.tf
+++ b/terraform/projects/app-search/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -51,6 +51,12 @@ resource "aws_elb" "transition-db-admin_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_transition-db-admin_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-transition-db-admin-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 22
     instance_protocol = "tcp"

--- a/terraform/projects/app-transition-db-admin/remote_state.tf
+++ b/terraform/projects/app-transition-db-admin/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-transition-postgresql/remote_state.tf
+++ b/terraform/projects/app-transition-postgresql/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -87,6 +87,12 @@ resource "aws_elb" "whitehall-backend_internal_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_internal_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-whitehall-backend-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"
@@ -129,6 +135,12 @@ resource "aws_elb" "whitehall-backend_external_elb" {
   subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_external_elb_id}"]
   internal        = "false"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-whitehall-backend-external-elb"
+    interval      = 60
+  }
 
   listener {
     instance_port     = 80

--- a/terraform/projects/app-whitehall-backend/remote_state.tf
+++ b/terraform/projects/app-whitehall-backend/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -69,6 +69,12 @@ resource "aws_elb" "whitehall-frontend_elb" {
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-frontend_elb_id}"]
   internal        = "true"
 
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+    bucket_prefix = "${var.stackname}-whitehall-frontend-internal-elb"
+    interval      = 60
+  }
+
   listener {
     instance_port     = 80
     instance_protocol = "http"

--- a/terraform/projects/app-whitehall-frontend/remote_state.tf
+++ b/terraform/projects/app-whitehall-frontend/remote_state.tf
@@ -34,6 +34,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -73,6 +79,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/infra-aws-logging/integration.govuk.backend
+++ b/terraform/projects/infra-aws-logging/integration.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "govuk/infra-aws-logging.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-aws-logging/main.tf
+++ b/terraform/projects/infra-aws-logging/main.tf
@@ -1,0 +1,124 @@
+# == Manifest: projects::infra-aws-logging
+#
+# Create an S3 bucket which allows AWS infrastructure to send logs, which then
+#
+# === Variables:
+#
+# aws_region
+# aws_environment
+#
+# === Outputs:
+#
+# aws_logging_bucket_id
+#
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+# Resources
+# --------------------------------------------------------------
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.10.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.0.0"
+}
+
+data "aws_elb_service_account" "main" {}
+
+# Create a bucket that allows AWS services to write to it
+resource "aws_s3_bucket" "aws-logging" {
+  bucket = "govuk-${var.aws_environment}-aws-logging"
+  acl    = "private"
+
+  tags {
+    Name        = "govuk-${var.aws_environment}-aws-logging"
+    Environment = "${var.aws_environment}"
+  }
+
+  # Expire everything after 30 days
+  lifecycle_rule {
+    enabled = true
+
+    prefix = "/"
+
+    expiration {
+      days = 30
+    }
+  }
+
+  policy = <<POLICY
+{
+  "Id": "Policy",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::govuk-${var.aws_environment}-aws-logging/*",
+      "Principal": {
+        "AWS": [
+          "${data.aws_elb_service_account.main.arn}"
+        ]
+      }
+    }
+  ]
+}
+POLICY
+}
+
+# Create a read user to allow ingestion of logs from the bucket
+resource "aws_iam_policy" "aws-logging_logit-read_iam_policy" {
+  name        = "${var.aws_environment}-aws-logging_logit-read_iam_policy"
+  path        = "/"
+  description = "Allow "
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "SidID",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+             ],
+            "Resource": [
+                "arn:aws:s3:::govuk-${var.aws_environment}-aws-logging/*"
+            ]
+        }
+    ]
+ }
+EOF
+}
+
+resource "aws_iam_user" "aws-logging_logit-read_iam_user" {
+  name = "aws-logging_logit-read"
+}
+
+resource "aws_iam_policy_attachment" "aws-logging_logit-read_iam_policy_attachment" {
+  name       = "aws-logging_logit-read_iam_policy_attachment"
+  users      = ["${aws_iam_user.aws-logging_logit-read_iam_user.name}"]
+  policy_arn = "${aws_iam_policy.aws-logging_logit-read_iam_policy.arn}"
+}
+
+# Outputs
+# --------------------------------------------------------------
+
+output "aws_logging_bucket_id" {
+  value       = "${aws_s3_bucket.aws-logging.id}"
+  description = "Name of the AWS logging bucket"
+}

--- a/tools/generate-remote-state-boiler-plate.sh
+++ b/tools/generate-remote-state-boiler-plate.sh
@@ -46,6 +46,12 @@ variable "remote_state_infra_stack_dns_zones_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_aws_logging_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_aws_logging remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -85,6 +91,16 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_aws_logging" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
     region = "eu-west-1"
   }
 }


### PR DESCRIPTION
https://trello.com/c/YnzOGMp7/773-ship-logs-from-elbs-to-the-aws-infrastructure-logging-bucket

Create a bucket that has the correct permissions to be able to accept logs from AWS ELBs, and assign permissions so that our SaaS ELK provider is able to read and ingest the logs.

Add the access_logs parameter to every ELB we have, and update the remote state files. I've set it to push to the bucket every 60 seconds.

As an aside, this has added almost 1000 lines of code, and ELBs really do feel like a good use case for a module in this instance. 