### PR TITLE
Add project alarms

### DIFF
--- a/doc/architecture/decisions/0031-aws-metrics-and-alarms.md
+++ b/doc/architecture/decisions/0031-aws-metrics-and-alarms.md
@@ -1,0 +1,21 @@
+# 31. AWS metrics and alarms
+
+Date: 2017-10-23
+
+## Status
+
+Pending
+
+## Context
+
+Non critical services with ELB - AGS - Instance setup:
+
+- Enable ELB metrics on ELB and backend HTTP_5XX errors
+
+## Decision
+
+Decision here...
+
+## Consequences
+
+Consequences here...

--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -218,6 +218,32 @@ resource "aws_iam_role_policy_attachment" "apt_1_iam_role_policy_attachment" {
   policy_arn = "${aws_iam_policy.apt_1_iam_policy.arn}"
 }
 
+module "alarms-elb-apt-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-apt-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.apt_internal_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "50"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "50"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
+module "alarms-elb-apt-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-apt-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.apt_external_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "50"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "50"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-asset-master/main.tf
+++ b/terraform/projects/app-asset-master/main.tf
@@ -75,6 +75,22 @@ module "asset-master" {
   root_block_device_volume_size = "30"
 }
 
+module "alarms-autoscaling-asset-master" {
+  source                            = "../../modules/aws/alarms/autoscaling"
+  name_prefix                       = "${var.stackname}-asset-master"
+  autoscaling_group_name            = "${module.asset-master.autoscaling_group_name}"
+  alarm_actions                     = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  groupinserviceinstances_threshold = "1"
+}
+
+module "alarms-ec2-asset-master" {
+  source                   = "../../modules/aws/alarms/ec2"
+  name_prefix              = "${var.stackname}-asset-master"
+  autoscaling_group_name   = "${module.asset-master.autoscaling_group_name}"
+  alarm_actions            = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  cpuutilization_threshold = "85"
+}
+
 # Outputs
 # --------------------------------------------------------------
 output "efs_mount_target_dns_names" {

--- a/terraform/projects/app-backend-redis/main.tf
+++ b/terraform/projects/app-backend-redis/main.tf
@@ -54,6 +54,13 @@ module "backend_redis_cluster" {
   security_group_ids = ["${data.terraform_remote_state.infra_security_groups.sg_backend-redis_id}"]
 }
 
+module "alarms-elasticache-backend-redis" {
+  source           = "../../modules/aws/alarms/elasticache"
+  name_prefix      = "${var.stackname}-backend-redis"
+  alarm_actions    = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  cache_cluster_id = "${module.backend_redis_cluster.replication_group_id}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -204,6 +204,32 @@ module "backend" {
   root_block_device_volume_size = "30"
 }
 
+module "alarms-elb-backend-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-backend-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.backend_elb_internal.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
+module "alarms-elb-backend-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-backend-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.backend_elb_external.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -108,6 +108,19 @@ module "bouncer" {
   asg_desired_capacity          = "2"
 }
 
+module "alarms-elb-bouncer-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-bouncer-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.bouncer_external_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -242,6 +242,32 @@ module "cache" {
   asg_desired_capacity          = "${var.asg_desired_capacity}"
 }
 
+module "alarms-elb-cache-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-cache-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.cache_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "50"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "50"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
+module "alarms-elb-cache-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-cache-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.cache_external_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "50"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "50"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -154,6 +154,19 @@ module "calculators-frontend" {
   asg_desired_capacity          = "${var.asg_desired_capacity}"
 }
 
+module "alarms-elb-calculators-frontend-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-calculators-frontend-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.calculators-frontend_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "50"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "50"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -179,6 +179,32 @@ module "content-store" {
   asg_desired_capacity          = "2"
 }
 
+module "alarms-elb-content-store-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-content-store-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.content-store_internal_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "50"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "50"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
+module "alarms-elb-content-store-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-content-store-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.content-store_external_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "50"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "50"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -112,6 +112,22 @@ resource "aws_route53_record" "db_admin_service_record" {
   }
 }
 
+module "alarms-autoscaling-db-admin" {
+  source                            = "../../modules/aws/alarms/autoscaling"
+  name_prefix                       = "${var.stackname}-db-admin"
+  autoscaling_group_name            = "${module.db-admin.autoscaling_group_name}"
+  alarm_actions                     = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  groupinserviceinstances_threshold = "1"
+}
+
+module "alarms-ec2-db-admin" {
+  source                   = "../../modules/aws/alarms/ec2"
+  name_prefix              = "${var.stackname}-db-admin"
+  autoscaling_group_name   = "${module.db-admin.autoscaling_group_name}"
+  alarm_actions            = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  cpuutilization_threshold = "85"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -168,6 +168,19 @@ resource "aws_iam_role_policy_attachment" "deploy_iam_role_policy_attachment" {
   policy_arn = "${aws_iam_policy.deploy_iam_policy.arn}"
 }
 
+module "alarms-elb-deploy-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-deploy-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.deploy_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "50"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "50"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-docker-management/main.tf
+++ b/terraform/projects/app-docker-management/main.tf
@@ -108,6 +108,19 @@ module "docker_management" {
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
 }
 
+module "alarms-elb-docker-management-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-docker-management-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.docker_management_etcd_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "50"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "50"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -133,6 +133,19 @@ module "draft-cache" {
   asg_desired_capacity          = "2"
 }
 
+module "alarms-elb-draft-cache-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-draft-cache-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.draft-cache_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -179,6 +179,32 @@ module "draft-content-store" {
   asg_desired_capacity          = "2"
 }
 
+module "alarms-elb-draft-content-store-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-draft-content-store-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.draft-content-store_internal_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "50"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "50"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
+module "alarms-elb-draft-content-store-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-draft-content-store-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.draft-content-store_external_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "50"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "50"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -136,6 +136,19 @@ module "draft-frontend" {
   asg_desired_capacity          = "2"
 }
 
+module "alarms-elb-draft-frontend-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-draft-frontend-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.draft-frontend_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "50"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "50"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -137,6 +137,19 @@ module "frontend" {
   root_block_device_volume_size = "30"
 }
 
+module "alarms-elb-frontend-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-frontend-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.frontend_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -241,6 +241,32 @@ resource "aws_iam_role_policy_attachment" "graphite_1_iam_role_policy_cloudwatch
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
 }
 
+module "alarms-elb-graphite-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-graphite-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.graphite_internal_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "200"
+  healthyhostcount_threshold     = "1"
+}
+
+module "alarms-elb-graphite-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-graphite-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.graphite_external_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -106,6 +106,19 @@ module "jumpbox" {
   root_block_device_volume_size = "64"
 }
 
+module "alarms-elb-jumpbox-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-jumpbox-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.jumpbox_external_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "0"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "0"
+  surgequeuelength_threshold     = "200"
+  healthyhostcount_threshold     = "1"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-logs-cdn/main.tf
+++ b/terraform/projects/app-logs-cdn/main.tf
@@ -154,6 +154,19 @@ resource "aws_iam_role_policy_attachment" "logs-cdn_iam_role_policy_attachment" 
   policy_arn = "${aws_iam_policy.logs-cdn_iam_policy.arn}"
 }
 
+module "alarms-elb-logs-cdn-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-logs-cdn-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.logs-cdn_external_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "0"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "0"
+  surgequeuelength_threshold     = "200"
+  healthyhostcount_threshold     = "1"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -203,6 +203,19 @@ resource "aws_iam_role_policy_attachment" "mapit_2_iam_role_policy_attachment" {
   policy_arn = "${aws_iam_policy.mapit_iam_policy.arn}"
 }
 
+module "alarms-elb-mapit-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-mapit-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.mapit_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -94,6 +94,22 @@ resource "aws_iam_role_policy_attachment" "mirrorer_iam_role_policy_attachment" 
   policy_arn = "${aws_iam_policy.mirrorer_iam_policy.arn}"
 }
 
+module "alarms-autoscaling-mirrorer" {
+  source                            = "../../modules/aws/alarms/autoscaling"
+  name_prefix                       = "${var.stackname}-mirrorer"
+  autoscaling_group_name            = "${module.mirrorer.autoscaling_group_name}"
+  alarm_actions                     = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  groupinserviceinstances_threshold = "1"
+}
+
+module "alarms-ec2-mirrorer" {
+  source                   = "../../modules/aws/alarms/ec2"
+  name_prefix              = "${var.stackname}-mirrorer"
+  autoscaling_group_name   = "${module.mirrorer.autoscaling_group_name}"
+  alarm_actions            = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  cpuutilization_threshold = "85"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -233,6 +233,54 @@ resource "aws_iam_role_policy_attachment" "mongo-3_iam_role_policy_attachment" {
   policy_arn = "${aws_iam_policy.mongo-iam_policy.arn}"
 }
 
+module "alarms-autoscaling-mongo-1" {
+  source                            = "../../modules/aws/alarms/autoscaling"
+  name_prefix                       = "${var.stackname}-mongo-1"
+  autoscaling_group_name            = "${module.mongo-1.autoscaling_group_name}"
+  alarm_actions                     = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  groupinserviceinstances_threshold = "1"
+}
+
+module "alarms-ec2-mongo-1" {
+  source                   = "../../modules/aws/alarms/ec2"
+  name_prefix              = "${var.stackname}-mongo-1"
+  autoscaling_group_name   = "${module.mongo-1.autoscaling_group_name}"
+  alarm_actions            = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  cpuutilization_threshold = "85"
+}
+
+module "alarms-autoscaling-mongo-2" {
+  source                            = "../../modules/aws/alarms/autoscaling"
+  name_prefix                       = "${var.stackname}-mongo-2"
+  autoscaling_group_name            = "${module.mongo-2.autoscaling_group_name}"
+  alarm_actions                     = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  groupinserviceinstances_threshold = "1"
+}
+
+module "alarms-ec2-mongo-2" {
+  source                   = "../../modules/aws/alarms/ec2"
+  name_prefix              = "${var.stackname}-mongo-2"
+  autoscaling_group_name   = "${module.mongo-2.autoscaling_group_name}"
+  alarm_actions            = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  cpuutilization_threshold = "85"
+}
+
+module "alarms-autoscaling-mongo-3" {
+  source                            = "../../modules/aws/alarms/autoscaling"
+  name_prefix                       = "${var.stackname}-mongo-3"
+  autoscaling_group_name            = "${module.mongo-3.autoscaling_group_name}"
+  alarm_actions                     = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  groupinserviceinstances_threshold = "1"
+}
+
+module "alarms-ec2-mongo-3" {
+  source                   = "../../modules/aws/alarms/ec2"
+  name_prefix              = "${var.stackname}-mongo-3"
+  autoscaling_group_name   = "${module.mongo-3.autoscaling_group_name}"
+  alarm_actions            = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  cpuutilization_threshold = "85"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -160,6 +160,32 @@ resource "aws_route53_record" "internal_service_record" {
   }
 }
 
+module "alarms-elb-monitoring-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-monitoring-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.monitoring_internal_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "0"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "0"
+  surgequeuelength_threshold     = "200"
+  healthyhostcount_threshold     = "1"
+}
+
+module "alarms-elb-monitoring-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-monitoring-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.monitoring_external_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-mysql-primary/main.tf
+++ b/terraform/projects/app-mysql-primary/main.tf
@@ -78,6 +78,13 @@ resource "aws_route53_record" "service_record" {
   records = ["${module.mysql_primary_rds_instance.rds_instance_address}"]
 }
 
+module "alarms-rds-mysql-primary" {
+  source         = "../../modules/aws/alarms/rds"
+  name_prefix    = "${var.stackname}-mysql-primary"
+  alarm_actions  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  db_instance_id = "${module.mysql_primary_rds_instance.rds_instance_id}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -90,6 +90,21 @@ resource "aws_route53_record" "replica_service_record" {
   records = ["${module.postgresql-standby_rds_instance.rds_replica_address}"]
 }
 
+module "alarms-rds-postgresql-primary" {
+  source         = "../../modules/aws/alarms/rds"
+  name_prefix    = "${var.stackname}-postgresql-primary"
+  alarm_actions  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  db_instance_id = "${module.postgresql-primary_rds_instance.rds_instance_id}"
+}
+
+module "alarms-rds-postgresql-standby" {
+  source               = "../../modules/aws/alarms/rds"
+  name_prefix          = "${var.stackname}-postgresql-standby"
+  alarm_actions        = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  db_instance_id       = "${module.postgresql-standby_rds_instance.rds_replica_id}"
+  replicalag_threshold = "120"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -179,6 +179,32 @@ module "publishing-api" {
   asg_desired_capacity          = "2"
 }
 
+module "alarms-elb-publishing-api-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-publishing-api-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.publishing-api_elb_internal.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
+module "alarms-elb-publishing-api-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-publishing-api-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.publishing-api_elb_external.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -175,6 +175,19 @@ resource "aws_iam_role_policy_attachment" "puppetmaster_iam_role_policy_attachme
   policy_arn = "${aws_iam_policy.puppetmaster_iam_policy.arn}"
 }
 
+module "alarms-elb-puppetmaster-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-puppetmaster-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.puppetmaster_internal_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "0"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "0"
+  surgequeuelength_threshold     = "200"
+  healthyhostcount_threshold     = "1"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-rabbitmq/main.tf
+++ b/terraform/projects/app-rabbitmq/main.tf
@@ -121,6 +121,19 @@ resource "aws_iam_role_policy_attachment" "rabbitmq_iam_role_policy_attachment" 
   policy_arn = "${aws_iam_policy.rabbitmq_iam_policy.arn}"
 }
 
+module "alarms-elb-rabbitmq-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-rabbitmq-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.rabbitmq_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "0"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "0"
+  surgequeuelength_threshold     = "200"
+  healthyhostcount_threshold     = "1"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -317,6 +317,58 @@ module "router-backend-3" {
   root_block_device_volume_size = "20"
 }
 
+module "alarms-elb-router-api-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-router-api-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.router_api_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
+module "alarms-elb-router-backend-1-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-router-backend-1-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.router_backend_1_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "0"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "0"
+  surgequeuelength_threshold     = "200"
+  healthyhostcount_threshold     = "1"
+}
+
+module "alarms-elb-router-backend-2-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-router-backend-2-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.router_backend_2_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "0"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "0"
+  surgequeuelength_threshold     = "200"
+  healthyhostcount_threshold     = "1"
+}
+
+module "alarms-elb-router-backend-3-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-router-backend-3-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.router_backend_3_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "0"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "0"
+  surgequeuelength_threshold     = "200"
+  healthyhostcount_threshold     = "1"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-rummager-elasticsearch/main.tf
+++ b/terraform/projects/app-rummager-elasticsearch/main.tf
@@ -235,6 +235,19 @@ resource "aws_iam_role_policy_attachment" "rummager-elasticsearch_3_iam_role_pol
   policy_arn = "${aws_iam_policy.rummager-elasticsearch_iam_policy.arn}"
 }
 
+module "alarms-elb-rummager-elasticsearch-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-rummager-elasticsearch-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.rummager-elasticsearch_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "0"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "0"
+  surgequeuelength_threshold     = "200"
+  healthyhostcount_threshold     = "1"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -154,6 +154,19 @@ module "search" {
   asg_desired_capacity          = "${var.asg_desired_capacity}"
 }
 
+module "alarms-elb-search-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-search-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.search_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -103,6 +103,22 @@ resource "aws_route53_record" "transition_db_admin_service_record" {
   }
 }
 
+module "alarms-autoscaling-transition-db-admin" {
+  source                            = "../../modules/aws/alarms/autoscaling"
+  name_prefix                       = "${var.stackname}-transition-db-admin"
+  autoscaling_group_name            = "${module.transition-db-admin.autoscaling_group_name}"
+  alarm_actions                     = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  groupinserviceinstances_threshold = "1"
+}
+
+module "alarms-ec2-transition-db-admin" {
+  source                   = "../../modules/aws/alarms/ec2"
+  name_prefix              = "${var.stackname}-transition-db-admin"
+  autoscaling_group_name   = "${module.transition-db-admin.autoscaling_group_name}"
+  alarm_actions            = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  cpuutilization_threshold = "85"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -90,6 +90,21 @@ resource "aws_route53_record" "replica_service_record" {
   records = ["${module.transition-postgresql-standby_rds_instance.rds_replica_address}"]
 }
 
+module "alarms-rds-transition-postgresql-primary" {
+  source         = "../../modules/aws/alarms/rds"
+  name_prefix    = "${var.stackname}-transition-postgresql-primary"
+  alarm_actions  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  db_instance_id = "${module.transition-postgresql-primary_rds_instance.rds_instance_id}"
+}
+
+module "alarms-rds-transition-postgresql-standby" {
+  source               = "../../modules/aws/alarms/rds"
+  name_prefix          = "${var.stackname}-transition-postgresql-standby"
+  alarm_actions        = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  db_instance_id       = "${module.transition-postgresql-standby_rds_instance.rds_replica_id}"
+  replicalag_threshold = "120"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -194,6 +194,32 @@ module "whitehall-backend" {
   asg_desired_capacity          = "2"
 }
 
+module "alarms-elb-whitehall-backend-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-whitehall-backend-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.whitehall-backend_internal_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
+module "alarms-elb-whitehall-backend-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-whitehall-backend-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.whitehall-backend_external_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -120,6 +120,19 @@ module "whitehall-frontend" {
   asg_desired_capacity          = "2"
 }
 
+module "alarms-elb-whitehall-frontend-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-whitehall-frontend-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  elb_name                       = "${aws_elb.whitehall-frontend_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 


### PR DESCRIPTION
Add basic AWS alarms to app projects.
ADR needs to be redacted.
Thresholds are a little bit arbitrary until we get a sense of sensible values.
NAT Gateway still needs an alarm
