### PR TITLE
Add module alarms autoscaling

### DIFF
--- a/terraform/modules/aws/alarms/autoscaling/main.tf
+++ b/terraform/modules/aws/alarms/autoscaling/main.tf
@@ -1,0 +1,66 @@
+# == Modules: aws::alarms::autoscaling
+#
+# This module creates the following CloudWatch alarms in the
+# AWS/Autoscaling namespace:
+#
+#   - GroupInServiceInstances less than threshold, where
+#     `groupinserviceinstances_threshold` is a given parameter
+#
+# === Variables:
+#
+# name_prefix
+# groupinserviceinstances_threshold
+# alarm_actions
+# autoscaling_group_name
+#
+# === Outputs:
+#
+# alarm_autoscaling_groupinserviceinstances_id
+#
+variable "name_prefix" {
+  type        = "string"
+  description = "The alarm name prefix."
+}
+
+variable "groupinserviceinstances_threshold" {
+  type        = "string"
+  description = "The value against which the Autoscaling GroupInServiceInstaces metric is compared. Defaults to 1."
+  default     = "1"
+}
+
+variable "alarm_actions" {
+  type        = "list"
+  description = "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN)."
+}
+
+variable "autoscaling_group_name" {
+  type        = "string"
+  description = "The name of the AutoScalingGroup that we want to monitor."
+}
+
+# Resources
+#--------------------------------------------------------------
+resource "aws_cloudwatch_metric_alarm" "autoscaling_groupinserviceinstances" {
+  alarm_name          = "${var.name_prefix}-autoscaling-groupinserviceinstances"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "GroupInServiceInstances"
+  namespace           = "AWS/AutoScaling"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "${var.groupinserviceinstances_threshold}"
+  actions_enabled     = true
+  alarm_actions       = ["${var.alarm_actions}"]
+  alarm_description   = "This metric monitors instances in service in an AutoScalingGroup"
+
+  dimensions {
+    AutoScalingGroupName = "${var.autoscaling_group_name}"
+  }
+}
+
+# Outputs
+#--------------------------------------------------------------
+output "alarm_autoscaling_groupinserviceinstances_id" {
+  value       = "${aws_cloudwatch_metric_alarm.autoscaling_groupinserviceinstances.id}"
+  description = "The ID of the autoscaling GroupInServiceInstances health check."
+}


### PR DESCRIPTION
Add a new AWS module to manage autoscaling alarms. At the moment
it only includes an alarm on the number of instances in service,
but we could add more based on our needs. The alarm threshold can
be configured with a variable. The actions need to be specified
with an input variable.