### PR TITLE
Alarms update docs

### DIFF
--- a/terraform/modules/aws/alarms/autoscaling/README.md
+++ b/terraform/modules/aws/alarms/autoscaling/README.md
@@ -1,24 +1,31 @@
-## Module: aws::alarms::autoscaling
+## Module: aws/alarms/autoscaling
 
 This module creates the following CloudWatch alarms in the
 AWS/Autoscaling namespace:
 
-  - GroupInServiceInstances less than threshold, where
-    `groupinserviceinstances_threshold` is a given parameter
+  - GroupInServiceInstances less than threshold
+
+All metrics are measured during a period of 60 seconds and evaluated
+during 2 consecutive periods.
+
+AWS/Autoscaling metrics reference:
+
+http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/as-metricscollected.html
+
 
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
+| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
 | autoscaling_group_name | The name of the AutoScalingGroup that we want to monitor. | string | - | yes |
-| groupinserviceinstances_threshold | The value against which the Autoscaling GroupInServiceInstaces metric is compared. Defaults to 1. | string | `1` | no |
+| groupinserviceinstances_threshold | The value against which the Autoscaling GroupInServiceInstaces metric is compared. | string | `1` | no |
 | name_prefix | The alarm name prefix. | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| alarm_autoscaling_groupinserviceinstances_id | Outputs -------------------------------------------------------------- |
+| alarm_autoscaling_groupinserviceinstances_id | The ID of the autoscaling GroupInServiceInstances health check. |
 

--- a/terraform/modules/aws/alarms/autoscaling/main.tf
+++ b/terraform/modules/aws/alarms/autoscaling/main.tf
@@ -1,11 +1,18 @@
 /**
-* ## Module: aws::alarms::autoscaling
+* ## Module: aws/alarms/autoscaling
 *
 * This module creates the following CloudWatch alarms in the
 * AWS/Autoscaling namespace:
 *
-*   - GroupInServiceInstances less than threshold, where
-*     `groupinserviceinstances_threshold` is a given parameter
+*   - GroupInServiceInstances less than threshold
+*
+* All metrics are measured during a period of 60 seconds and evaluated
+* during 2 consecutive periods.
+*
+* AWS/Autoscaling metrics reference:
+*
+* http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/as-metricscollected.html
+*
 */
 variable "name_prefix" {
   type        = "string"
@@ -14,13 +21,13 @@ variable "name_prefix" {
 
 variable "groupinserviceinstances_threshold" {
   type        = "string"
-  description = "The value against which the Autoscaling GroupInServiceInstaces metric is compared. Defaults to 1."
+  description = "The value against which the Autoscaling GroupInServiceInstaces metric is compared."
   default     = "1"
 }
 
 variable "alarm_actions" {
   type        = "list"
-  description = "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN)."
+  description = "The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN)."
 }
 
 variable "autoscaling_group_name" {
@@ -50,6 +57,8 @@ resource "aws_cloudwatch_metric_alarm" "autoscaling_groupinserviceinstances" {
 
 # Outputs
 #--------------------------------------------------------------
+
+// The ID of the autoscaling GroupInServiceInstances health check.
 output "alarm_autoscaling_groupinserviceinstances_id" {
   value       = "${aws_cloudwatch_metric_alarm.autoscaling_groupinserviceinstances.id}"
   description = "The ID of the autoscaling GroupInServiceInstances health check."

--- a/terraform/modules/aws/alarms/ebs/README.md
+++ b/terraform/modules/aws/alarms/ebs/README.md
@@ -1,12 +1,15 @@
-## Module: aws::alarms::ebs
+## Module: aws/alarms/ebs
 
 This module creates the following CloudWatch alarms in the
 AWS/EBS namespace:
 
-  - VolumeQueueLength greater than or equal to threshold, where
-    `volumequeuelength_threshold` is a given parameter
+  - VolumeQueueLength greater than or equal to threshold
+
+All metrics are measured during a period of 120 seconds and evaluated
+during 2 consecutive periods.
 
 AWS/EBS metrics reference:
+
 http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ebs-metricscollected.html
 
 
@@ -14,14 +17,14 @@ http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ebs-metricscollect
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
+| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
 | name_prefix | The alarm name prefix. | string | - | yes |
 | volume_id | The ID of the EBS volume that we want to monitor. | string | - | yes |
-| volumequeuelength_threshold | The value against which the EBS VolumeQueueLength metric is compared. Defaults to 10. | string | `10` | no |
+| volumequeuelength_threshold | The value against which the EBS VolumeQueueLength metric is compared. | string | `10` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| alarm_ebs_volumequeuelength_id | Outputs -------------------------------------------------------------- |
+| alarm_ebs_volumequeuelength_id | The ID of the EBS VolumeQueueLength health check. |
 

--- a/terraform/modules/aws/alarms/ebs/main.tf
+++ b/terraform/modules/aws/alarms/ebs/main.tf
@@ -1,13 +1,16 @@
 /**
-* ## Module: aws::alarms::ebs
+* ## Module: aws/alarms/ebs
 *
 * This module creates the following CloudWatch alarms in the
 * AWS/EBS namespace:
 *
-*   - VolumeQueueLength greater than or equal to threshold, where
-*     `volumequeuelength_threshold` is a given parameter
+*   - VolumeQueueLength greater than or equal to threshold
+*
+* All metrics are measured during a period of 120 seconds and evaluated
+* during 2 consecutive periods.
 *
 * AWS/EBS metrics reference:
+*
 * http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ebs-metricscollected.html
 */
 variable "name_prefix" {
@@ -17,13 +20,13 @@ variable "name_prefix" {
 
 variable "volumequeuelength_threshold" {
   type        = "string"
-  description = "The value against which the EBS VolumeQueueLength metric is compared. Defaults to 10."
+  description = "The value against which the EBS VolumeQueueLength metric is compared."
   default     = "10"
 }
 
 variable "alarm_actions" {
   type        = "list"
-  description = "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN)."
+  description = "The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN)."
 }
 
 variable "volume_id" {
@@ -53,6 +56,8 @@ resource "aws_cloudwatch_metric_alarm" "ebs_volumequeuelength" {
 
 # Outputs
 #--------------------------------------------------------------
+
+// The ID of the EBS VolumeQueueLength health check.
 output "alarm_ebs_volumequeuelength_id" {
   value       = "${aws_cloudwatch_metric_alarm.ebs_volumequeuelength.id}"
   description = "The ID of the EBS VolumeQueueLength health check."

--- a/terraform/modules/aws/alarms/ec2/README.md
+++ b/terraform/modules/aws/alarms/ec2/README.md
@@ -1,30 +1,34 @@
-## Module: aws::alarms::ec2
+## Module: aws/alarms/ec2
 
 This module creates the following CloudWatch alarms in the
 AWS/EC2 namespace:
 
-  - CPUUtilization greater than or equal to threshold threshold, where
-    `cpuutilization_threshold` is a given parameter
+  - CPUUtilization greater than or equal to threshold threshold
   - StatusCheckFailed_Instance greater than or equal to 1 (instance status
     check failed)
 
 Alarms are created for all the instances that belong to a given
-autoscaling group name.
+autoscaling group name. All metrics are measured during a period of 60 seconds
+and evaluated during 2 consecutive periods.
+
+AWS/EC2 metrics reference:
+
+http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ec2-metricscollected.html
 
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
+| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
 | autoscaling_group_name | The name of the AutoScalingGroup that we want to monitor. | string | - | yes |
-| cpuutilization_threshold | The value against which the CPUUtilization metric is compared. Defaults to 80. | string | `80` | no |
+| cpuutilization_threshold | The value against which the CPUUtilization metric is compared, in percent. | string | `80` | no |
 | name_prefix | The alarm name prefix. | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| alarm_ec2_cpuutilization_id | Outputs -------------------------------------------------------------- |
+| alarm_ec2_cpuutilization_id | The ID of the instance CPUUtilization health check. |
 | alarm_ec2_statuscheckfailed_instance_id | The ID of the instance StatusCheckFailed_Instance health check. |
 

--- a/terraform/modules/aws/alarms/ec2/main.tf
+++ b/terraform/modules/aws/alarms/ec2/main.tf
@@ -1,16 +1,20 @@
 /**
-* ## Module: aws::alarms::ec2
+* ## Module: aws/alarms/ec2
 *
 * This module creates the following CloudWatch alarms in the
 * AWS/EC2 namespace:
 *
-*   - CPUUtilization greater than or equal to threshold threshold, where
-*     `cpuutilization_threshold` is a given parameter
+*   - CPUUtilization greater than or equal to threshold threshold
 *   - StatusCheckFailed_Instance greater than or equal to 1 (instance status
 *     check failed)
 *
 * Alarms are created for all the instances that belong to a given
-* autoscaling group name.
+* autoscaling group name. All metrics are measured during a period of 60 seconds
+* and evaluated during 2 consecutive periods.
+*
+* AWS/EC2 metrics reference:
+*
+* http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ec2-metricscollected.html
 */
 variable "name_prefix" {
   type        = "string"
@@ -19,13 +23,13 @@ variable "name_prefix" {
 
 variable "cpuutilization_threshold" {
   type        = "string"
-  description = "The value against which the CPUUtilization metric is compared. Defaults to 80."
+  description = "The value against which the CPUUtilization metric is compared, in percent."
   default     = "80"
 }
 
 variable "alarm_actions" {
   type        = "list"
-  description = "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN)."
+  description = "The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN)."
 }
 
 variable "autoscaling_group_name" {
@@ -73,11 +77,14 @@ resource "aws_cloudwatch_metric_alarm" "ec2_statuscheckfailed_instance" {
 
 # Outputs
 #--------------------------------------------------------------
+
+// The ID of the instance CPUUtilization health check.
 output "alarm_ec2_cpuutilization_id" {
   value       = "${aws_cloudwatch_metric_alarm.ec2_cpuutilization.id}"
   description = "The ID of the instance CPUUtilization health check."
 }
 
+// The ID of the instance StatusCheckFailed_Instance health check.
 output "alarm_ec2_statuscheckfailed_instance_id" {
   value       = "${aws_cloudwatch_metric_alarm.ec2_statuscheckfailed_instance.id}"
   description = "The ID of the instance StatusCheckFailed_Instance health check."

--- a/terraform/modules/aws/alarms/elb/README.md
+++ b/terraform/modules/aws/alarms/elb/README.md
@@ -1,4 +1,4 @@
-## Module: aws::alarms::elb
+## Module: aws/alarms/elb
 
 This module creates the following CloudWatch alarms in the
 AWS/ELB namespace:
@@ -27,6 +27,7 @@ To disable the HealthyHostCount alarm, set the `healthyhostcount_threshold`
 parameter to 0.
 
 AWS/ELB metrics reference:
+
 http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/elb-metricscollected.html
 
 
@@ -34,22 +35,22 @@ http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/elb-metricscollect
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
+| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
 | elb_name | The name of the ELB that we want to monitor. | string | - | yes |
-| healthyhostcount_threshold | The value against which the HealthyHostCount metric is compared. Defaults to 0 (disabled) | string | `0` | no |
-| httpcode_backend_4xx_threshold | The value against which the HTTPCode_Backend_4XX metric is compared. Defaults to 80. | string | `80` | no |
-| httpcode_backend_5xx_threshold | The value against which the HTTPCode_Backend_5XX metric is compared. Defaults to 80. | string | `80` | no |
-| httpcode_elb_4xx_threshold | The value against which the HTTPCode_ELB_4XX metric is compared. Defaults to 80. | string | `80` | no |
-| httpcode_elb_5xx_threshold | The value against which the HTTPCode_ELB_5XX metric is compared. Defaults to 80. | string | `80` | no |
+| healthyhostcount_threshold | The value against which the HealthyHostCount metric is compared. | string | `0` | no |
+| httpcode_backend_4xx_threshold | The value against which the HTTPCode_Backend_4XX metric is compared. | string | `80` | no |
+| httpcode_backend_5xx_threshold | The value against which the HTTPCode_Backend_5XX metric is compared. | string | `80` | no |
+| httpcode_elb_4xx_threshold | The value against which the HTTPCode_ELB_4XX metric is compared. | string | `80` | no |
+| httpcode_elb_5xx_threshold | The value against which the HTTPCode_ELB_5XX metric is compared. | string | `80` | no |
 | name_prefix | The alarm name prefix. | string | - | yes |
-| surgequeuelength_threshold | The value against which the SurgeQueueLength metric is compared. The maximum size of the queue is 1,024. Additional requests are rejected when the queue is full. Defaults to 0 (disabled) | string | `0` | no |
+| surgequeuelength_threshold | The value against which the SurgeQueueLength metric is compared. The maximum size of the queue is 1,024. Additional requests are rejected when the queue is full. | string | `0` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | alarm_elb_healthyhostcount_id | The ID of the ELB HealthyHostCount health check. |
-| alarm_elb_httpcode_backend_4xx_id | Outputs -------------------------------------------------------------- |
+| alarm_elb_httpcode_backend_4xx_id | The ID of the ELB HTTPCode_Backend_4XX health check. |
 | alarm_elb_httpcode_backend_5xx_id | The ID of the ELB HTTPCode_Backend_5XX health check. |
 | alarm_elb_httpcode_elb_4xx_id | The ID of the ELB HTTPCode_ELB_4XX health check. |
 | alarm_elb_httpcode_elb_5xx_id | The ID of the ELB HTTPCode_ELB_5XX health check. |

--- a/terraform/modules/aws/alarms/elb/main.tf
+++ b/terraform/modules/aws/alarms/elb/main.tf
@@ -1,5 +1,5 @@
 /**
-* ## Module: aws::alarms::elb
+* ## Module: aws/alarms/elb
 *
 * This module creates the following CloudWatch alarms in the
 * AWS/ELB namespace:
@@ -28,6 +28,7 @@
 * parameter to 0.
 *
 * AWS/ELB metrics reference:
+*
 * http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/elb-metricscollected.html
 */
 variable "name_prefix" {
@@ -37,7 +38,7 @@ variable "name_prefix" {
 
 variable "alarm_actions" {
   type        = "list"
-  description = "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN)."
+  description = "The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN)."
 }
 
 variable "elb_name" {
@@ -47,37 +48,37 @@ variable "elb_name" {
 
 variable "httpcode_backend_4xx_threshold" {
   type        = "string"
-  description = "The value against which the HTTPCode_Backend_4XX metric is compared. Defaults to 80."
+  description = "The value against which the HTTPCode_Backend_4XX metric is compared."
   default     = "80"
 }
 
 variable "httpcode_backend_5xx_threshold" {
   type        = "string"
-  description = "The value against which the HTTPCode_Backend_5XX metric is compared. Defaults to 80."
+  description = "The value against which the HTTPCode_Backend_5XX metric is compared."
   default     = "80"
 }
 
 variable "httpcode_elb_4xx_threshold" {
   type        = "string"
-  description = "The value against which the HTTPCode_ELB_4XX metric is compared. Defaults to 80."
+  description = "The value against which the HTTPCode_ELB_4XX metric is compared."
   default     = "80"
 }
 
 variable "httpcode_elb_5xx_threshold" {
   type        = "string"
-  description = "The value against which the HTTPCode_ELB_5XX metric is compared. Defaults to 80."
+  description = "The value against which the HTTPCode_ELB_5XX metric is compared."
   default     = "80"
 }
 
 variable "surgequeuelength_threshold" {
   type        = "string"
-  description = "The value against which the SurgeQueueLength metric is compared. The maximum size of the queue is 1,024. Additional requests are rejected when the queue is full. Defaults to 0 (disabled)"
+  description = "The value against which the SurgeQueueLength metric is compared. The maximum size of the queue is 1,024. Additional requests are rejected when the queue is full."
   default     = "0"
 }
 
 variable "healthyhostcount_threshold" {
   type        = "string"
-  description = "The value against which the HealthyHostCount metric is compared. Defaults to 0 (disabled)"
+  description = "The value against which the HealthyHostCount metric is compared."
   default     = "0"
 }
 
@@ -199,31 +200,38 @@ resource "aws_cloudwatch_metric_alarm" "elb_healthyhostcount" {
 
 # Outputs
 #--------------------------------------------------------------
+
+// The ID of the ELB HTTPCode_Backend_4XX health check.
 output "alarm_elb_httpcode_backend_4xx_id" {
   value       = "${aws_cloudwatch_metric_alarm.elb_httpcode_backend_4xx.id}"
   description = "The ID of the ELB HTTPCode_Backend_4XX health check."
 }
 
+// The ID of the ELB HTTPCode_Backend_5XX health check.
 output "alarm_elb_httpcode_backend_5xx_id" {
   value       = "${aws_cloudwatch_metric_alarm.elb_httpcode_backend_5xx.id}"
   description = "The ID of the ELB HTTPCode_Backend_5XX health check."
 }
 
+// The ID of the ELB HTTPCode_ELB_4XX health check.
 output "alarm_elb_httpcode_elb_4xx_id" {
   value       = "${aws_cloudwatch_metric_alarm.elb_httpcode_elb_4xx.id}"
   description = "The ID of the ELB HTTPCode_ELB_4XX health check."
 }
 
+// The ID of the ELB HTTPCode_ELB_5XX health check.
 output "alarm_elb_httpcode_elb_5xx_id" {
   value       = "${aws_cloudwatch_metric_alarm.elb_httpcode_elb_5xx.id}"
   description = "The ID of the ELB HTTPCode_ELB_5XX health check."
 }
 
+// The ID of the ELB SurgeQueueLength health check.
 output "alarm_elb_surgequeuelength_id" {
   value       = "${aws_cloudwatch_metric_alarm.elb_surgequeuelength.id}"
   description = "The ID of the ELB SurgeQueueLength health check."
 }
 
+// The ID of the ELB HealthyHostCount health check.
 output "alarm_elb_healthyhostcount_id" {
   value       = "${aws_cloudwatch_metric_alarm.elb_healthyhostcount.id}"
   description = "The ID of the ELB HealthyHostCount health check."

--- a/terraform/modules/aws/alarms/natgateway/README.md
+++ b/terraform/modules/aws/alarms/natgateway/README.md
@@ -1,4 +1,4 @@
-## Modules: aws::alarms::natgateway
+## Modules: aws/alarms/natgateway
 
 This module creates the following CloudWatch alarms in the
 AWS/NATGateway namespace:
@@ -10,19 +10,19 @@ All metrics are measured during a period of 60 seconds and evaluated
 during 5 consecutive periods.
 
 AWS/NATGateway metrics reference:
-http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/nat-gateway-metricscollected.html
 
+http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/nat-gateway-metricscollected.html
 
 
 ## Inputs
 
-| Name | Description | Default | Required |
-|------|-------------|:-----:|:-----:|
-| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN). | - | yes |
-| errorportallocation_threshold | The value against which the ErrorPortAllocation metric is compared. Defaults to 10. | `10` | no |
-| name_prefix | The alarm name prefix. | - | yes |
-| nat_gateway_id | The ID of the NAT Gateway that we want to monitor. | - | yes |
-| packetsdropcount_threshold | The value against which the PacketsDropCount metric is compared. Defaults to 100. | `100` | no |
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
+| errorportallocation_threshold | The value against which the ErrorPortAllocation metric is compared. | string | `10` | no |
+| name_prefix | The alarm name prefix. | string | - | yes |
+| nat_gateway_id | The ID of the NAT Gateway that we want to monitor. | string | - | yes |
+| packetsdropcount_threshold | The value against which the PacketsDropCount metric is compared. | string | `100` | no |
 
 ## Outputs
 

--- a/terraform/modules/aws/alarms/natgateway/main.tf
+++ b/terraform/modules/aws/alarms/natgateway/main.tf
@@ -1,5 +1,5 @@
 /**
-* ## Modules: aws::alarms::natgateway
+* ## Modules: aws/alarms/natgateway
 *
 * This module creates the following CloudWatch alarms in the
 * AWS/NATGateway namespace:
@@ -11,8 +11,8 @@
 * during 5 consecutive periods.
 *
 * AWS/NATGateway metrics reference:
-* http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/nat-gateway-metricscollected.html
 *
+* http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/nat-gateway-metricscollected.html
 */
 variable "name_prefix" {
   type        = "string"
@@ -21,7 +21,7 @@ variable "name_prefix" {
 
 variable "alarm_actions" {
   type        = "list"
-  description = "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN)."
+  description = "The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN)."
 }
 
 variable "nat_gateway_id" {
@@ -31,13 +31,13 @@ variable "nat_gateway_id" {
 
 variable "errorportallocation_threshold" {
   type        = "string"
-  description = "The value against which the ErrorPortAllocation metric is compared. Defaults to 10."
+  description = "The value against which the ErrorPortAllocation metric is compared."
   default     = "10"
 }
 
 variable "packetsdropcount_threshold" {
   type        = "string"
-  description = "The value against which the PacketsDropCount metric is compared. Defaults to 100."
+  description = "The value against which the PacketsDropCount metric is compared."
   default     = "100"
 }
 

--- a/terraform/modules/aws/alarms/rds/README.md
+++ b/terraform/modules/aws/alarms/rds/README.md
@@ -1,4 +1,4 @@
-## Modules: aws::alarms::rds
+## Modules: aws/alarms/rds
 
 This module creates the following CloudWatch alarms in the
 AWS/RDS namespace:
@@ -16,21 +16,21 @@ disable the ReplicaLag alarm, set the `replicalag_threshold`
 parameter to 0.
 
 AWS/RDS metrics reference:
-http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/rds-metricscollected.html
 
+http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/rds-metricscollected.html
 
 
 ## Inputs
 
-| Name | Description | Default | Required |
-|------|-------------|:-----:|:-----:|
-| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN). | - | yes |
-| cpuutilization_threshold | The value against which the CPUUtilization metric is compared. Defaults to 80. | `80` | no |
-| db_instance_id | The ID of the database instance that we want to monitor. | - | yes |
-| freeablememory_threshold | The value against which the FreeableMemory metric is compared. Defaults to 2147483648 Bytes (2 Gb). | `2147483648` | no |
-| freestoragespace_threshold | The value against which the FreeStorageSpace metric is compared. Defaults to 10737418240 Bytes (10 Gb). | `10737418240` | no |
-| name_prefix | The alarm name prefix. | - | yes |
-| replicalag_threshold | The value against which the ReplicaLag metric is compared. Defaults to 0 (disabled) | `0` | no |
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
+| cpuutilization_threshold | The value against which the CPUUtilization metric is compared, in percent. | string | `80` | no |
+| db_instance_id | The ID of the database instance that we want to monitor. | string | - | yes |
+| freeablememory_threshold | The value against which the FreeableMemory metric is compared, in Bytes. | string | `2147483648` | no |
+| freestoragespace_threshold | The value against which the FreeStorageSpace metric is compared, in Bytes. | string | `10737418240` | no |
+| name_prefix | The alarm name prefix. | string | - | yes |
+| replicalag_threshold | The value against which the ReplicaLag metric is compared, in seconds. | string | `0` | no |
 
 ## Outputs
 

--- a/terraform/modules/aws/alarms/rds/main.tf
+++ b/terraform/modules/aws/alarms/rds/main.tf
@@ -1,5 +1,5 @@
 /**
-* ## Modules: aws::alarms::rds
+* ## Modules: aws/alarms/rds
 *
 * This module creates the following CloudWatch alarms in the
 * AWS/RDS namespace:
@@ -17,8 +17,8 @@
 * parameter to 0.
 *
 * AWS/RDS metrics reference:
-* http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/rds-metricscollected.html
 *
+* http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/rds-metricscollected.html
 */
 variable "name_prefix" {
   type        = "string"
@@ -27,7 +27,7 @@ variable "name_prefix" {
 
 variable "alarm_actions" {
   type        = "list"
-  description = "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Number (ARN)."
+  description = "The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN)."
 }
 
 variable "db_instance_id" {
@@ -37,25 +37,25 @@ variable "db_instance_id" {
 
 variable "cpuutilization_threshold" {
   type        = "string"
-  description = "The value against which the CPUUtilization metric is compared. Defaults to 80."
+  description = "The value against which the CPUUtilization metric is compared, in percent."
   default     = "80"
 }
 
 variable "freeablememory_threshold" {
   type        = "string"
-  description = "The value against which the FreeableMemory metric is compared. Defaults to 2147483648 Bytes (2 Gb)."
+  description = "The value against which the FreeableMemory metric is compared, in Bytes."
   default     = "2147483648"
 }
 
 variable "freestoragespace_threshold" {
   type        = "string"
-  description = "The value against which the FreeStorageSpace metric is compared. Defaults to 10737418240 Bytes (10 Gb)."
+  description = "The value against which the FreeStorageSpace metric is compared, in Bytes."
   default     = "10737418240"
 }
 
 variable "replicalag_threshold" {
   type        = "string"
-  description = "The value against which the ReplicaLag metric is compared. Defaults to 0 (disabled)"
+  description = "The value against which the ReplicaLag metric is compared, in seconds."
   default     = "0"
 }
 


### PR DESCRIPTION
- Remove "::" in module name description
- Add missing links to metrics references
- Remove default from variable description
- Add relevant units to variable description
- Add single line comment with output description to work around https://github.com/segmentio/terraform-docs/issues/29