### PR TITLE
Add infra-stack-sns-alerts

### DIFF
--- a/terraform/projects/infra-stack-sns-alerts/integration.blue.backend
+++ b/terraform/projects/infra-stack-sns-alerts/integration.blue.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "blue/infra-stack-sns-alerts.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-stack-sns-alerts/main.tf
+++ b/terraform/projects/infra-stack-sns-alerts/main.tf
@@ -1,0 +1,58 @@
+# == Manifest: projects::infra-stack-sns-alerts
+#
+# This module creates a SNS topic for alert notifications. It creates
+# and subscribes a SQS queue for further integration.
+#
+# === Variables:
+#
+# aws_region
+# stackname
+#
+# === Outputs:
+#
+# sns_topic_alerts_arn
+#
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+}
+
+# Resources
+# --------------------------------------------------------------
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.10.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.0.0"
+}
+
+resource "aws_sns_topic" "alerts" {
+  name = "${var.stackname}-alerts"
+}
+
+resource "aws_sqs_queue" "alerts_queue" {
+  name = "${var.stackname}-alerts"
+}
+
+resource "aws_sns_topic_subscription" "alerts_sqs_target" {
+  topic_arn = "${aws_sns_topic.alerts.arn}"
+  protocol  = "sqs"
+  endpoint  = "${aws_sqs_queue.alerts_queue.arn}"
+}
+
+# Outputs
+# --------------------------------------------------------------
+output "sns_topic_alerts_arn" {
+  value       = "${aws_sns_topic.alerts.arn}"
+  description = ""
+}


### PR DESCRIPTION
Add initial project to configure a dedicated topic for stack alerts. The
project creates a SQS subscription to enable integration with other notification
methods.