### PR TITLE
Allow internal hosts to connect to alert on port 443

### DIFF
--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -35,6 +35,11 @@ variable "elb_external_certname" {
   description = "The ACM cert domain name to find the ARN of"
 }
 
+variable "elb_internal_certname" {
+  type        = "string"
+  description = "The ACM cert domain name to find the ARN of"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -49,6 +54,11 @@ provider "aws" {
 
 data "aws_acm_certificate" "elb_external_cert" {
   domain   = "${var.elb_external_certname}"
+  statuses = ["ISSUED"]
+}
+
+data "aws_acm_certificate" "elb_internal_cert" {
+  domain   = "${var.elb_internal_certname}"
   statuses = ["ISSUED"]
 }
 
@@ -101,6 +111,15 @@ resource "aws_elb" "monitoring_internal_elb" {
     instance_protocol = "tcp"
     lb_port           = 5667
     lb_protocol       = "tcp"
+  }
+
+  listener {
+    instance_port     = 80
+    instance_protocol = "http"
+    lb_port           = 443
+    lb_protocol       = "https"
+
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_internal_cert.arn}"
   }
 
   health_check {

--- a/terraform/projects/infra-security-groups/monitoring.tf
+++ b/terraform/projects/infra-security-groups/monitoring.tf
@@ -47,6 +47,19 @@ resource "aws_security_group_rule" "allow_monitoring_internal_elb_in" {
   source_security_group_id = "${aws_security_group.monitoring_internal_elb.id}"
 }
 
+resource "aws_security_group_rule" "allow_monitoring_internal_elb_http_in" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.monitoring.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.monitoring_internal_elb.id}"
+}
+
 resource "aws_security_group" "monitoring_external_elb" {
   name        = "${var.stackname}_monitoring_external_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
@@ -91,6 +104,16 @@ resource "aws_security_group_rule" "allow_management_to_monitoring_internal_elb_
   type      = "ingress"
   from_port = 5667
   to_port   = 5667
+  protocol  = "tcp"
+
+  security_group_id        = "${aws_security_group.monitoring_internal_elb.id}"
+  source_security_group_id = "${aws_security_group.management.id}"
+}
+
+resource "aws_security_group_rule" "allow_management_to_monitoring_internal_elb_https" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 443
   protocol  = "tcp"
 
   security_group_id        = "${aws_security_group.monitoring_internal_elb.id}"


### PR DESCRIPTION
We have a number of hosts running the `check_icinga` plugin. These are
currently failing to connect. This changeset should permit that access.