### PR TITLE
Add docs for projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ This might be useful, for example, as part of a PR builder job:
 The code for this, and this documentation itself, were taken from excellent work
 done by the GDS Verify team.
 
+### Writing Terraform files
+
+We use [terraform-docs](https://github.com/segmentio/terraform-docs) to create
+documentation for our Terraform code.
+
+The `main.tf` file should contain a comment with the module or project name, and
+a small description:
+
+```
+/**
+* ## Module: my-module
+*
+* This module does super awesome things
+*/
+```
+
+Run `terraform-docs` across the code and add a `README.md`:
+
+`terraform-docs md my-module/ > my-module/README.md`
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -11,33 +11,8 @@ rearchitect and rebuild while moving.
 
 ## Building a new environment
 
-### Bootstrap Commands
-
-The bootstrap phase requires you to have AWS account credentials. For
-this repo it's recommended that you store them in `.aws/credentials`
-under distinct profile names and leave `[default]` empty.
-
-We'll do the initial terraform configuration out of bounds to avoid
-making bootstrapping difficult. First we create the S3 bucket, which
-must have a globally unique name, used to store the terraform state
-files. Then we enable bucket versioning in case of anything going
-hideously wrong.
-
-    export AWS_PROFILE=test-admin
-    export AWS_REGION=eu-west-1
-    export STACK_NAME=test
-
-    export TERRAFORM_BUCKET="uk.gov.aws-stacks-terraform-state-${AWS_REGION}-${STACK_NAME}"
-
-    # create the bucket
-    $ aws --region $AWS_REGION s3 mb "s3://${TERRAFORM_BUCKET}"
-    make_bucket: s3://...bucketname.../
-
-    # enable versioning on the bucket
-    $ aws --region $AWS_REGION       \
-        s3api put-bucket-versioning  \
-        --bucket ${TERRAFORM_BUCKET} \
-        --versioning-configuration Status=Enabled
+Please see [this guide](doc/guides/environment-provisioning.md) for building a
+fresh environment.
 
 ## Architecture Decision Records
 

--- a/terraform/modules/aws/alarms/autoscaling/README.md
+++ b/terraform/modules/aws/alarms/autoscaling/README.md
@@ -1,0 +1,24 @@
+## Module: aws::alarms::autoscaling
+
+This module creates the following CloudWatch alarms in the
+AWS/Autoscaling namespace:
+
+  - GroupInServiceInstances less than threshold, where
+    `groupinserviceinstances_threshold` is a given parameter
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
+| autoscaling_group_name | The name of the AutoScalingGroup that we want to monitor. | string | - | yes |
+| groupinserviceinstances_threshold | The value against which the Autoscaling GroupInServiceInstaces metric is compared. Defaults to 1. | string | `1` | no |
+| name_prefix | The alarm name prefix. | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| alarm_autoscaling_groupinserviceinstances_id | Outputs -------------------------------------------------------------- |
+

--- a/terraform/modules/aws/alarms/autoscaling/main.tf
+++ b/terraform/modules/aws/alarms/autoscaling/main.tf
@@ -1,22 +1,12 @@
-# == Modules: aws::alarms::autoscaling
-#
-# This module creates the following CloudWatch alarms in the
-# AWS/Autoscaling namespace:
-#
-#   - GroupInServiceInstances less than threshold, where
-#     `groupinserviceinstances_threshold` is a given parameter
-#
-# === Variables:
-#
-# name_prefix
-# groupinserviceinstances_threshold
-# alarm_actions
-# autoscaling_group_name
-#
-# === Outputs:
-#
-# alarm_autoscaling_groupinserviceinstances_id
-#
+/**
+* ## Module: aws::alarms::autoscaling
+*
+* This module creates the following CloudWatch alarms in the
+* AWS/Autoscaling namespace:
+*
+*   - GroupInServiceInstances less than threshold, where
+*     `groupinserviceinstances_threshold` is a given parameter
+*/
 variable "name_prefix" {
   type        = "string"
   description = "The alarm name prefix."

--- a/terraform/modules/aws/alarms/ebs/README.md
+++ b/terraform/modules/aws/alarms/ebs/README.md
@@ -1,0 +1,27 @@
+## Module: aws::alarms::ebs
+
+This module creates the following CloudWatch alarms in the
+AWS/EBS namespace:
+
+  - VolumeQueueLength greater than or equal to threshold, where
+    `volumequeuelength_threshold` is a given parameter
+
+AWS/EBS metrics reference:
+http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ebs-metricscollected.html
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
+| name_prefix | The alarm name prefix. | string | - | yes |
+| volume_id | The ID of the EBS volume that we want to monitor. | string | - | yes |
+| volumequeuelength_threshold | The value against which the EBS VolumeQueueLength metric is compared. Defaults to 10. | string | `10` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| alarm_ebs_volumequeuelength_id | Outputs -------------------------------------------------------------- |
+

--- a/terraform/modules/aws/alarms/ebs/main.tf
+++ b/terraform/modules/aws/alarms/ebs/main.tf
@@ -1,25 +1,15 @@
-# == Modules: aws::alarms::ebs
-#
-# This module creates the following CloudWatch alarms in the
-# AWS/EBS namespace:
-#
-#   - VolumeQueueLength greater than or equal to threshold, where
-#     `volumequeuelength_threshold` is a given parameter
-#
-# AWS/EBS metrics reference:
-# http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ebs-metricscollected.html
-#
-# === Variables:
-#
-# name_prefix
-# volumequeuelength_threshold
-# alarm_actions
-# volume_id
-#
-# === Outputs:
-#
-# alarm_ebs_volumequeuelength_id
-#
+/**
+* ## Module: aws::alarms::ebs
+*
+* This module creates the following CloudWatch alarms in the
+* AWS/EBS namespace:
+*
+*   - VolumeQueueLength greater than or equal to threshold, where
+*     `volumequeuelength_threshold` is a given parameter
+*
+* AWS/EBS metrics reference:
+* http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ebs-metricscollected.html
+*/
 variable "name_prefix" {
   type        = "string"
   description = "The alarm name prefix."

--- a/terraform/modules/aws/alarms/ec2/README.md
+++ b/terraform/modules/aws/alarms/ec2/README.md
@@ -1,0 +1,30 @@
+## Module: aws::alarms::ec2
+
+This module creates the following CloudWatch alarms in the
+AWS/EC2 namespace:
+
+  - CPUUtilization greater than or equal to threshold threshold, where
+    `cpuutilization_threshold` is a given parameter
+  - StatusCheckFailed_Instance greater than or equal to 1 (instance status
+    check failed)
+
+Alarms are created for all the instances that belong to a given
+autoscaling group name.
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
+| autoscaling_group_name | The name of the AutoScalingGroup that we want to monitor. | string | - | yes |
+| cpuutilization_threshold | The value against which the CPUUtilization metric is compared. Defaults to 80. | string | `80` | no |
+| name_prefix | The alarm name prefix. | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| alarm_ec2_cpuutilization_id | Outputs -------------------------------------------------------------- |
+| alarm_ec2_statuscheckfailed_instance_id | The ID of the instance StatusCheckFailed_Instance health check. |
+

--- a/terraform/modules/aws/alarms/ec2/main.tf
+++ b/terraform/modules/aws/alarms/ec2/main.tf
@@ -1,28 +1,17 @@
-# == Modules: aws::alarms::ec2
-#
-# This module creates the following CloudWatch alarms in the
-# AWS/EC2 namespace:
-#
-#   - CPUUtilization greater than or equal to threshold threshold, where
-#     `cpuutilization_threshold` is a given parameter
-#   - StatusCheckFailed_Instance greater than or equal to 1 (instance status
-#     check failed)
-#
-# Alarms are created for all the instances that belong to a given
-# autoscaling group name.
-#
-# === Variables:
-#
-# name_prefix
-# cpuutilization_threshold
-# alarm_actions
-# autoscaling_group_name
-#
-# === Outputs:
-#
-# alarm_ec2_cpuutilization_id
-# alarm_ec2_statuscheckfailed_instance_id
-#
+/**
+* ## Module: aws::alarms::ec2
+*
+* This module creates the following CloudWatch alarms in the
+* AWS/EC2 namespace:
+*
+*   - CPUUtilization greater than or equal to threshold threshold, where
+*     `cpuutilization_threshold` is a given parameter
+*   - StatusCheckFailed_Instance greater than or equal to 1 (instance status
+*     check failed)
+*
+* Alarms are created for all the instances that belong to a given
+* autoscaling group name.
+*/
 variable "name_prefix" {
   type        = "string"
   description = "The alarm name prefix."

--- a/terraform/modules/aws/alarms/elb/README.md
+++ b/terraform/modules/aws/alarms/elb/README.md
@@ -1,0 +1,57 @@
+## Module: aws::alarms::elb
+
+This module creates the following CloudWatch alarms in the
+AWS/ELB namespace:
+
+  - HTTPCode_Backend_4XX greater than or equal to threshold
+  - HTTPCode_Backend_5XX greater than or equal to threshold
+  - HTTPCode_ELB_4XX greater than or equal to threshold
+  - HTTPCode_ELB_5XX greater than or equal to threshold
+  - SurgeQueueLength greater than or equal to threshold
+  - HealthyHostCount less than threshold
+
+All metrics are measured during a period of 60 seconds and evaluated
+during 5 consecutive periods.
+
+HTTPCode_* metrics are only reported for HTTP listeners. These metrics
+should encapsulate errors caused by high SurgeQueueLength values and
+lack of healthy backends.
+
+For HTTP listeners we can disable SurgeQueueLength and HealthyHostCount
+alarms. For TCP listeners, we should disable HTTPCode_* alarms.
+
+To disable HTTPCode_* alarms, set the `httpcode_*_threshold` parameters to 0.
+To disable the SurgeQueueLength alarm, set the `surgequeuelength_threshold`
+parameter to 0.
+To disable the HealthyHostCount alarm, set the `healthyhostcount_threshold`
+parameter to 0.
+
+AWS/ELB metrics reference:
+http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/elb-metricscollected.html
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
+| elb_name | The name of the ELB that we want to monitor. | string | - | yes |
+| healthyhostcount_threshold | The value against which the HealthyHostCount metric is compared. Defaults to 0 (disabled) | string | `0` | no |
+| httpcode_backend_4xx_threshold | The value against which the HTTPCode_Backend_4XX metric is compared. Defaults to 80. | string | `80` | no |
+| httpcode_backend_5xx_threshold | The value against which the HTTPCode_Backend_5XX metric is compared. Defaults to 80. | string | `80` | no |
+| httpcode_elb_4xx_threshold | The value against which the HTTPCode_ELB_4XX metric is compared. Defaults to 80. | string | `80` | no |
+| httpcode_elb_5xx_threshold | The value against which the HTTPCode_ELB_5XX metric is compared. Defaults to 80. | string | `80` | no |
+| name_prefix | The alarm name prefix. | string | - | yes |
+| surgequeuelength_threshold | The value against which the SurgeQueueLength metric is compared. The maximum size of the queue is 1,024. Additional requests are rejected when the queue is full. Defaults to 0 (disabled) | string | `0` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| alarm_elb_healthyhostcount_id | The ID of the ELB HealthyHostCount health check. |
+| alarm_elb_httpcode_backend_4xx_id | Outputs -------------------------------------------------------------- |
+| alarm_elb_httpcode_backend_5xx_id | The ID of the ELB HTTPCode_Backend_5XX health check. |
+| alarm_elb_httpcode_elb_4xx_id | The ID of the ELB HTTPCode_ELB_4XX health check. |
+| alarm_elb_httpcode_elb_5xx_id | The ID of the ELB HTTPCode_ELB_5XX health check. |
+| alarm_elb_surgequeuelength_id | The ID of the ELB SurgeQueueLength health check. |
+

--- a/terraform/modules/aws/alarms/elb/main.tf
+++ b/terraform/modules/aws/alarms/elb/main.tf
@@ -1,55 +1,35 @@
-# == Modules: aws::alarms::elb
-#
-# This module creates the following CloudWatch alarms in the
-# AWS/ELB namespace:
-#
-#   - HTTPCode_Backend_4XX greater than or equal to threshold
-#   - HTTPCode_Backend_5XX greater than or equal to threshold
-#   - HTTPCode_ELB_4XX greater than or equal to threshold
-#   - HTTPCode_ELB_5XX greater than or equal to threshold
-#   - SurgeQueueLength greater than or equal to threshold
-#   - HealthyHostCount less than threshold
-#
-# All metrics are measured during a period of 60 seconds and evaluated
-# during 5 consecutive periods.
-#
-# HTTPCode_* metrics are only reported for HTTP listeners. These metrics
-# should encapsulate errors caused by high SurgeQueueLength values and
-# lack of healthy backends.
-#
-# For HTTP listeners we can disable SurgeQueueLength and HealthyHostCount
-# alarms. For TCP listeners, we should disable HTTPCode_* alarms.
-#
-# To disable HTTPCode_* alarms, set the `httpcode_*_threshold` parameters to 0.
-# To disable the SurgeQueueLength alarm, set the `surgequeuelength_threshold`
-# parameter to 0.
-# To disable the HealthyHostCount alarm, set the `healthyhostcount_threshold`
-# parameter to 0.
-#
-# AWS/ELB metrics reference:
-# http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/elb-metricscollected.html
-#
-# === Variables:
-#
-# name_prefix
-# alarm_actions
-# elb_name
-# httpcode_backend_4xx_threshold
-# httpcode_backend_5xx_threshold
-# httpcode_elb_4xx_threshold
-# httpcode_elb_5xx_threshold
-# surgequeuelength_threshold
-# healthyhostcount_threshold
-#
-# === Outputs:
-#
-# alarm_elb_httpcode_backend_4xx_id
-# alarm_elb_httpcode_backend_5xx_id
-# alarm_elb_httpcode_elb_4xx_id
-# alarm_elb_httpcode_elb_5xx_id
-# alarm_elb_surgequeuelength_id
-# alarm_elb_healthyhostcount_id
-#
+/**
+* ## Module: aws::alarms::elb
+*
+* This module creates the following CloudWatch alarms in the
+* AWS/ELB namespace:
+*
+*   - HTTPCode_Backend_4XX greater than or equal to threshold
+*   - HTTPCode_Backend_5XX greater than or equal to threshold
+*   - HTTPCode_ELB_4XX greater than or equal to threshold
+*   - HTTPCode_ELB_5XX greater than or equal to threshold
+*   - SurgeQueueLength greater than or equal to threshold
+*   - HealthyHostCount less than threshold
+*
+* All metrics are measured during a period of 60 seconds and evaluated
+* during 5 consecutive periods.
+*
+* HTTPCode_* metrics are only reported for HTTP listeners. These metrics
+* should encapsulate errors caused by high SurgeQueueLength values and
+* lack of healthy backends.
+*
+* For HTTP listeners we can disable SurgeQueueLength and HealthyHostCount
+* alarms. For TCP listeners, we should disable HTTPCode_* alarms.
+*
+* To disable HTTPCode_* alarms, set the `httpcode_*_threshold` parameters to 0.
+* To disable the SurgeQueueLength alarm, set the `surgequeuelength_threshold`
+* parameter to 0.
+* To disable the HealthyHostCount alarm, set the `healthyhostcount_threshold`
+* parameter to 0.
+*
+* AWS/ELB metrics reference:
+* http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/elb-metricscollected.html
+*/
 variable "name_prefix" {
   type        = "string"
   description = "The alarm name prefix."

--- a/terraform/modules/aws/elasticache_redis_cluster/README.md
+++ b/terraform/modules/aws/elasticache_redis_cluster/README.md
@@ -1,0 +1,22 @@
+## Module: aws::elasticache_redis_cluster
+
+Create a redis replication cluster and elasticache subnet group
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| default_tags | Additional resource tags | map | `<map>` | no |
+| elasticache_node_type | The node type to use. Must not be t.* in order to use failover. | string | `cache.m3.medium` | no |
+| enable_clustering | Set to true to enable clustering mode | string | `true` | no |
+| name | The common name for all the resources created by this module | string | - | yes |
+| security_group_ids | Security group IDs to apply to this cluster | list | - | yes |
+| subnet_ids | Subnet IDs to assign to the aws_elasticache_subnet_group | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| configuration_endpoint_address | Configuration endpoint address of the redis cluster |
+

--- a/terraform/modules/aws/elasticache_redis_cluster/main.tf
+++ b/terraform/modules/aws/elasticache_redis_cluster/main.tf
@@ -1,15 +1,8 @@
-# == Module: aws::elasticache_redis_cluster
-#
-# Create a redis replication cluster and elasticache subnet group
-#
-# === Variables:
-#
-# subnet_ids
-# security_group_ids
-#
-# === Outputs:
-#
-#
+/**
+* ## Module: aws::elasticache_redis_cluster
+*
+* Create a redis replication cluster and elasticache subnet group
+*/
 
 variable "name" {
   type        = "string"

--- a/terraform/modules/aws/network/nat/main.tf
+++ b/terraform/modules/aws/network/nat/main.tf
@@ -1,18 +1,9 @@
-# == Module: aws::network::nat
-#
-# Create a NAT gateway and associated EIP on each one of the public
-# subnets provided.
-#
-# === Variables:
-#
-# subnet_ids
-# subnet_ids_length
-#
-# === Outputs:
-#
-# nat_gateway_ids
-# nat_gateway_subnets_ids_map
-#
+/**
+* ## Module: aws::network::nat
+*
+* Create a NAT gateway and associated EIP on each one of the public
+* subnets provided.
+*/
 
 variable "subnet_ids" {
   type        = "list"

--- a/terraform/modules/aws/network/private_subnet/main.tf
+++ b/terraform/modules/aws/network/private_subnet/main.tf
@@ -1,34 +1,19 @@
-# == Modules: aws::network::private_subnet
-#
-# This module creates AWS private subnets on a given VPC, each one
-# with a route table and route table association.
-#
-# You can optionally provide a subnet_nat_gateways variable, indicating
-# the NAT Gateway ID that a subnet can use. If specified, then a
-# route will also be added by this module, enabling Internet access.
-#
-# If you provide subnet_nat_gateways, then subnet_nat_gateways_length
-# must also be provided with the number of elements in the subnet_nat_gateways
-# map. This is necessary to get around a Terraform issue that prevents a
-# "count" from evaluating computed values. Probably referenced here:
-# https://github.com/hashicorp/terraform/issues/10857
-#
-# === Variables:
-#
-# default_tags
-# vpc_id
-# subnet_cidrs
-# subnet_availability_zones
-# subnet_nat_gateways
-# subnet_nat_gateways_length
-#
-# === Outputs:
-#
-# subnet_ids
-# subnet_names_ids_map
-# subnet_route_table_ids
-# subnet_names_route_tables_map
-#
+/**
+* ## Modules: aws::network::private_subnet
+*
+* This module creates AWS private subnets on a given VPC, each one
+* with a route table and route table association.
+*
+* You can optionally provide a subnet_nat_gateways variable, indicating
+* the NAT Gateway ID that a subnet can use. If specified, then a
+* route will also be added by this module, enabling Internet access.
+*
+* If you provide subnet_nat_gateways, then subnet_nat_gateways_length
+* must also be provided with the number of elements in the subnet_nat_gateways
+* map. This is necessary to get around a Terraform issue that prevents a
+* "count" from evaluating computed values. Probably referenced here:
+* https://github.com/hashicorp/terraform/issues/10857
+*/
 variable "default_tags" {
   type        = "map"
   description = "Additional resource tags"

--- a/terraform/modules/aws/network/public_subnet/main.tf
+++ b/terraform/modules/aws/network/public_subnet/main.tf
@@ -1,22 +1,9 @@
-# == Modules: aws::network::public_subnet
-#
-# This module creates all resources necessary for a AWS public
-# subnet
-#
-# === Variables:
-#
-# default_tags
-# vpc_id
-# route_table_public_id
-# subnet_cidrs
-# subnet_availability_zones
-#
-# === Outputs:
-#
-# subnet_ids
-# subnet_names_ids_map
-#
-
+/**
+* ## Modules: aws::network::public_subnet
+*
+* This module creates all resources necessary for a AWS public
+* subnet
+*/
 variable "default_tags" {
   type        = "map"
   description = "Additional resource tags"

--- a/terraform/modules/aws/network/vpc/main.tf
+++ b/terraform/modules/aws/network/vpc/main.tf
@@ -1,20 +1,8 @@
-# == Modules: aws::network::vpc
-#
-# This module creates a VPC, Internet Gateway and route associated
-#
-# === Variables:
-#
-# default_tags
-# name
-# cidr
-#
-# === Outputs:
-#
-# vpc_id
-# vpc_cidr
-# internet_gateway_id
-# route_table_public_id
-#
+/**
+* ## Modules: aws::network::vpc
+*
+* This module creates a VPC, Internet Gateway and route associated
+*/
 variable "default_tags" {
   type        = "map"
   description = "Additional resource tags"

--- a/terraform/modules/aws/node_group/README.md
+++ b/terraform/modules/aws/node_group/README.md
@@ -1,0 +1,45 @@
+## Module: aws::node_group
+
+This module creates an instance in a autoscaling group that expands
+in the subnets specified by the variable instance_subnet_ids. An ELB
+is also provisioned to access the instance. The instance AMI is Ubuntu,
+you can specify the version with the instance_ami_filter_name variable.
+The machine type can also be configured with a variable.
+
+When the variable create_service_dns_name is set to true, this module
+will create a DNS name service_dns_name in the zone_id specified pointing
+to the ELB record.
+
+Additionally, this module will create an IAM role that we can attach
+policies to in other modules.
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| asg_desired_capacity | The autoscaling groups desired capacity | string | `1` | no |
+| asg_max_size | The autoscaling groups max_size | string | `1` | no |
+| asg_min_size | The autoscaling groups max_size | string | `1` | no |
+| create_instance_key | Whether to create a key pair for the instance launch configuration | string | `false` | no |
+| default_tags | Additional resource tags | map | `<map>` | no |
+| instance_additional_user_data | Append additional user-data script | string | `` | no |
+| instance_ami_filter_name | Name to use to find AMI images for the instance | string | `ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*` | no |
+| instance_default_policy | Name of the JSON file containing the default IAM role policy for the instance | string | `default_policy.json` | no |
+| instance_elb_ids | A list of the ELB IDs to attach this ASG to | list | - | yes |
+| instance_key_name | Name of the instance key | string | - | yes |
+| instance_public_key | The jumpbox default public key material | string | `` | no |
+| instance_security_group_ids | List of security group ids to attach to the ASG | list | - | yes |
+| instance_subnet_ids | List of subnet ids where the instance can be deployed | list | - | yes |
+| instance_type | Instance type | string | `t2.micro` | no |
+| instance_user_data | User_data provisioning script (default user_data.sh in module directory) | string | `user_data.sh` | no |
+| name | Jumpbox resources name. Only alphanumeric characters and hyphens allowed | string | - | yes |
+| root_block_device_volume_size | The size of the instance root volume in gigabytes | string | `20` | no |
+| vpc_id | The ID of the VPC in which the jumpbox is created | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| instance_iam_role_name | Node IAM Role Name. Use with aws_iam_role_policy_attachment to attach specific policies to the node role |
+

--- a/terraform/modules/aws/node_group/main.tf
+++ b/terraform/modules/aws/node_group/main.tf
@@ -1,43 +1,19 @@
-# == Module: aws::node_group
-#
-# This module creates an instance in a autoscaling group that expands
-# in the subnets specified by the variable instance_subnet_ids. An ELB
-# is also provisioned to access the instance. The instance AMI is Ubuntu,
-# you can specify the version with the instance_ami_filter_name variable.
-# The machine type can also be configured with a variable.
-#
-# When the variable create_service_dns_name is set to true, this module
-# will create a DNS name service_dns_name in the zone_id specified pointing
-# to the ELB record.
-#
-# Additionally, this module will create an IAM role that we can attach
-# policies to in other modules.
-#
-# === Variables:
-#
-# name
-# vpc_id
-# default_tags
-# instance_subnet_ids
-# instance_security_group_ids
-# instance_ami_filter_name
-# instance_type
-# create_instance_key
-# instance_key_name
-# instance_public_key
-# instance_user_data
-# instance_additional_user_data
-# asg_desired_capacity
-# asg_min_size
-# asg_max_size
-# root_block_device_volume_size
-#
-# === Outputs:
-#
-# instance_iam_role_id
-# autoscaling_group_name
-#
-
+/**
+* ## Module: aws::node_group
+*
+* This module creates an instance in a autoscaling group that expands
+* in the subnets specified by the variable instance_subnet_ids. An ELB
+* is also provisioned to access the instance. The instance AMI is Ubuntu,
+* you can specify the version with the instance_ami_filter_name variable.
+* The machine type can also be configured with a variable.
+*
+* When the variable create_service_dns_name is set to true, this module
+* will create a DNS name service_dns_name in the zone_id specified pointing
+* to the ELB record.
+*
+* Additionally, this module will create an IAM role that we can attach
+* policies to in other modules.
+*/
 variable "name" {
   type        = "string"
   description = "Jumpbox resources name. Only alphanumeric characters and hyphens allowed"

--- a/terraform/modules/aws/rds_instance/README.md
+++ b/terraform/modules/aws/rds_instance/README.md
@@ -1,0 +1,34 @@
+## Module: aws::rds_instance
+
+Create an RDS instance
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| allocated_storage | The allocated storage in gigabytes. | string | `10` | no |
+| create_replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate | string | `0` | no |
+| default_tags | Additional resource tags | map | `<map>` | no |
+| engine_name | RDS engine (eg mysql, postgresql) | string | - | yes |
+| engine_version | Which version of MySQL to use (eg 5.5.46) | string | - | yes |
+| instance_class | The instance type of the RDS instance. | string | `db.t1.micro` | no |
+| multi_az | Specifies if the RDS instance is multi-AZ | string | `false` | no |
+| name | The common name for all the resources created by this module | string | - | yes |
+| parameter_group_name | Name of the parameter group to make the instance a member of. | string | `` | no |
+| password | Password for accessing the database. | string | - | yes |
+| replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate | string | `false` | no |
+| security_group_ids | Security group IDs to apply to this cluster | list | - | yes |
+| storage_type | One of standard (magnetic), gp2 (general purpose SSD), or io1 (provisioned IOPS SSD). The default is gp2 | string | `gp2` | no |
+| subnet_ids | Subnet IDs to assign to the aws_elasticache_subnet_group | list | - | yes |
+| username | User to create on the database | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| rds_instance_address |  |
+| rds_instance_endpoint |  |
+| rds_instance_id |  |
+| rds_instance_resource_id |  |
+

--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -1,31 +1,8 @@
-# == Module: aws::rds_instance
-#
-# Create a RDS instance
-#
-# === Variables:
-#
-# name
-# engine_name
-# engine_version
-# default_tags
-# subnet_ids
-# username
-# password
-# allocated_storage
-# storage_type
-# instance_class
-# security_group_ids
-# multi_az
-# create_replicate_source_db
-# replicate_source_db
-#
-# === Outputs:
-#
-# rds_instance_id
-# rds_instance_resource_id
-# rds_instance_endpoint
-# rds_instance_address
-
+/**
+* ## Module: aws::rds_instance
+*
+* Create an RDS instance
+*/
 variable "name" {
   type        = "string"
   description = "The common name for all the resources created by this module"

--- a/terraform/projects/app-apt/README.md
+++ b/terraform/projects/app-apt/README.md
@@ -1,0 +1,31 @@
+## Project: app-apt
+
+Apt node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| apt_1_subnet | Name of the subnet to place the apt instance 1 and EBS volume | string | - | yes |
+| aws_environment | AWS environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| apt_external_service_dns_name | DNS name to access the Apt external service |
+| gemstash_internal_elb_dns_name | DNS name to access the Gemstash internal service |
+

--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -1,19 +1,8 @@
-# == Manifest: projects::app-apt
-#
-# Apt node
-#
-# === Variables:
-#
-# aws_environment
-# aws_region
-# stackname
-# ssh_public_key
-# instance_ami_filter_name
-# apt_1_subnet
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-apt
+*
+* Apt node
+*/
 variable "aws_environment" {
   type        = "string"
   description = "AWS environment"

--- a/terraform/projects/app-asset-master/README.md
+++ b/terraform/projects/app-asset-master/README.md
@@ -1,0 +1,27 @@
+## Project: app-asset-master
+
+Asset Master node.
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | asset-master default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| assets_service_record | DNS service name for assets |
+| efs_mount_target_dns_names | Outputs -------------------------------------------------------------- |
+

--- a/terraform/projects/app-asset-master/main.tf
+++ b/terraform/projects/app-asset-master/main.tf
@@ -1,17 +1,8 @@
-# == Manifest: projects::app-asset-master
-#
-# Asset Master node.
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-asset-master
+*
+* Asset Master node.
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-backend-redis/README.md
+++ b/terraform/projects/app-backend-redis/README.md
@@ -1,0 +1,26 @@
+## Project: app-backend-redis
+
+Backend VDC Redis Elasticache cluster
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| enable_clustering | Enable clustering | string | `false` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| stackname | Stackname | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| backend_redis_configuration_endpoint_address | Backend VDC redis configuration endpoint address |
+| service_dns_name | DNS name to access the node service |
+

--- a/terraform/projects/app-backend-redis/main.tf
+++ b/terraform/projects/app-backend-redis/main.tf
@@ -1,16 +1,8 @@
-# == Manifest: projects::app-backend-redis
-#
-# Backend VDC Redis Elasticache cluster
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-backend-redis
+*
+* Backend VDC Redis Elasticache cluster
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-backend/README.md
+++ b/terraform/projects/app-backend/README.md
@@ -1,0 +1,35 @@
+## Project: app-backend
+
+Backend node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | backend default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| app_service_records_external_dns_name | DNS name to access the app service records |
+| app_service_records_internal_dns_name | DNS name to access the app service records |
+| backend_elb_external_address | AWS' external DNS name for the backend ELB |
+| backend_elb_internal_address | AWS' internal DNS name for the backend ELB |
+| service_dns_name_external | DNS name to access the node service |
+| service_dns_name_internal | DNS name to access the node service |
+

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -1,18 +1,8 @@
-# == Manifest: projects::app-backend
-#
-# Backend node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-backend
+*
+* Backend node
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-backup/README.md
+++ b/terraform/projects/app-backup/README.md
@@ -1,0 +1,30 @@
+## Project: app-backup
+
+Backup node
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| backup_subnet | Name of the subnet to place the Backup instance 1 and EBS volume | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| backup_external_elb_dns_name | DNS name to access the backup ELB |
+| backup_internal_service_dns_name | DNS name to access the backup internal service |
+

--- a/terraform/projects/app-backup/main.tf
+++ b/terraform/projects/app-backup/main.tf
@@ -1,19 +1,9 @@
-# == Manifest: projects::app-backup
-#
-# Backup node
-#
-# === Variables:
-#
-# aws_region
-# aws_environment
-# stackname
-# ssh_public_key
-# instance_ami_filter_name
-# backup_subnet
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-backup
+*
+* Backup node
+*
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-bouncer/README.md
+++ b/terraform/projects/app-bouncer/README.md
@@ -1,0 +1,28 @@
+## Project: app-bouncer
+
+Bouncer node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | bouncer default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| bouncer_elb_address | AWS' internal DNS name for the bouncer ELB |
+| service_dns_name | DNS name to access the node service |
+

--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -1,18 +1,8 @@
-# == Manifest: projects::app-bouncer
-#
-# bouncer node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-bouncer
+*
+* Bouncer node
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-cache/README.md
+++ b/terraform/projects/app-cache/README.md
@@ -1,0 +1,37 @@
+## Project: app-cache
+
+Cache application servers
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
+| asg_desired_capacity | The desired capacity of the autoscaling group | string | `2` | no |
+| asg_max_size | The maximum size of the autoscaling group | string | `2` | no |
+| asg_min_size | The minimum size of the autoscaling group | string | `2` | no |
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_artefact_bucket_stack | Override infra_artefact_bucket remote state path | string | `` | no |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| cache_elb_dns_name | DNS name to access the cache service |
+| cache_external_elb_dns_name | DNS name to access the external cache service |
+| external_service_dns_name | DNS name to access the external service |
+| service_dns_name | DNS name to access the service |
+

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -1,24 +1,8 @@
-# == Manifest: projects::app-cache
-#
-# Frontend application servers
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# elb_external_certname
-# elb_internal_certname
-# app_service_records
-# asg_max_size
-# asg_min_size
-# asg_desired_capacity
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-cache
+*
+* Cache application servers
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-calculators-frontend/README.md
+++ b/terraform/projects/app-calculators-frontend/README.md
@@ -1,0 +1,33 @@
+## Project: app-calculators-frontend
+
+Calculators Frontend application servers
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
+| asg_desired_capacity | The desired capacity of the autoscaling group | string | `2` | no |
+| asg_max_size | The maximum size of the autoscaling group | string | `2` | no |
+| asg_min_size | The minimum size of the autoscaling group | string | `2` | no |
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| calculators-frontend_elb_dns_name | DNS name to access the calculators-frontend service |
+| service_dns_name | DNS name to access the node service |
+

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -1,23 +1,8 @@
-# == Manifest: projects::app-calculators-frontend
-#
-# Calculators Frontend application servers
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# elb_internal_certname
-# asg_max_size
-# asg_min_size
-# asg_desired_capacity
-# app_service_records
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-calculators-frontend
+*
+* Calculators Frontend application servers
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-content-store/README.md
+++ b/terraform/projects/app-content-store/README.md
@@ -1,0 +1,31 @@
+## Project: app-content-store
+
+content-store node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | content-store default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| content-store_elb_address | AWS' internal DNS name for the content-store ELB |
+| external_service_dns_name | DNS name to access the node service |
+| internal_service_dns_name | DNS name to access the node service |
+

--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -1,19 +1,8 @@
-# == Manifest: projects::app-content-store
-#
-# content-store node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# elb_external_certname
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-content-store
+*
+* content-store node
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-db-admin/README.md
+++ b/terraform/projects/app-db-admin/README.md
@@ -1,0 +1,29 @@
+## Project: app-db-admin
+
+Database administrator servers.
+
+These nodes connect to RDS instances and administer them.
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| db-admin_elb_dns_name | DNS name to access the db-admin service |
+

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -1,18 +1,10 @@
-# == Manifest: projects::app-db-admin
-#
-# Frontend application servers
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-db-admin
+*
+* Database administrator servers.
+*
+* These nodes connect to RDS instances and administer them.
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-deploy/README.md
+++ b/terraform/projects/app-deploy/README.md
@@ -1,0 +1,30 @@
+## Project: app-deploy
+
+Deploy node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| deploy_subnet | Name of the subnet to place the apt instance 1 and EBS volume | string | - | yes |
+| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_artefact_bucket_stack | Override infra_artefact_bucket remote state path | string | `` | no |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| deploy_elb_dns_name | DNS name to access the deploy service |
+

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -1,19 +1,8 @@
-# == Manifest: projects::app-puppetmaster
-#
-# Deploy node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# elb_external_certname
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-deploy
+*
+* Deploy node
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-docker-management/README.md
+++ b/terraform/projects/app-docker-management/README.md
@@ -1,0 +1,28 @@
+## Project: app-docker_management
+
+Docker management node, used to run run adhoc containers.
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| docker_management_etcd_elb_dns_name | DNS name to access the docker_management service |
+| etcd_service_dns_name | DNS name to access the node service |
+

--- a/terraform/projects/app-docker-management/main.tf
+++ b/terraform/projects/app-docker-management/main.tf
@@ -1,18 +1,8 @@
-# == Manifest: projects::app-docker_management
-#
-# Docker node from the 'management' VDC
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-docker_management
+*
+* Docker management node, used to run run adhoc containers.
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-draft-cache/README.md
+++ b/terraform/projects/app-draft-cache/README.md
@@ -1,0 +1,30 @@
+## Project: app-draft-cache
+
+Draft Cache servers
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| draft-cache_elb_dns_name | DNS name to access the draft-cache service |
+| draft-router-api_internal_dns_name | DNS name to access draft-router-api |
+| service_dns_name | DNS name to access the service |
+

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -1,19 +1,8 @@
-# == Manifest: projects::app-draft-cache
-#
-# Frontend application servers
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# elb_internal_certname
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-draft-cache
+*
+* Draft Cache servers
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-draft-content-store/README.md
+++ b/terraform/projects/app-draft-content-store/README.md
@@ -1,0 +1,31 @@
+## Project: app-draft-content-store
+
+draft-content-store node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | draft-content-store default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| draft-content-store_elb_address | AWS' internal DNS name for the draft-content-store ELB |
+| external_service_dns_name | DNS name to access the node service |
+| internal_service_dns_name | DNS name to access the node service |
+

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -1,19 +1,8 @@
-# == Manifest: projects::app-draft-content-store
-#
-# draft-content-store node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# elb_external_certname
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-draft-content-store
+*
+* draft-content-store node
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-draft-frontend/README.md
+++ b/terraform/projects/app-draft-frontend/README.md
@@ -1,0 +1,30 @@
+## Project: app-draft-frontend
+
+Draft Frontend application servers
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| draft-frontend_elb_dns_name | DNS name to access the draft-frontend service |
+| service_dns_name | DNS name to access the service |
+

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -1,20 +1,8 @@
-# == Manifest: projects::app-draft-frontend
-#
-# Frontend application servers
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# elb_internal_certname
-# app_service_records
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-draft-frontend
+*
+* Draft Frontend application servers
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-frontend/README.md
+++ b/terraform/projects/app-frontend/README.md
@@ -1,0 +1,30 @@
+## Project: app-frontend
+
+Frontend application servers
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| frontend_elb_dns_name | DNS name to access the frontend service |
+| service_dns_name | DNS name to access the node service |
+

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -1,20 +1,8 @@
-# == Manifest: projects::app-frontend
-#
-# Frontend application servers
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# elb_internal_certname
-# app_service_records
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-frontend
+*
+* Frontend application servers
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-graphite/README.md
+++ b/terraform/projects/app-graphite/README.md
@@ -1,0 +1,31 @@
+## Project: app-graphite
+
+Graphite node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| graphite_1_subnet | Name of the subnet to place the Graphite instance 1 and EBS volume | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| graphite_external_elb_dns_name | DNS name to access the Graphite external service |
+| graphite_internal_service_dns_name | DNS name to access the Graphite internal service |
+

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -1,21 +1,8 @@
-# == Manifest: projects::app-graphite
-#
-# Graphite node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# graphite_1_subnet
-# elb_external_certname
-# elb_internal_certname
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-graphite
+*
+* Graphite node
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-jumpbox/README.md
+++ b/terraform/projects/app-jumpbox/README.md
@@ -1,0 +1,28 @@
+## Project: app-jumpbox
+
+Jumpbox node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Jumpbox default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| jumpbox_elb_address | AWS' internal DNS name for the jumpbox ELB |
+| service_dns_name | DNS name to access the node service |
+

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -1,18 +1,8 @@
-# == Manifest: projects::app-jumpbox
-#
-# Jumpbox node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-jumpbox
+*
+* Jumpbox node
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-logs-cdn/README.md
+++ b/terraform/projects/app-logs-cdn/README.md
@@ -1,0 +1,29 @@
+## Project: app-logs-cdn
+
+logs-cdn node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| logs_cdn_subnet | Name of the subnet to place the EBS volume | string | - | yes |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | logs-cdn default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| logs-cdn_elb_address | AWS' internal DNS name for the logs-cdn ELB |
+| service_dns_name | DNS name to access the node service |
+

--- a/terraform/projects/app-logs-cdn/main.tf
+++ b/terraform/projects/app-logs-cdn/main.tf
@@ -1,21 +1,8 @@
-# == Manifest: projects::app-logs-cdn
-#
-# logs-cdn node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# logs_cdn_subnet
-#
-# === Outputs:
-#
-# logs-cdn_elb_address
-# service_dns_name
-
+/**
+* ## Project: app-logs-cdn
+*
+* logs-cdn node
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-mapit/README.md
+++ b/terraform/projects/app-mapit/README.md
@@ -1,0 +1,31 @@
+## Project: app-mapit
+
+Mapit node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | The type of EC2 instance to use for both ASGs. | string | `t2.medium` | no |
+| mapit_1_subnet | Name of the subnet to place the mapit instance 1 and EBS volume | string | - | yes |
+| mapit_2_subnet | Name of the subnet to place the mapit instance 1 and EBS volume | string | - | yes |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| mapit_service_dns_name | DNS name to access the mapit internal service |
+

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -1,20 +1,8 @@
-# == Manifest: projects::app-mapit
-#
-# Mapit node
-#
-# === Variables:
-#
-# aws_environment
-# aws_region
-# stackname
-# ssh_public_key
-# instance_ami_filter_name
-# mapit_1_subnet
-# mapit_2_subnet
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-mapit
+*
+* Mapit node
+*/
 variable "aws_environment" {
   type        = "string"
   description = "AWS environment"

--- a/terraform/projects/app-mirrorer/README.md
+++ b/terraform/projects/app-mirrorer/README.md
@@ -1,0 +1,22 @@
+## Project: app-mirrorer
+
+Mirrorer node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| mirrorer_subnet | Subnet to contain mirrorer and its EBS volume | string | - | yes |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | mirrorer default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+

--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -1,18 +1,8 @@
-# == Manifest: projects::app-mirrorer
-#
-# Frontend application servers
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-mirrorer
+*
+* Mirrorer node
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-mongo/README.md
+++ b/terraform/projects/app-mongo/README.md
@@ -1,0 +1,38 @@
+## Project: app-mongo
+
+Mongo hosts
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| mongo_1_ip | IP address of the private IP to assign to the instance | string | - | yes |
+| mongo_1_reserved_ips_subnet | Name of the subnet to place the reserved IP of the instance | string | - | yes |
+| mongo_1_subnet | Name of the subnet to place the Mongo instance 1 and EBS volume | string | - | yes |
+| mongo_2_ip | IP address of the private IP to assign to the instance | string | - | yes |
+| mongo_2_reserved_ips_subnet | Name of the subnet to place the reserved IP of the instance | string | - | yes |
+| mongo_2_subnet | Name of the subnet to place the Mongo 2 and EBS volume | string | - | yes |
+| mongo_3_ip | IP address of the private IP to assign to the instance | string | - | yes |
+| mongo_3_reserved_ips_subnet | Name of the subnet to place the reserved IP of the instance | string | - | yes |
+| mongo_3_subnet | Name of the subnet to place the Mongo 3 and EBS volume | string | - | yes |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| mongo_1_service_dns_name | DNS name to access the Mongo 1 internal service |
+| mongo_2_service_dns_name | DNS name to access the Mongo 2 internal service |
+| mongo_3_service_dns_name | DNS name to access the Mongo 3 internal service |
+

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -1,30 +1,8 @@
-# == Manifest: projects::app-mongo
-#
-# Mongo hosts
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# mongo_1_subnet
-# mongo_2_subnet
-# mongo_3_subnet
-# mongo_1_reserved_ips_subnet
-# mongo_2_reserved_ips_subnet
-# mongo_3_reserved_ips_subnet
-# mongo_1_ip
-# mongo_2_ip
-# mongo_3_ip
-#
-# === Outputs:
-#
-# mongo_1_service_dns_name
-# mongo_2_service_dns_name
-# mongo_3_service_dns_name
-#
+/**
+* ## Project: app-mongo
+*
+* Mongo hosts
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-monitoring/README.md
+++ b/terraform/projects/app-monitoring/README.md
@@ -1,0 +1,29 @@
+## Project: app-monitoring
+
+Monitoring node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| monitoring_external_elb_dns_name | External DNS name to access the monitoring service |
+| monitoring_internal_elb_dns_name | Internal DNS name to access the monitoring service |
+

--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -1,19 +1,8 @@
-# == Manifest: projects::app-monitoring
-#
-# Monitoring node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# elb_external_certname
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-monitoring
+*
+* Monitoring node
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-monitortest/README.md
+++ b/terraform/projects/app-monitortest/README.md
@@ -1,0 +1,22 @@
+## Project: app-monitoring
+
+Monitoring node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+

--- a/terraform/projects/app-monitortest/main.tf
+++ b/terraform/projects/app-monitortest/main.tf
@@ -1,19 +1,8 @@
-# == Manifest: projects::app-monitoring
-#
-# Monitoring node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# elb_external_certname
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-monitoring
+*
+* Monitoring node
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-mysql-primary/README.md
+++ b/terraform/projects/app-mysql-primary/README.md
@@ -1,0 +1,29 @@
+## Project: app-mysql-primary
+
+RDS Mysql Primary instance
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| password | DB password | string | - | yes |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| stackname | Stackname | string | - | yes |
+| username | Mysql username | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| mysql_primary_address | Mysql instance address |
+| mysql_primary_endpoint | Mysql instance endpoint |
+| mysql_primary_id | Mysql instance ID |
+| mysql_primary_resource_id | Mysql instance resource ID |
+

--- a/terraform/projects/app-mysql-primary/main.tf
+++ b/terraform/projects/app-mysql-primary/main.tf
@@ -1,16 +1,8 @@
-# == Manifest: projects::app-mysql-primary
-#
-# RDS Mysql Primary instance
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-mysql-primary
+*
+* RDS Mysql Primary instance
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-postgresql/README.md
+++ b/terraform/projects/app-postgresql/README.md
@@ -1,0 +1,30 @@
+## Project: app-postgresql
+
+RDS PostgreSQL instances
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| multi_az | Enable multi-az. | string | `false` | no |
+| password | DB password | string | - | yes |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| stackname | Stackname | string | - | yes |
+| username | PostgreSQL username | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| postgresql-primary_address | postgresql instance address |
+| postgresql-primary_endpoint | postgresql instance endpoint |
+| postgresql-primary_id | postgresql instance ID |
+| postgresql-primary_resource_id | postgresql instance resource ID |
+

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -1,18 +1,8 @@
-# == Manifest: projects::app-postgresql
-#
-# RDS PostgreSQL Primary instance
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# username
-# password
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-postgresql
+*
+* RDS PostgreSQL instances
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-publishing-api/README.md
+++ b/terraform/projects/app-publishing-api/README.md
@@ -1,0 +1,32 @@
+## Project: app-publishing-api
+
+publishing-api node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | publishing-api default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| publishing-api_elb_address_external | AWS' external DNS name for the publishing-api ELB |
+| publishing-api_elb_address_internal | AWS' internal DNS name for the publishing-api ELB |
+| service_dns_name_external | DNS name to access the external node service |
+| service_dns_name_internal | DNS name to access the internal node service |
+

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -1,20 +1,8 @@
-# == Manifest: projects::app-publishing-api
-#
-# publishing-api node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# elb_external_certname
-# elb_internal_certname
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-publishing-api
+*
+* publishing-api node
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-puppetmaster/README.md
+++ b/terraform/projects/app-puppetmaster/README.md
@@ -1,0 +1,30 @@
+## Project: app-puppetmaster
+
+Puppetmaster node
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Puppetmaster default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| puppetdb_service_dns_name | DNS name to access the node service |
+| puppetmaster_bootstrap_elb_dns_name | DNS name to access the puppetmaster bootstrap service |
+| puppetmaster_internal_elb_dns_name | DNS name to access the puppetmaster service |
+| service_dns_name | DNS name to access the node service |
+

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -1,18 +1,8 @@
-# == Manifest: projects::app-puppetmaster
-#
-# Puppetmaster node
-#
-# === Variables:
-#
-# aws_region
-# aws_environment
-# stackname
-# ssh_public_key
-# instance_ami_filter_name
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-puppetmaster
+*
+* Puppetmaster node
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-rabbitmq/README.md
+++ b/terraform/projects/app-rabbitmq/README.md
@@ -1,0 +1,27 @@
+## Project: app-rabbitmq
+
+Rabbitmq cluster
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| rabbitmq_internal_service_dns_name | DNS name to access the rabbitmq internal service |
+

--- a/terraform/projects/app-rabbitmq/main.tf
+++ b/terraform/projects/app-rabbitmq/main.tf
@@ -1,18 +1,8 @@
-# == Manifest: projects::app-rabbitmq
-#
-# rabbitmq nodes (1 - 3)
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-rabbitmq
+*
+* Rabbitmq cluster
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-router-backend/README.md
+++ b/terraform/projects/app-router-backend/README.md
@@ -1,0 +1,34 @@
+## Project: app-router-backend
+
+Router backend hosts both Mongo and router-api
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| router-backend_1_subnet | Name of the subnet to place the Router Mongo 1 | string | - | yes |
+| router-backend_2_subnet | Name of the subnet to place the Router Mongo 2 | string | - | yes |
+| router-backend_3_subnet | Name of the subnet to place the Router Mongo 3 | string | - | yes |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| router_api_service_dns_name | DNS name to access the router-api internal service |
+| router_backend_1_service_dns_name | DNS name to access the Router Mongo 1 internal service |
+| router_backend_2_service_dns_name | DNS name to access the Router Mongo 2 internal service |
+| router_backend_3_service_dns_name | DNS name to access the Router Mongo 3 internal service |
+

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -1,25 +1,8 @@
-# == Manifest: projects::app-router-backend
-#
-# Router backend hosts both Mongo and router-api
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# router-backend_1_subnet
-# router-backend_2_subnet
-# router-backend_3_subnet
-# elb_internal_certname
-#
-# === Outputs:
-#
-# router_backend_1_service_dns_name
-# router_backend_2_service_dns_name
-# router_backend_3_service_dns_name
-#
+/**
+* ## Project: app-router-backend
+*
+* Router backend hosts both Mongo and router-api
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-rummager-elasticsearch/README.md
+++ b/terraform/projects/app-rummager-elasticsearch/README.md
@@ -1,0 +1,32 @@
+## Project: app-rummager-elasticsearch
+
+Rummager Elasticsearch cluster
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| cluster_name | Name of the Elasticsearch cluster to use for discovery | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| rummager_elasticsearch_1_subnet | Name of the subnet to place the Elasticsearch instance 1 and EBS volume | string | - | yes |
+| rummager_elasticsearch_2_subnet | Name of the subnet to place the Elasticsearch 2 and EBS volume | string | - | yes |
+| rummager_elasticsearch_3_subnet | Name of the subnet to place the Elasticsearch instance 3 and EBS volume | string | - | yes |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| rummager_elasticsearch_elb_dns_name | DNS name to access the Elasticsearch ELB |
+| service_dns_name | DNS name to access the Elasticsearch internal service |
+

--- a/terraform/projects/app-rummager-elasticsearch/main.tf
+++ b/terraform/projects/app-rummager-elasticsearch/main.tf
@@ -1,24 +1,8 @@
-# == Manifest: projects::app-rummager-elasticsearch
-#
-# Elasticsearch node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# rummager_elasticsearch_1_subnet
-# rummager_elasticsearch_2_subnet
-# rummager_elasticsearch_3_subnet
-# cluster_name
-#
-# === Outputs:
-#
-# service_dns_name
-# rummager_elasticsearch_elb_dns_name
-#
+/**
+* ## Project: app-rummager-elasticsearch
+*
+* Rummager Elasticsearch cluster
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-search/README.md
+++ b/terraform/projects/app-search/README.md
@@ -1,0 +1,33 @@
+## Project: app-search
+
+Search application servers
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
+| asg_desired_capacity | The desired capacity of the autoscaling group | string | `2` | no |
+| asg_max_size | The maximum size of the autoscaling group | string | `2` | no |
+| asg_min_size | The minimum size of the autoscaling group | string | `2` | no |
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| search_elb_dns_name | DNS name to access the search service |
+| service_dns_name | DNS name to access the node service |
+

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -1,23 +1,8 @@
-# == Manifest: projects::app-search
-#
-# Search application servers
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# asg_max_size
-# asg_min_size
-# asg_desired_capacity
-# elb_internal_certname
-# app_service_records
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-search
+*
+* Search application servers
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-transition-db-admin/README.md
+++ b/terraform/projects/app-transition-db-admin/README.md
@@ -1,0 +1,26 @@
+## Project: app-transition-db-admin
+
+ DB admin boxes for Transition's RDS instance
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | Default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| transition-db-admin_elb_dns_name | DNS name to access the transition-db-admin service |
+

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -1,17 +1,8 @@
-# == Manifest: projects::app-transition-db-admin
-#
-# DB admin boxes for Transition's RDS instance
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-transition-db-admin
+*
+* DB admin boxes for Transition's RDS instance
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-transition-postgresql/README.md
+++ b/terraform/projects/app-transition-postgresql/README.md
@@ -1,0 +1,30 @@
+## Project: app-transition-postgresql
+
+RDS Transition PostgreSQL Primary instance
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| multi_az | Enable multi-az. | string | `false` | no |
+| password | DB password | string | - | yes |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| stackname | Stackname | string | - | yes |
+| username | PostgreSQL username | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| transition-postgresql-primary_address | transition-postgresql instance address |
+| transition-postgresql-primary_endpoint | transition-postgresql instance endpoint |
+| transition-postgresql-primary_id | transition-postgresql instance ID |
+| transition-postgresql-primary_resource_id | transition-postgresql instance resource ID |
+

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -1,18 +1,8 @@
-# == Manifest: projects::app-transition-postgresql
-#
-# RDS Transition PostgreSQL Primary instance
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# username
-# password
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-transition-postgresql
+*
+* RDS Transition PostgreSQL Primary instance
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-whitehall-backend/README.md
+++ b/terraform/projects/app-whitehall-backend/README.md
@@ -1,0 +1,33 @@
+## Project: app-whitehall-backend
+
+Whitehall Backend nodes
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | whitehall-backend default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| external_service_dns_name | DNS name to access the external node service |
+| internal_service_dns_name | DNS name to access the node service |
+| whitehall-backend_external_elb_address | AWS' external DNS name for the whitehall-backend ELB |
+| whitehall-backend_internal_elb_address | AWS' internal DNS name for the whitehall-backend ELB |
+

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -1,21 +1,8 @@
-# == Manifest: projects::app-whitehall-backend
-#
-# Backend node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# elb_internal_certname
-# elb_external_certname
-# app_service_records
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-whitehall-backend
+*
+* Whitehall Backend nodes
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/app-whitehall-frontend/README.md
+++ b/terraform/projects/app-whitehall-frontend/README.md
@@ -1,0 +1,29 @@
+## Project: app-whitehall-frontend
+
+Whitehall Frontend nodes
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
+| remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| ssh_public_key | whitehall-frontend default public key material | string | - | yes |
+| stackname | Stackname | string | - | yes |
+| user_data_snippets | List of user-data snippets | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| service_dns_name | DNS name to access the node service |
+| whitehall-frontend_elb_address | AWS' internal DNS name for the whitehall-frontend ELB |
+

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -1,19 +1,8 @@
-# == Manifest: projects::app-whitehall-frontend
-#
-# Backend node
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# aws_environment
-# ssh_public_key
-# instance_ami_filter_name
-# elb_internal_certname
-#
-# === Outputs:
-#
-
+/**
+* ## Project: app-whitehall-frontend
+*
+* Whitehall Frontend nodes
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/infra-artefact-bucket/README.md
+++ b/terraform/projects/infra-artefact-bucket/README.md
@@ -1,0 +1,23 @@
+ ## Project: artefact-bucket
+
+This creates 3 s3 buckets
+
+artefact: The bucket that will hold the artefacts
+artefact_access_logs: Bucket for logs to go to
+artefact_replication_destination: Bucket in another region to replicate to
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| aws_secondary_region | Secondary region for cross-replication | string | `eu-west-2` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| write_artefact_bucket_policy_arn | ARN of the write artefact-bucket policy |
+

--- a/terraform/projects/infra-artefact-bucket/main.tf
+++ b/terraform/projects/infra-artefact-bucket/main.tf
@@ -1,20 +1,12 @@
-# == Manifest: projects:: Artefact-bucket :: buckets
-#
-# This creates 3 s3 buckets
-#
-# * artefact -- The bucket that will hold the artefacts
-# * artefact_access_logs -- Bucket for logs to go to
-# * artefact_replication_destination -- Bucket in another region to replicate to
-#
-# === Variables:
-#
-# aws_region
-# aws_secondary_region
-# aws_environment
-#
-# === Outputs:
-#
-
+/**
+*  ## Project: artefact-bucket
+*
+* This creates 3 s3 buckets
+*
+* artefact: The bucket that will hold the artefacts
+* artefact_access_logs: Bucket for logs to go to
+* artefact_replication_destination: Bucket in another region to replicate to
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/infra-networking/README.md
+++ b/terraform/projects/infra-networking/README.md
@@ -1,0 +1,51 @@
+## Project: infra-networking
+
+This module governs the creation of full network stacks.
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_region | AWS region | string | `eu-west-1` | no |
+| private_subnet_availability_zones | Map containing private subnet names and availability zones associated | map | - | yes |
+| private_subnet_cidrs | Map containing private subnet names and CIDR associated | map | - | yes |
+| private_subnet_elasticache_availability_zones | Map containing private elasticache subnet names and availability zones associated | map | - | yes |
+| private_subnet_elasticache_cidrs | Map containing private elasticache subnet names and CIDR associated | map | - | yes |
+| private_subnet_nat_gateway_association | Map of private subnet names and public subnet used to route external traffic (the public subnet must be listed in public_subnet_nat_gateway_enable to ensure it has a NAT gateway attached) | map | - | yes |
+| private_subnet_rds_availability_zones | Map containing private rds subnet names and availability zones associated | map | - | yes |
+| private_subnet_rds_cidrs | Map containing private rds subnet names and CIDR associated | map | - | yes |
+| private_subnet_reserved_ips_availability_zones | Map containing private ENI subnet names and availability zones associated | map | - | yes |
+| private_subnet_reserved_ips_cidrs | Map containing private ENI subnet names and CIDR associated | map | - | yes |
+| public_subnet_availability_zones | Map containing public subnet names and availability zones associated | map | - | yes |
+| public_subnet_cidrs | Map containing public subnet names and CIDR associated | map | - | yes |
+| public_subnet_nat_gateway_enable | List of public subnet names where we want to create a NAT Gateway | list | - | yes |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| stackname | Stackname | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| private_subnet_elasticache_ids | List of private subnet IDs |
+| private_subnet_elasticache_names_azs_map |  |
+| private_subnet_elasticache_names_ids_map | Map containing the pair name-id for each private subnet created |
+| private_subnet_elasticache_names_route_tables_map | Map containing the name of each private subnet and route_table ID associated |
+| private_subnet_ids | List of private subnet IDs |
+| private_subnet_names_azs_map |  |
+| private_subnet_names_ids_map | Map containing the pair name-id for each private subnet created |
+| private_subnet_names_route_tables_map | Map containing the name of each private subnet and route_table ID associated |
+| private_subnet_rds_ids | List of private subnet IDs |
+| private_subnet_rds_names_azs_map |  |
+| private_subnet_rds_names_ids_map | Map containing the pair name-id for each private subnet created |
+| private_subnet_rds_names_route_tables_map | Map containing the name of each private subnet and route_table ID associated |
+| private_subnet_reserved_ips_ids | List of private subnet IDs |
+| private_subnet_reserved_ips_names_azs_map |  |
+| private_subnet_reserved_ips_names_ids_map | Map containing the pair name-id for each private subnet created |
+| private_subnet_reserved_ips_names_route_tables_map | Map containing the name of each private subnet and route_table ID associated |
+| public_subnet_ids | List of public subnet IDs |
+| public_subnet_names_azs_map |  |
+| public_subnet_names_ids_map | Map containing the pair name-id for each public subnet created |
+| vpc_id | Outputs -------------------------------------------------------------- |
+

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -1,32 +1,8 @@
-# == Manifest: projects::infra-networking
-#
-# This module governs the creation of full network stacks.
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# public_subnet_cidrs
-# public_subnet_availability_zones
-# public_subnet_nat_gateway_enable
-# private_subnet_cidrs
-# private_subnet_availability_zones
-# private_subnet_nat_gateway_association
-# private_subnet_elasticache_cidrs
-# private_subnet_elasticache_availability_zones
-#
-# === Outputs:
-#
-# public_subnet_ids
-# public_subnet_names_ids_map
-# private_subnet_ids
-# private_subnet_names_ids_map
-# private_subnet_names_route_tables_map
-# private_subnet_elasticache_ids
-# private_subnet_elasticache_names_ids_map
-# private_subnet_elasticache_names_route_tables_map
-#
-
+/**
+* ## Project: infra-networking
+*
+* This module governs the creation of full network stacks.
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/infra-root-dns-zones/README.md
+++ b/terraform/projects/infra-root-dns-zones/README.md
@@ -1,0 +1,25 @@
+## Project: infra-root-dns-zones
+
+This module creates the internal and external root DNS zones.
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_region | AWS region | string | `eu-west-1` | no |
+| create_external_zone | Create an external DNS zone (default true) | string | `true` | no |
+| create_internal_zone | Create an internal DNS zone (default true) | string | `true` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| root_domain_external_name | External DNS root domain name. Override default for Integration, Staging, Production if create_external_zone is true | string | `mydomain.external` | no |
+| root_domain_internal_name | Internal DNS root domain name. Override default for Integration, Staging, Production if create_internal_zone is true | string | `mydomain.internal` | no |
+| stackname | Stackname | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| external_root_zone_id | Route53 External Root Zone ID |
+| internal_root_zone_id | Outputs -------------------------------------------------------------- |
+

--- a/terraform/projects/infra-root-dns-zones/main.tf
+++ b/terraform/projects/infra-root-dns-zones/main.tf
@@ -1,21 +1,8 @@
-# == Manifest: projects::infra-root-dns-zones
-#
-# This module creates the internal and external root DNS zones.
-#
-# === Variables:
-#
-# aws_region
-# create_internal_zone
-# root_domain_internal_name
-# create_external_zone
-# root_domain_external_name
-#
-# === Outputs:
-#
-# internal_root_zone_id
-# external_root_zone_id
-#
-
+/**
+* ## Project: infra-root-dns-zones
+*
+* This module creates the internal and external root DNS zones.
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -1,0 +1,97 @@
+## Project: infra-security-groups
+
+Manage the security groups for the entire infrastructure
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_region | AWS region | string | `eu-west-1` | no |
+| carrenza_integration_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
+| office_ips | An array of CIDR blocks that will be allowed offsite access. | list | - | yes |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| stackname | The name of the stack being built. Must be unique within the environment as it's used for disambiguation. | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| sg_apt_external_elb_id |  |
+| sg_apt_id |  |
+| sg_apt_internal_elb_id |  |
+| sg_asset-master_id |  |
+| sg_backend-redis_id |  |
+| sg_backend_elb_external_id |  |
+| sg_backend_elb_internal_id |  |
+| sg_backend_id |  |
+| sg_backup_elb_id |  |
+| sg_backup_id |  |
+| sg_bouncer_elb_id |  |
+| sg_bouncer_id |  |
+| sg_cache_elb_id |  |
+| sg_cache_external_elb_id |  |
+| sg_cache_id |  |
+| sg_calculators-frontend_elb_id |  |
+| sg_calculators-frontend_id |  |
+| sg_content-store_external_elb_id |  |
+| sg_content-store_id |  |
+| sg_content-store_internal_elb_id |  |
+| sg_db-admin_elb_id |  |
+| sg_db-admin_id |  |
+| sg_deploy_elb_id |  |
+| sg_deploy_id |  |
+| sg_docker_management_etcd_elb_id |  |
+| sg_docker_management_id |  |
+| sg_draft-cache_elb_id |  |
+| sg_draft-cache_id |  |
+| sg_draft-content-store_external_elb_id |  |
+| sg_draft-content-store_id |  |
+| sg_draft-content-store_internal_elb_id |  |
+| sg_draft-frontend_elb_id |  |
+| sg_draft-frontend_id |  |
+| sg_frontend_elb_id |  |
+| sg_frontend_id |  |
+| sg_graphite_external_elb_id |  |
+| sg_graphite_id |  |
+| sg_graphite_internal_elb_id |  |
+| sg_jumpbox_id |  |
+| sg_logs-cdn_elb_id |  |
+| sg_logs-cdn_id |  |
+| sg_management_id |  |
+| sg_mapit_elb_id |  |
+| sg_mapit_id |  |
+| sg_mirrorer_id |  |
+| sg_mongo_id |  |
+| sg_monitoring_external_elb_id |  |
+| sg_monitoring_id |  |
+| sg_monitoring_internal_elb_id |  |
+| sg_monitortest_external_elb_id |  |
+| sg_monitortest_id |  |
+| sg_mysql-primary_id |  |
+| sg_offsite_ssh_id |  |
+| sg_postgresql-primary_id |  |
+| sg_publishing-api_elb_external_id |  |
+| sg_publishing-api_elb_internal_id |  |
+| sg_publishing-api_id |  |
+| sg_puppetmaster_elb_id |  |
+| sg_puppetmaster_id |  |
+| sg_rabbitmq_elb_id |  |
+| sg_rabbitmq_id |  |
+| sg_router-api_elb_id |  |
+| sg_router-backend_elb_id |  |
+| sg_router-backend_id |  |
+| sg_rummager-elasticsearch_elb_id |  |
+| sg_rummager-elasticsearch_id |  |
+| sg_search_elb_id |  |
+| sg_search_id |  |
+| sg_transition-db-admin_elb_id |  |
+| sg_transition-db-admin_id |  |
+| sg_transition-postgresql-primary_id |  |
+| sg_whitehall-backend_external_elb_id |  |
+| sg_whitehall-backend_id |  |
+| sg_whitehall-backend_internal_elb_id |  |
+| sg_whitehall-frontend_elb_id |  |
+| sg_whitehall-frontend_id |  |
+

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -1,3 +1,9 @@
+/**
+* ## Project: infra-security-groups
+*
+* Manage the security groups for the entire infrastructure
+*/
+
 terraform {
   backend          "s3"             {}
   required_version = "= 0.10.7"

--- a/terraform/projects/infra-stack-dns-zones/README.md
+++ b/terraform/projects/infra-stack-dns-zones/README.md
@@ -1,0 +1,38 @@
+## Project: infra-stack-dns-zones
+
+This module creates the internal and external DNS zones used by our stacks.
+
+When we select to create a DNS zone, the domain name and ID of the zone that
+manages the root domain needs to be provided to register the DNS delegation
+and NS servers of the created zone. The domain name of the new zone is created
+from the variables provided as <stackname>.<root_domain_internal|external_name>
+
+We can't create a internal DNS zone per stack because on AWS we can't overlap
+internal domain names. Instead we use the same internal zone for all the sacks
+and we use the name schema `<service>.<stackname>.<root_domain>`
+
+The outputs of this project should be used by the stacks to create the right
+service records on the internal and external DNS zones.
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_region | AWS region | string | `eu-west-1` | no |
+| create_external_zone | Create an external DNS zone (default true) | string | `true` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| root_domain_external_name | External DNS root domain name. Override default for Integration, Staging, Production if create_external_zone is true | string | `mydomain.external` | no |
+| root_domain_internal_name | Internal DNS root domain name. Override default for Integration, Staging, Production if create_internal_zone is true | string | `mydomain.internal` | no |
+| stackname | Stackname | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| external_domain_name | Route53 External Domain Name |
+| external_zone_id | Route53 External Zone ID |
+| internal_domain_name | Route53 Internal Domain Name |
+| internal_zone_id | Outputs -------------------------------------------------------------- |
+

--- a/terraform/projects/infra-stack-dns-zones/main.tf
+++ b/terraform/projects/infra-stack-dns-zones/main.tf
@@ -1,35 +1,20 @@
-# == Manifest: projects::infra-stack-dns-zones
-#
-# This module creates the internal and external DNS zones used by our stacks.
-#
-# When we select to create a DNS zone, the domain name and ID of the zone that
-# manages the root domain needs to be provided to register the DNS delegation
-# and NS servers of the created zone. The domain name of the new zone is created
-# from the variables provided as <stackname>.<root_domain_internal|external_name>
-#
-# We can't create a internal DNS zone per stack because on AWS we can't overlap
-# internal domain names. Instead we use the same internal zone for all the sacks
-# and we use the name schema `<service>.<stackname>.<root_domain>`
-#
-# The outputs of this project should be used by the stacks to create the right
-# service records on the internal and external DNS zones.
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# root_domain_internal_name
-# create_external_zone
-# root_domain_external_name
-#
-# === Outputs:
-#
-# internal_zone_id
-# internal_domain_name
-# external_zone_id
-# external_domain_name
-#
-
+/**
+* ## Project: infra-stack-dns-zones
+*
+* This module creates the internal and external DNS zones used by our stacks.
+*
+* When we select to create a DNS zone, the domain name and ID of the zone that
+* manages the root domain needs to be provided to register the DNS delegation
+* and NS servers of the created zone. The domain name of the new zone is created
+* from the variables provided as <stackname>.<root_domain_internal|external_name>
+*
+* We can't create a internal DNS zone per stack because on AWS we can't overlap
+* internal domain names. Instead we use the same internal zone for all the sacks
+* and we use the name schema `<service>.<stackname>.<root_domain>`
+*
+* The outputs of this project should be used by the stacks to create the right
+* service records on the internal and external DNS zones.
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/infra-vpc/README.md
+++ b/terraform/projects/infra-vpc/README.md
@@ -1,0 +1,26 @@
+## Project: infra-vpc
+
+Creates the base VPC layer for an AWS stack.
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_region | AWS region | string | `eu-west-1` | no |
+| log_retention | Number of days to retain flow logs for | string | `3` | no |
+| stackname | Stackname | string | `` | no |
+| traffic_type | The traffic type to capture. Allows ACCEPT, ALL or REJECT | string | `REJECT` | no |
+| vpc_cidr | VPC IP address range, represented as a CIDR block | string | - | yes |
+| vpc_name | A name tag for the VPC | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| flow_log_id | AWS VPC Flog log ID |
+| internet_gateway_id |  |
+| route_table_public_id |  |
+| vpc_cidr |  |
+| vpc_id |  |
+

--- a/terraform/projects/infra-vpc/main.tf
+++ b/terraform/projects/infra-vpc/main.tf
@@ -1,24 +1,8 @@
-# == Manifest: projects::infra-vpc
-#
-# Creates the base VPC layer for an AWS stack.
-#
-# === Variables:
-#
-# aws_region
-# stackname
-# vpc_name
-# vpc_cidr
-# traffic_type
-# log_retention
-#
-# === Outputs:
-#
-# vpc_id
-# vpc_cidr
-# internet_gateway_id
-# route_table_public_id
-# flow_log_id
-
+/**
+* ## Project: infra-vpc
+*
+* Creates the base VPC layer for an AWS stack.
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"

--- a/terraform/projects/infra-wraith-bucket/README.md
+++ b/terraform/projects/infra-wraith-bucket/README.md
@@ -1,0 +1,21 @@
+## Project: wraith-bucket
+
+This creates 2 S3 buckets
+
+wraith-logs: The bucket that will hold the logs produced by wraith
+wraith_access_logs: Bucket for logs to go to
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| write_wraith_bucket_policy_arn | ARN of the write wraith-bucket policy |
+

--- a/terraform/projects/infra-wraith-bucket/main.tf
+++ b/terraform/projects/infra-wraith-bucket/main.tf
@@ -1,18 +1,11 @@
-# == Manifest: projects:: Wraith-bucket :: buckets
-#
-# This creates 2 s3 buckets
-#
-# * wraith-logs -- The bucket that will hold the logs produced by wraith
-# * wraith_access_logs -- Bucket for logs to go to
-#
-# === Variables:
-#
-# aws_region
-# aws_environment
-#
-# === Outputs:
-#
-
+/**
+* ## Project: wraith-bucket
+*
+* This creates 2 S3 buckets
+*
+* wraith-logs: The bucket that will hold the logs produced by wraith
+* wraith_access_logs: Bucket for logs to go to
+*/
 variable "aws_region" {
   type        = "string"
   description = "AWS region"


### PR DESCRIPTION
Create a table showing inputs and outputs for each project.

I used [terraform-docs](https://github.com/segmentio/terraform-docs), and ran this in a forloop from the root directory:

`for i in $(find terraform/projects -type d); do terraform-docs md $i > $i/README.md; done`

It may be more useful for modules.