### PR TITLE
Add log_bin_trust_function_creators to MySQL

### DIFF
--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -71,6 +71,13 @@ resource "aws_db_parameter_group" "mysql-primary" {
     value = 1073741824
   }
 
+  # TODO: this should be set to 0 when we have migrated to Production
+  # as it not recommended to set this option
+  parameter {
+    name  = "log_bin_trust_function_creators"
+    value = 1
+  }
+
   tags {
     aws_stackname = "${var.stackname}"
   }


### PR DESCRIPTION
I discovered that the Signon application had stopped working, and we discovered that the migration to a new schema had failed (a table was missing that the application expected).

In the migration, when trying to create a trigger that modifies data, MySQL throws an error because we do not have the correct level of privileges to create this:

```
15:40:09 *** [err :: ip-10-1-5-53.eu-west-1.compute.internal] E, [2017-11-20T15:40:09.784565 #675] ERROR -- : Error in class=Lhm::Entangler, reverting. exception=ActiveRecord::StatementInvalid message=Mysql2::Error: You do not have the SUPER privilege and binary logging is enabled (you *might* want to use the less safe log_bin_trust_function_creators variable): create trigger `lhmt_del_event_logs`
```

Since we are unable to elevate the privilege for any user in RDS to `SUPER`, we need to enable the `log_bin_trust_function_creators` parameter by adding it as an option in the parameter group.

The documentation recommends against allowing this types of changes:

"When you create a stored function, you must declare either that it is deterministic or that it does not modify data. Otherwise, it may be unsafe for data recovery or replication." In theory, this migration should only happen the first time that Signon is deployed. In most cases, we can get around this because we would normally sync databases between environments, but this does not happen
for Signon.

When this change has been deployed to Production in AWS, we could revert this change after consultation with developers that it will not need to be enabled in the future.

It is disruptive to the workflow as the RDS instance needs to be restarted for the change to take affect.

https://trello.com/c/UXVQEhl5/827-fix-signon-in-aws