### PR TITLE
Add Redis cluster ID to module and alarm

### DIFF
--- a/terraform/modules/aws/alarms/elasticache/README.md
+++ b/terraform/modules/aws/alarms/elasticache/README.md
@@ -19,7 +19,7 @@ http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/elasticache-metric
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | alarm_actions | The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN). | list | - | yes |
-| cache_node_id | The ID of the cache node that we want to monitor. | string | - | yes |
+| cache_cluster_id | The ID of the cache cluster that we want to monitor. | string | - | yes |
 | cpuutilization_threshold | The value against which the CPUUtilization metric is compared, in percent. | string | `80` | no |
 | freeablememory_threshold | The value against which the FreeableMemory metric is compared, in Bytes. | string | `2147483648` | no |
 | name_prefix | The alarm name prefix. | string | - | yes |

--- a/terraform/modules/aws/alarms/elasticache/main.tf
+++ b/terraform/modules/aws/alarms/elasticache/main.tf
@@ -24,9 +24,9 @@ variable "alarm_actions" {
   description = "The list of actions to execute when this alarm transitions into an ALARM state. Each action is specified as an Amazon Resource Number (ARN)."
 }
 
-variable "cache_node_id" {
+variable "cache_cluster_id" {
   type        = "string"
-  description = "The ID of the cache node that we want to monitor."
+  description = "The ID of the cache cluster that we want to monitor."
 }
 
 variable "cpuutilization_threshold" {
@@ -57,7 +57,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_cpuutilization" {
   alarm_description   = "This metric monitors the percentage of CPU utilization."
 
   dimensions {
-    CacheNodeId = "${var.cache_node_id}"
+    CacheClusterId = "${var.cache_cluster_id}"
   }
 }
 
@@ -75,7 +75,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_freeablememory" {
   alarm_description   = "This metric monitors the amount of free memory available on the host."
 
   dimensions {
-    CacheNodeId = "${var.cache_node_id}"
+    CacheClusterId = "${var.cache_cluster_id}"
   }
 }
 

--- a/terraform/modules/aws/elasticache_redis_cluster/README.md
+++ b/terraform/modules/aws/elasticache_redis_cluster/README.md
@@ -1,4 +1,4 @@
-## Module: aws::elasticache_redis_cluster
+## Module: aws/elasticache_redis_cluster
 
 Create a redis replication cluster and elasticache subnet group
 
@@ -18,5 +18,6 @@ Create a redis replication cluster and elasticache subnet group
 
 | Name | Description |
 |------|-------------|
-| configuration_endpoint_address | Configuration endpoint address of the redis cluster |
+| configuration_endpoint_address | Configuration endpoint address of the redis cluster. |
+| replication_group_id | The ID of the ElastiCache Replication Group. |
 

--- a/terraform/modules/aws/elasticache_redis_cluster/main.tf
+++ b/terraform/modules/aws/elasticache_redis_cluster/main.tf
@@ -1,5 +1,5 @@
 /**
-* ## Module: aws::elasticache_redis_cluster
+* ## Module: aws/elasticache_redis_cluster
 *
 * Create a redis replication cluster and elasticache subnet group
 */
@@ -86,7 +86,14 @@ resource "aws_elasticache_replication_group" "redis_master_with_replica" {
 # Outputs
 #--------------------------------------------------------------
 
+// Configuration endpoint address of the redis cluster.
 output "configuration_endpoint_address" {
   value       = "${var.enable_clustering > 0 ? join("", aws_elasticache_replication_group.redis_cluster.*.configuration_endpoint_address) : aws_elasticache_replication_group.redis_master_with_replica.primary_endpoint_address}"
-  description = "Configuration endpoint address of the redis cluster"
+  description = "Configuration endpoint address of the redis cluster."
+}
+
+// The ID of the ElastiCache Replication Group.
+output "replication_group_id" {
+  value       = "${var.enable_clustering > 0 ? aws_elasticache_replication_group.redis_cluster.0.id : aws_elasticache_replication_group.redis_master_with_replica.id}"
+  description = "The ID of the ElastiCache Replication Group."
 }


### PR DESCRIPTION
Add Cluster ID output to ElastiCache module and use this
parameter to filter CloudWatch metrics. Previously we were
using node ID but we only build instances with the cluster resource.