### PR TITLE
Use name_prefix instead of name for launch config

### DIFF
--- a/terraform/modules/aws/node_group/main.tf
+++ b/terraform/modules/aws/node_group/main.tf
@@ -179,7 +179,7 @@ resource "aws_key_pair" "node_key" {
 }
 
 resource "aws_launch_configuration" "node_launch_configuration" {
-  name          = "${var.name}"
+  name_prefix   = "${var.name}-"
   image_id      = "${data.aws_ami.node_ami_ubuntu.id}"
   instance_type = "${var.instance_type}"
   user_data     = "${join("\n\n", list(file("${path.module}/${var.instance_user_data}"), var.instance_additional_user_data))}"


### PR DESCRIPTION
Terraform recommends in the
[documentation](https://www.terraform.io/docs/providers/aws/r/launch_configuration.html#using-with-autoscaling-groups)
to use launch configs in this way. We already set the
`create_before_destroy` lifecycle parameter, but because we hardcode the
name, terraform tries to create a new launch config with the same name
and fails. Updating the launch config to use name_prefix successfully
creates a new launch config with a different name and then applies that
to the ASG before destroying the existing launch config.

Because this is in a shared module, this will force a new launch config
when we next apply any changes using it, but this shouldnt result in any
difference except for the launch config name, which will have a random
suffix after it.