### PR TITLE
Allow rummager elasticsearch to write to backups bucket

### DIFF
--- a/terraform/projects/app-cache/README.md
+++ b/terraform/projects/app-cache/README.md
@@ -17,7 +17,7 @@ Cache application servers
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
-| remote_state_infra_artefact_bucket_stack | Override infra_artefact_bucket remote state path | string | `` | no |
+| remote_state_infra_artefact_bucket_key_stack | Override infra_artefact_bucket remote state path | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -64,7 +64,7 @@ variable "asg_desired_capacity" {
   default     = "2"
 }
 
-variable "remote_state_infra_artefact_bucket_stack" {
+variable "remote_state_infra_artefact_bucket_key_stack" {
   type        = "string"
   description = "Override infra_artefact_bucket remote state path"
   default     = ""
@@ -84,7 +84,7 @@ data "terraform_remote_state" "artefact_bucket" {
 
   config {
     bucket = "${var.remote_state_bucket}"
-    key    = "${coalesce(var.remote_state_infra_artefact_bucket_stack, var.stackname)}/artefact-bucket.tfstate"
+    key    = "${coalesce(var.remote_state_infra_artefact_bucket_key_stack, var.stackname)}/artefact-bucket.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -32,7 +32,7 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
-variable "remote_state_infra_database_backups_bucket_stack" {
+variable "remote_state_infra_database_backups_bucket_key_stack" {
   type        = "string"
   description = "Override stackname path to infra_database_backups_bucket remote state"
   default     = ""
@@ -139,7 +139,7 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 
   config {
     bucket = "${var.remote_state_bucket}"
-    key    = "${coalesce(var.remote_state_infra_database_backups_bucket_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
+    key    = "${coalesce(var.remote_state_infra_database_backups_bucket_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -32,6 +32,12 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
+variable "remote_state_infra_database_backups_bucket_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_database_backups_bucket remote state"
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -133,7 +139,7 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 
   config {
     bucket = "${var.remote_state_bucket}"
-    key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
+    key    = "${coalesce(var.remote_state_infra_database_backups_bucket_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-deploy/README.md
+++ b/terraform/projects/app-deploy/README.md
@@ -13,7 +13,7 @@ Deploy node
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
-| remote_state_infra_artefact_bucket_stack | Override infra_artefact_bucket remote state path | string | `` | no |
+| remote_state_infra_artefact_bucket_key_stack | Override infra_artefact_bucket remote state path | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -40,7 +40,7 @@ variable "deploy_subnet" {
   description = "Name of the subnet to place the apt instance 1 and EBS volume"
 }
 
-variable "remote_state_infra_artefact_bucket_stack" {
+variable "remote_state_infra_artefact_bucket_key_stack" {
   type        = "string"
   description = "Override infra_artefact_bucket remote state path"
   default     = ""
@@ -60,7 +60,7 @@ data "terraform_remote_state" "artefact_bucket" {
 
   config {
     bucket = "${var.remote_state_bucket}"
-    key    = "${coalesce(var.remote_state_infra_artefact_bucket_stack, var.stackname)}/artefact-bucket.tfstate"
+    key    = "${coalesce(var.remote_state_infra_artefact_bucket_key_stack, var.stackname)}/artefact-bucket.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -75,6 +75,12 @@ variable "mongo_3_ip" {
   description = "IP address of the private IP to assign to the instance"
 }
 
+variable "remote_state_infra_database_backups_bucket_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_database_backups_bucket remote state"
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -286,7 +292,7 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 
   config {
     bucket = "${var.remote_state_bucket}"
-    key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
+    key    = "${coalesce(var.remote_state_infra_database_backups_bucket_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -75,7 +75,7 @@ variable "mongo_3_ip" {
   description = "IP address of the private IP to assign to the instance"
 }
 
-variable "remote_state_infra_database_backups_bucket_stack" {
+variable "remote_state_infra_database_backups_bucket_key_stack" {
   type        = "string"
   description = "Override stackname path to infra_database_backups_bucket remote state"
   default     = ""
@@ -292,7 +292,7 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 
   config {
     bucket = "${var.remote_state_bucket}"
-    key    = "${coalesce(var.remote_state_infra_database_backups_bucket_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
+    key    = "${coalesce(var.remote_state_infra_database_backups_bucket_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -50,6 +50,12 @@ variable "elb_internal_certname" {
   description = "The ACM cert domain name to find the ARN of"
 }
 
+variable "remote_state_infra_database_backups_bucket_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_database_backups_bucket remote state"
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -374,7 +380,7 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 
   config {
     bucket = "${var.remote_state_bucket}"
-    key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
+    key    = "${coalesce(var.remote_state_infra_database_backups_bucket_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -50,7 +50,7 @@ variable "elb_internal_certname" {
   description = "The ACM cert domain name to find the ARN of"
 }
 
-variable "remote_state_infra_database_backups_bucket_stack" {
+variable "remote_state_infra_database_backups_bucket_key_stack" {
   type        = "string"
   description = "Override stackname path to infra_database_backups_bucket remote state"
   default     = ""
@@ -380,7 +380,7 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 
   config {
     bucket = "${var.remote_state_bucket}"
-    key    = "${coalesce(var.remote_state_infra_database_backups_bucket_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
+    key    = "${coalesce(var.remote_state_infra_database_backups_bucket_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-rummager-elasticsearch/README.md
+++ b/terraform/projects/app-rummager-elasticsearch/README.md
@@ -12,9 +12,12 @@ Rummager Elasticsearch cluster
 | cluster_name | Name of the Elasticsearch cluster to use for discovery | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_aws_logging_key_stack | Override stackname path to infra_aws_logging remote state | string | `` | no |
+| remote_state_infra_database_backups_bucket_key_stack | Override stackname path to infra_database_backups_bucket remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_vpc remote state | string | `` | no |
+| remote_state_infra_stack_sns_alerts_key_stack | Override stackname path to infra_stack_sns_alerts remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
 | rummager_elasticsearch_1_subnet | Name of the subnet to place the Elasticsearch instance 1 and EBS volume | string | - | yes |
 | rummager_elasticsearch_2_subnet | Name of the subnet to place the Elasticsearch 2 and EBS volume | string | - | yes |

--- a/terraform/projects/app-rummager-elasticsearch/main.tf
+++ b/terraform/projects/app-rummager-elasticsearch/main.tf
@@ -73,6 +73,7 @@ variable "remote_state_infra_database_backups_bucket_key_stack" {
   description = "Override stackname path to infra_database_backups_bucket remote state"
   default     = ""
 }
+
 # Resources
 # --------------------------------------------------------------
 terraform {

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -24,6 +24,12 @@ variable "ssh_public_key" {
   description = "Default public key material"
 }
 
+variable "remote_state_infra_database_backups_bucket_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_database_backups_bucket remote state"
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -124,7 +130,7 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 
   config {
     bucket = "${var.remote_state_bucket}"
-    key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
+    key    = "${coalesce(var.remote_state_infra_database_backups_bucket_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -24,7 +24,7 @@ variable "ssh_public_key" {
   description = "Default public key material"
 }
 
-variable "remote_state_infra_database_backups_bucket_stack" {
+variable "remote_state_infra_database_backups_bucket_key_stack" {
   type        = "string"
   description = "Override stackname path to infra_database_backups_bucket remote state"
   default     = ""
@@ -130,7 +130,7 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 
   config {
     bucket = "${var.remote_state_bucket}"
-    key    = "${coalesce(var.remote_state_infra_database_backups_bucket_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
+    key    = "${coalesce(var.remote_state_infra_database_backups_bucket_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
     region = "eu-west-1"
   }
 }


### PR DESCRIPTION
Attach the policy that would allow each instance to write snapshots to
the database backups S3 bucket.

Related to https://github.com/alphagov/govuk-aws/pull/348

https://trello.com/c/wl3p8Y9D/787-investigate-elasticsearch-backups