### PR TITLE
Add lifecycle rules to database backups

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -36,4 +36,70 @@ resource "aws_s3_bucket" "database_backups" {
     Name            = "govuk-${var.aws_environment}-database-backups"
     aws_environment = "${var.aws_environment}"
   }
+
+  lifecycle_rule {
+    prefix  = "mysql/"
+    enabled = true
+
+    transition {
+      storage_class = "STANDARD_IA"
+      days          = 30
+    }
+
+    transition {
+      storage_class = "GLACIER"
+      days          = 60
+    }
+
+    expiration {
+      days = 90
+    }
+  }
+
+  lifecycle_rule {
+    prefix  = "postgres/"
+    enabled = true
+
+    transition {
+      storage_class = "STANDARD_IA"
+      days          = 30
+    }
+
+    transition {
+      storage_class = "GLACIER"
+      days          = 60
+    }
+
+    expiration {
+      days = 90
+    }
+  }
+
+  lifecycle_rule {
+    prefix  = "mongodb/daily"
+    enabled = true
+
+    transition {
+      storage_class = "STANDARD_IA"
+      days          = 30
+    }
+
+    transition {
+      storage_class = "GLACIER"
+      days          = 60
+    }
+
+    expiration {
+      days = 90
+    }
+  }
+
+  lifecycle_rule {
+    prefix  = "mongodb/regular"
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+  }
 }


### PR DESCRIPTION
Add lifecycle rules to our database backups. In line with what we currently do, keep backups for 3 months, but move them to lower storage costs after 30 and 60 days respectively.

With mongodb, keep "regular" backups to 7 days so we have point in time backups that go back 7 days. Keep "daily" backups for 90 days.

https://trello.com/c/F6UQeeiN/777-design-rds-replicas-and-backups