### PR TITLE
Disable a broken pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,5 @@
 - repo: local
   hooks:
-    - id: terraform-validate
-      name: ===> Validating syntax of all .tf files
-      entry: tools/terraform-validate.sh
-      language: script
-      files: \.tf$
     - id: terraform-format
       name: ===> Making sure new terraform code is in a canonical format
       entry: tools/terraform-format.sh


### PR DESCRIPTION
Since upgrading terraform this has stopped working, and everyone is
disabling it locally, so remove it until we can invest some time
in to fixing it up.