### PR TITLE
Set IOPS to 1000 for Graphite volume

### DIFF
--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -213,7 +213,7 @@ resource "aws_ebs_volume" "graphite-1" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.graphite_1_subnet)}"
   size              = 250
   type              = "io1"
-  iops              = 100
+  iops              = 1000
 
   tags {
     Name            = "${var.stackname}-graphite-1"


### PR DESCRIPTION
I set it to the minimum at 100, and the Icinga alert triggered way above critical.

I set it to 500, and it moved down to warning.

Moving it to 1000 seems sensible to ensure graphite can write all operations in a timely fashion.

I have made the change in place, so change is to reflect any future deployments.