### PR TITLE
Update Bouncer ELBs and rules

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -13,6 +13,7 @@ Manage the security groups for the entire infrastructure
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
 | stackname | The name of the stack being built. Must be unique within the environment as it's used for disambiguation. | string | - | yes |
+| traffic_replay_ips | An array of CIDR blocks that will replay traffic against an environment | list | - | yes |
 
 ## Outputs
 

--- a/terraform/projects/infra-security-groups/bouncer.tf
+++ b/terraform/projects/infra-security-groups/bouncer.tf
@@ -24,8 +24,8 @@ resource "aws_security_group" "bouncer" {
 
 resource "aws_security_group_rule" "allow_bouncer_elb_in" {
   type      = "ingress"
-  from_port = 443
-  to_port   = 443
+  from_port = 80
+  to_port   = 80
   protocol  = "tcp"
 
   # Which security group is the rule assigned to
@@ -45,7 +45,25 @@ resource "aws_security_group" "bouncer_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_fastly_to_bouncer_elb" {
+resource "aws_security_group_rule" "allow_fastly_to_bouncer_elb_http" {
+  type              = "ingress"
+  to_port           = 80
+  from_port         = 80
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.bouncer_elb.id}"
+  cidr_blocks       = ["${data.fastly_ip_ranges.fastly.cidr_blocks}", "${var.office_ips}"]
+}
+
+resource "aws_security_group_rule" "allow_traffic-replay_to_bouncer_elb_http" {
+  type              = "ingress"
+  to_port           = 80
+  from_port         = 80
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.bouncer_elb.id}"
+  cidr_blocks       = ["${var.traffic_replay_ips}"]
+}
+
+resource "aws_security_group_rule" "allow_fastly_to_bouncer_elb_https" {
   type              = "ingress"
   to_port           = 443
   from_port         = 443

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -33,3 +33,8 @@ variable "carrenza_integration_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will be allowed to SSH to the jumpbox."
 }
+
+variable "traffic_replay_ips" {
+  type        = "list"
+  description = "An array of CIDR blocks that will replay traffic against an environment"
+}


### PR DESCRIPTION
Bouncer should respond to traffic on port 80, as it handles redirects that may not neccessarily be coming from an https request.

We should also ensure there is a certificate for https requests, and update security groups so that the monitoring instance is able to test the endpoint.

EDIT: after doing this I realised that we'd need to allow all traffic in the external ELB to allow the monitoring instance to be able to connect. I don't want to create an internal ELB for a single check, so need to decide how we should best monitor this.