### PR TITLE
Add MySQL read replica

### DIFF
--- a/terraform/projects/app-mysql/README.md
+++ b/terraform/projects/app-mysql/README.md
@@ -29,4 +29,6 @@ RDS Mysql Primary instance
 | mysql_primary_endpoint | Mysql instance endpoint |
 | mysql_primary_id | Mysql instance ID |
 | mysql_primary_resource_id | Mysql instance resource ID |
+| mysql_replica_address | Mysql instance address |
+| mysql_replica_endpoint | Mysql instance endpoint |
 

--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -46,6 +46,7 @@ provider "aws" {
   version = "1.0.0"
 }
 
+# MySQL Primary instance
 module "mysql_primary_rds_instance" {
   source               = "../../modules/aws/rds_instance"
   name                 = "${var.stackname}-mysql-primary"
@@ -99,6 +100,42 @@ module "mysql_primary_log_exporter" {
   lambda_log_retention_in_days = "${var.cloudwatch_log_retention}"
 }
 
+# MySQL Replica instance
+module "mysql_replica_rds_instance" {
+  source                     = "../../modules/aws/rds_instance"
+  name                       = "${var.stackname}-mysql-replica"
+  default_tags               = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mysql-replica")}"
+  instance_class             = "db.m4.xlarge"
+  security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_mysql-replica_id}"]
+  create_replicate_source_db = "1"
+  replicate_source_db        = "${module.mysql_primary_rds_instance.rds_instance_id}"
+}
+
+resource "aws_route53_record" "replica_service_record" {
+  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
+  name    = "mysql-replica.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["${module.mysql_replica_rds_instance.rds_replica_address}"]
+}
+
+module "alarms-rds-mysql-replica" {
+  source               = "../../modules/aws/alarms/rds"
+  name_prefix          = "${var.stackname}-mysql-replica"
+  alarm_actions        = ["${data.terraform_remote_state.infra_stack_sns_alerts.sns_topic_alerts_arn}"]
+  db_instance_id       = "${module.mysql_replica_rds_instance.rds_replica_id}"
+  replicalag_threshold = "120"
+}
+
+module "mysql_replica_log_exporter" {
+  source                       = "../../modules/aws/rds_log_exporter"
+  rds_instance_id              = "${module.mysql_replica_rds_instance.rds_replica_id}"
+  s3_logging_bucket_name       = "${data.terraform_remote_state.infra_aws_logging.aws_logging_bucket_id}"
+  lambda_filename              = "${path.module}/../../lambda/RDSLogsToS3/RDSLogsToS3.zip"
+  lambda_role_arn              = "${data.terraform_remote_state.infra_aws_logging.lambda_rds_logs_to_s3_role_arn}"
+  lambda_log_retention_in_days = "${var.cloudwatch_log_retention}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 
@@ -119,5 +156,15 @@ output "mysql_primary_endpoint" {
 
 output "mysql_primary_address" {
   value       = "${module.mysql_primary_rds_instance.rds_instance_address}"
+  description = "Mysql instance address"
+}
+
+output "mysql_replica_endpoint" {
+  value       = "${module.mysql_replica_rds_instance.rds_instance_endpoint}"
+  description = "Mysql instance endpoint"
+}
+
+output "mysql_replica_address" {
+  value       = "${module.mysql_replica_rds_instance.rds_instance_address}"
   description = "Mysql instance address"
 }

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -5,14 +5,14 @@ Manage the security groups for the entire infrastructure
 
 ## Inputs
 
-| Name | Description | Default | Required |
-|------|-------------|:-----:|:-----:|
-| aws_region | AWS region | `eu-west-1` | no |
-| carrenza_integration_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | - | yes |
-| office_ips | An array of CIDR blocks that will be allowed offsite access. | - | yes |
-| remote_state_bucket | S3 bucket we store our terraform state in | - | yes |
-| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | `` | no |
-| stackname | The name of the stack being built. Must be unique within the environment as it's used for disambiguation. | - | yes |
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_region | AWS region | string | `eu-west-1` | no |
+| carrenza_integration_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
+| office_ips | An array of CIDR blocks that will be allowed offsite access. | list | - | yes |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| stackname | The name of the stack being built. Must be unique within the environment as it's used for disambiguation. | string | - | yes |
 
 ## Outputs
 
@@ -68,6 +68,7 @@ Manage the security groups for the entire infrastructure
 | sg_monitortest_external_elb_id |  |
 | sg_monitortest_id |  |
 | sg_mysql-primary_id |  |
+| sg_mysql-replica_id |  |
 | sg_offsite_ssh_id |  |
 | sg_postgresql-primary_id |  |
 | sg_publishing-api_elb_external_id |  |
@@ -87,6 +88,7 @@ Manage the security groups for the entire infrastructure
 | sg_transition-db-admin_elb_id |  |
 | sg_transition-db-admin_id |  |
 | sg_transition-postgresql-primary_id |  |
+| sg_transition-postgresql-standby_id |  |
 | sg_whitehall-backend_external_elb_id |  |
 | sg_whitehall-backend_id |  |
 | sg_whitehall-backend_internal_elb_id |  |

--- a/terraform/projects/infra-security-groups/mysql.tf
+++ b/terraform/projects/infra-security-groups/mysql.tf
@@ -69,3 +69,27 @@ resource "aws_security_group_rule" "allow_mysql-primary_db-admin_in" {
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.db-admin.id}"
 }
+
+resource "aws_security_group" "mysql-replica" {
+  name        = "${var.stackname}_mysql-replica_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access to mysql-replica from its clients"
+
+  tags {
+    Name = "${var.stackname}_mysql-replica_access"
+  }
+}
+
+# Contacts is the only application that reads from the MySQL replica
+resource "aws_security_group_rule" "allow_frontend_to_mysql-replica_3306" {
+  type      = "ingress"
+  from_port = 3306
+  to_port   = 3306
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.mysql-replica.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.frontend.id}"
+}

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -206,6 +206,10 @@ output "sg_mysql-primary_id" {
   value = "${aws_security_group.mysql-primary.id}"
 }
 
+output "sg_mysql-replica_id" {
+  value = "${aws_security_group.mysql-replica.id}"
+}
+
 output "sg_publishing-api_elb_internal_id" {
   value = "${aws_security_group.publishing-api_elb_internal.id}"
 }


### PR DESCRIPTION
Add a MySQL read replica. In our Puppet code this was previously called "mysql-slave", so take this opportunity to rename to "replica".

https://trello.com/c/F6UQeeiN/777-design-rds-replicas-and-backups