### PR TITLE
Use all of available glacier time for backups

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -48,11 +48,11 @@ resource "aws_s3_bucket" "database_backups" {
 
     transition {
       storage_class = "GLACIER"
-      days          = 60
+      days          = 90
     }
 
     expiration {
-      days = 90
+      days = 120
     }
   }
 
@@ -67,11 +67,11 @@ resource "aws_s3_bucket" "database_backups" {
 
     transition {
       storage_class = "GLACIER"
-      days          = 60
+      days          = 90
     }
 
     expiration {
-      days = 90
+      days = 120
     }
   }
 
@@ -86,11 +86,11 @@ resource "aws_s3_bucket" "database_backups" {
 
     transition {
       storage_class = "GLACIER"
-      days          = 60
+      days          = 90
     }
 
     expiration {
-      days = 90
+      days = 120
     }
   }
 


### PR DESCRIPTION
Glacier charges an [early delete
fee](https://aws.amazon.com/premiumsupport/knowledge-center/glacier-early-delete-fees/)
for deleting objects which are stored for less than 90 days. This
appears to be calculated by charging you for 90 days of storage
regardless of the length of time things are stored in glacier, and
calling this an early deletion fee. This is a footnote on the [pricing
page](https://aws.amazon.com/glacier/pricing/) which reads

> Glacier archives have a minimum 90 days of storage, and archives
> deleted before 90 days incur a pro-rated charge equal to the storage
> charge for the remaining days

We may as well make use of this
additional time as we are already paying for it through the early
deletion fee.