### PR TITLE
Set IOPS for io1 disk

### DIFF
--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -213,6 +213,7 @@ resource "aws_ebs_volume" "graphite-1" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.graphite_1_subnet)}"
   size              = 250
   type              = "io1"
+  iops              = 100
 
   tags {
     Name            = "${var.stackname}-graphite-1"


### PR DESCRIPTION
A minimum amount of IOPS must be set for this type of disk. Set to 100, and if it's problematic, increase.