### PR TITLE
Add ASG notifications to node_group

### DIFF
--- a/terraform/modules/aws/node_group/README.md
+++ b/terraform/modules/aws/node_group/README.md
@@ -21,6 +21,9 @@ policies to in other modules.
 | asg_desired_capacity | The autoscaling groups desired capacity | string | `1` | no |
 | asg_max_size | The autoscaling groups max_size | string | `1` | no |
 | asg_min_size | The autoscaling groups max_size | string | `1` | no |
+| asg_notification_topic_arn | The Topic ARN for Autoscaling Group notifications to be sent to | string | `` | no |
+| asg_notification_types | A list of Notification Types that trigger Autoscaling Group notifications. Acceptable values are documented in https://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_NotificationConfiguration.html | list | `<list>` | no |
+| create_asg_notifications | Enable Autoscaling Group notifications | string | `true` | no |
 | create_instance_key | Whether to create a key pair for the instance launch configuration | string | `false` | no |
 | default_tags | Additional resource tags | map | `<map>` | no |
 | instance_additional_user_data | Append additional user-data script | string | `` | no |

--- a/terraform/modules/aws/node_group/main.tf
+++ b/terraform/modules/aws/node_group/main.tf
@@ -116,6 +116,29 @@ variable "root_block_device_volume_size" {
   default     = "20"
 }
 
+variable "create_asg_notifications" {
+  type        = "string"
+  description = "Enable Autoscaling Group notifications"
+  default     = true
+}
+
+variable "asg_notification_types" {
+  type        = "list"
+  description = "A list of Notification Types that trigger Autoscaling Group notifications. Acceptable values are documented in https://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_NotificationConfiguration.html"
+
+  default = [
+    "autoscaling:EC2_INSTANCE_LAUNCH",
+    "autoscaling:EC2_INSTANCE_TERMINATE",
+    "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+  ]
+}
+
+variable "asg_notification_topic_arn" {
+  type        = "string"
+  description = "The Topic ARN for Autoscaling Group notifications to be sent to"
+  default     = ""
+}
+
 # Resources
 #--------------------------------------------------------------
 
@@ -247,6 +270,13 @@ resource "aws_autoscaling_group" "node_autoscaling_group" {
   lifecycle {
     create_before_destroy = true
   }
+}
+
+resource "aws_autoscaling_notification" "node_autoscaling_group_notifications" {
+  count         = "${var.create_asg_notifications}"
+  group_names   = ["${aws_autoscaling_group.node_autoscaling_group.name}"]
+  notifications = ["${var.asg_notification_types}"]
+  topic_arn     = "${var.asg_notification_topic_arn}"
 }
 
 # Outputs

--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -188,6 +188,7 @@ module "apt" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.apt_internal_elb.id}", "${aws_elb.apt_external_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "20"
 }
 

--- a/terraform/projects/app-asset-master/main.tf
+++ b/terraform/projects/app-asset-master/main.tf
@@ -72,6 +72,7 @@ module "asset-master" {
   asg_max_size                  = "1"
   asg_min_size                  = "1"
   asg_desired_capacity          = "1"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "30"
 }
 

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -201,6 +201,7 @@ module "backend" {
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "30"
 }
 

--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -125,6 +125,7 @@ module "bouncer" {
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 module "alarms-elb-bouncer-external" {

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -240,6 +240,7 @@ module "cache" {
   asg_max_size                  = "${var.asg_max_size}"
   asg_min_size                  = "${var.asg_min_size}"
   asg_desired_capacity          = "${var.asg_desired_capacity}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 module "alarms-elb-cache-internal" {

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -152,6 +152,7 @@ module "calculators-frontend" {
   asg_max_size                  = "${var.asg_max_size}"
   asg_min_size                  = "${var.asg_min_size}"
   asg_desired_capacity          = "${var.asg_desired_capacity}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 module "alarms-elb-calculators-frontend-internal" {

--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -177,6 +177,7 @@ module "content-store" {
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 module "alarms-elb-content-store-internal" {

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -103,6 +103,7 @@ module "db-admin" {
   asg_max_size                  = "1"
   asg_min_size                  = "1"
   asg_desired_capacity          = "1"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "64"
 }
 

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -139,6 +139,7 @@ module "deploy" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.deploy_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 resource "aws_ebs_volume" "deploy" {

--- a/terraform/projects/app-docker-management/main.tf
+++ b/terraform/projects/app-docker-management/main.tf
@@ -106,6 +106,7 @@ module "docker_management" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.docker_management_etcd_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 module "alarms-elb-docker-management-internal" {

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -131,6 +131,7 @@ module "draft-cache" {
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 module "alarms-elb-draft-cache-internal" {

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -177,6 +177,7 @@ module "draft-content-store" {
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 module "alarms-elb-draft-content-store-internal" {

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -134,6 +134,7 @@ module "draft-frontend" {
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 module "alarms-elb-draft-frontend-internal" {

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -134,6 +134,7 @@ module "frontend" {
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "30"
 }
 

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -207,6 +207,7 @@ module "graphite-1" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.graphite_internal_elb.id}", "${aws_elb.graphite_external_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 resource "aws_ebs_volume" "graphite-1" {

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -103,6 +103,7 @@ module "jumpbox" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.jumpbox_external_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "64"
 }
 

--- a/terraform/projects/app-logs-cdn/main.tf
+++ b/terraform/projects/app-logs-cdn/main.tf
@@ -125,6 +125,7 @@ module "logs-cdn" {
   asg_max_size                  = "1"
   asg_min_size                  = "1"
   asg_desired_capacity          = "1"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 resource "aws_ebs_volume" "logs-cdn" {

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -137,6 +137,7 @@ module "mapit-1" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.mapit_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "20"
 }
 
@@ -169,6 +170,7 @@ module "mapit-2" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.mapit_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "20"
 }
 

--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -64,6 +64,7 @@ module "mirrorer" {
   asg_max_size                  = "1"
   asg_min_size                  = "1"
   asg_desired_capacity          = "1"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "30"
 }
 

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -135,6 +135,7 @@ module "mongo-1" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = []
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "150"
 }
 
@@ -175,6 +176,7 @@ module "mongo-2" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = []
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "150"
 }
 
@@ -215,6 +217,7 @@ module "mongo-3" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = []
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "150"
 }
 

--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -134,6 +134,7 @@ module "monitoring" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.monitoring_external_elb.id}", "${aws_elb.monitoring_internal_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 resource "aws_route53_record" "external_service_record" {

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -177,6 +177,7 @@ module "publishing-api" {
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 module "alarms-elb-publishing-api-internal" {

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -161,6 +161,7 @@ module "puppetmaster" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.puppetmaster_bootstrap_elb.id}", "${aws_elb.puppetmaster_internal_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "50"
 }
 

--- a/terraform/projects/app-rabbitmq/main.tf
+++ b/terraform/projects/app-rabbitmq/main.tf
@@ -108,6 +108,7 @@ module "rabbitmq" {
   asg_max_size                  = "3"
   asg_min_size                  = "3"
   asg_desired_capacity          = "3"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 resource "aws_iam_policy" "rabbitmq_iam_policy" {

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -190,6 +190,7 @@ module "router-backend-1" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.router_backend_1_elb.id}", "${aws_elb.router_api_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "20"
 }
 
@@ -255,6 +256,7 @@ module "router-backend-2" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.router_backend_2_elb.id}", "${aws_elb.router_api_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "20"
 }
 
@@ -320,6 +322,7 @@ module "router-backend-3" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.router_backend_3_elb.id}", "${aws_elb.router_api_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "20"
 }
 

--- a/terraform/projects/app-rummager-elasticsearch/main.tf
+++ b/terraform/projects/app-rummager-elasticsearch/main.tf
@@ -153,6 +153,7 @@ module "rummager-elasticsearch-1" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.rummager-elasticsearch_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "20"
 }
 
@@ -186,6 +187,7 @@ module "rummager-elasticsearch-2" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.rummager-elasticsearch_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "20"
 }
 
@@ -219,6 +221,7 @@ module "rummager-elasticsearch-3" {
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.rummager-elasticsearch_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "20"
 }
 

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -152,6 +152,7 @@ module "search" {
   asg_max_size                  = "${var.asg_max_size}"
   asg_min_size                  = "${var.asg_min_size}"
   asg_desired_capacity          = "${var.asg_desired_capacity}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 module "alarms-elb-search-internal" {

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -94,6 +94,7 @@ module "transition-db-admin" {
   asg_max_size                  = "1"
   asg_min_size                  = "1"
   asg_desired_capacity          = "1"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
   root_block_device_volume_size = "64"
 }
 

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -201,6 +201,7 @@ module "whitehall-backend" {
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 module "alarms-elb-whitehall-backend-internal" {

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -118,6 +118,7 @@ module "whitehall-frontend" {
   asg_max_size                  = "2"
   asg_min_size                  = "2"
   asg_desired_capacity          = "2"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_alerts_arn}"
 }
 
 module "alarms-elb-whitehall-frontend-internal" {


### PR DESCRIPTION
Add AutoScaling Group notifications to the node_group module.
This is enabled by default, and requires the SNS alerts topic ARN. We
need to update all the app-* projects with the `asg_notification_topic_arn`
parameter before merging this change.