### PR TITLE
Add remote state infra-stack-sns-alerts

### DIFF
--- a/terraform/projects/app-apt/remote_state.tf
+++ b/terraform/projects/app-apt/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-asset-master/remote_state.tf
+++ b/terraform/projects/app-asset-master/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-backend-redis/remote_state.tf
+++ b/terraform/projects/app-backend-redis/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-backend/remote_state.tf
+++ b/terraform/projects/app-backend/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-backup/remote_state.tf
+++ b/terraform/projects/app-backup/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-bouncer/remote_state.tf
+++ b/terraform/projects/app-bouncer/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-cache/remote_state.tf
+++ b/terraform/projects/app-cache/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-calculators-frontend/remote_state.tf
+++ b/terraform/projects/app-calculators-frontend/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-content-store/remote_state.tf
+++ b/terraform/projects/app-content-store/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-db-admin/remote_state.tf
+++ b/terraform/projects/app-db-admin/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-deploy/remote_state.tf
+++ b/terraform/projects/app-deploy/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-docker-management/remote_state.tf
+++ b/terraform/projects/app-docker-management/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-draft-cache/remote_state.tf
+++ b/terraform/projects/app-draft-cache/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-draft-content-store/remote_state.tf
+++ b/terraform/projects/app-draft-content-store/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-draft-frontend/remote_state.tf
+++ b/terraform/projects/app-draft-frontend/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-frontend/remote_state.tf
+++ b/terraform/projects/app-frontend/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-graphite/remote_state.tf
+++ b/terraform/projects/app-graphite/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-jumpbox/remote_state.tf
+++ b/terraform/projects/app-jumpbox/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-logs-cdn/remote_state.tf
+++ b/terraform/projects/app-logs-cdn/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mapit/remote_state.tf
+++ b/terraform/projects/app-mapit/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mirrorer/remote_state.tf
+++ b/terraform/projects/app-mirrorer/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mongo/remote_state.tf
+++ b/terraform/projects/app-mongo/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-monitoring/remote_state.tf
+++ b/terraform/projects/app-monitoring/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-monitortest/remote_state.tf
+++ b/terraform/projects/app-monitortest/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mysql-primary/remote_state.tf
+++ b/terraform/projects/app-mysql-primary/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-postgresql/remote_state.tf
+++ b/terraform/projects/app-postgresql/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-publishing-api/remote_state.tf
+++ b/terraform/projects/app-publishing-api/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-puppetmaster/remote_state.tf
+++ b/terraform/projects/app-puppetmaster/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-rabbitmq/remote_state.tf
+++ b/terraform/projects/app-rabbitmq/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-router-backend/remote_state.tf
+++ b/terraform/projects/app-router-backend/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-rummager-elasticsearch/remote_state.tf
+++ b/terraform/projects/app-rummager-elasticsearch/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-search/remote_state.tf
+++ b/terraform/projects/app-search/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-transition-db-admin/remote_state.tf
+++ b/terraform/projects/app-transition-db-admin/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-transition-postgresql/remote_state.tf
+++ b/terraform/projects/app-transition-postgresql/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-whitehall-backend/remote_state.tf
+++ b/terraform/projects/app-whitehall-backend/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-whitehall-frontend/remote_state.tf
+++ b/terraform/projects/app-whitehall-frontend/remote_state.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -89,6 +95,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }

--- a/tools/generate-remote-state-boiler-plate.sh
+++ b/tools/generate-remote-state-boiler-plate.sh
@@ -52,6 +52,12 @@ variable "remote_state_infra_aws_logging_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_stack_sns_alerts_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_stack_sns_alerts remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -101,6 +107,16 @@ data "terraform_remote_state" "infra_aws_logging" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_aws_logging_key_stack, var.stackname)}/infra-aws-logging.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_stack_sns_alerts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_stack_sns_alerts_key_stack, var.stackname)}/infra-stack-sns-alerts.tfstate"
     region = "eu-west-1"
   }
 }


### PR DESCRIPTION
The infra-stack-sns-alerts project creates a shared topic for
stack alerts. This change adds a remote state data resource to
access the topic id from the app projects, to add the topic to alert
actions.