### PR TITLE
Add a project for a database backups bucket

### DIFF
--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -128,6 +128,21 @@ module "alarms-ec2-db-admin" {
   cpuutilization_threshold = "85"
 }
 
+data "terraform_remote_state" "infra_database_backups_bucket" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "db-admin_database_backups_iam_role_policy_attachment" {
+  role       = "${module.db-admin.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.write_database_backups_bucket_policy_arn}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -281,6 +281,22 @@ module "alarms-ec2-mongo-3" {
   cpuutilization_threshold = "85"
 }
 
+data "terraform_remote_state" "infra_database_backups_bucket" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "mongo_database_backups_iam_role_policy_attachment" {
+  count      = 3
+  role       = "${element(list(module.mongo-1.instance_iam_role_name, module.mongo-2.instance_iam_role_name, module.mongo-3.instance_iam_role_name), count.index)}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.write_database_backups_bucket_policy_arn}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -369,6 +369,22 @@ module "alarms-elb-router-backend-3-internal" {
   healthyhostcount_threshold     = "1"
 }
 
+data "terraform_remote_state" "infra_database_backups_bucket" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "router-backend_database_backups_iam_role_policy_attachment" {
+  count      = 3
+  role       = "${element(list(module.router-backend-1.instance_iam_role_name, module.router-backend-2.instance_iam_role_name, module.router-backend-3.instance_iam_role_name), count.index)}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.write_database_backups_bucket_policy_arn}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -119,6 +119,21 @@ module "alarms-ec2-transition-db-admin" {
   cpuutilization_threshold = "85"
 }
 
+data "terraform_remote_state" "infra_database_backups_bucket" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "transition-db-admin_database_backups_iam_role_policy_attachment" {
+  role       = "${module.transition-db-admin.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.write_database_backups_bucket_policy_arn}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -1,0 +1,21 @@
+## Project: database-backups-bucket
+
+This creates an s3 bucket
+
+database-backups: The bucket that will hold database backups
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| write_database_backups_bucket_policy_arn | ARN of the write database_backups-bucket policy |
+

--- a/terraform/projects/infra-database-backups-bucket/integration.govuk.backend
+++ b/terraform/projects/infra-database-backups-bucket/integration.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "govuk/infra-database-backups-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -1,0 +1,39 @@
+/**
+* ## Project: database-backups-bucket
+*
+* This creates an s3 bucket
+*
+* database-backups: The bucket that will hold database backups
+*
+*/
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+# Set up the backend & provider for each region
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.10.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.0.0"
+}
+
+resource "aws_s3_bucket" "database_backups" {
+  bucket = "govuk-${var.aws_environment}-database-backups"
+
+  tags {
+    Name            = "govuk-${var.aws_environment}-database-backups"
+    aws_environment = "${var.aws_environment}"
+  }
+}

--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -1,0 +1,46 @@
+/**
+* ## Project: database-backups-bucket
+*
+* Create a policy that allows writing of the database-backups bucket. This
+* doesn't create a role as the calling instance is assumed to already
+* have one which should be attached to this policy.
+*
+*/
+
+resource "aws_iam_policy" "database_backups_writer" {
+  name        = "govuk-${var.aws_environment}-database_backups-writer-policy"
+  policy      = "${data.aws_iam_policy_document.database_backups_writer.json}"
+  description = "Allows writing of the database_backups bucket"
+}
+
+data "aws_iam_policy_document" "database_backups_writer" {
+  statement {
+    sid = "ReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    # In theory  should work but it doesn't so use * instead
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    sid     = "WriteGovukDatabaseBackups"
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*",
+    ]
+  }
+}
+
+output "write_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.database_backups_writer.arn}"
+  description = "ARN of the write database_backups-bucket policy"
+}


### PR DESCRIPTION
This contains a bucket and an iam policy allowing to write to this
bucket. Once this is applied the iam policy will be attached to instance
roles to allow them to write to the bucket.