### PR TITLE
Upgrade cache machines with more memory

### DIFF
--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -230,7 +230,7 @@ module "cache" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "cache", "aws_hostname", "cache-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_cache_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "m4.large"
   create_instance_key           = true
   instance_key_name             = "${var.stackname}-cache"
   instance_public_key           = "${var.ssh_public_key}"


### PR DESCRIPTION
The cache nodes are pretty important as they service all frontend traffic coming into our stack. After enabling traffic relay, I've seen alerts come through about memory usage. While Varnish should use an amount of memory for caching, the cache instances also run services such as NGINX and Router, and so we need to ensure we don't starve anything else of memory.

This also puts the cache instances in line with the memory size in the current integration environment.