### PR TITLE
Add variable to disable Puppetmaster bootstrap ELB

### DIFF
--- a/doc/guides/environment-provisioning.md
+++ b/doc/guides/environment-provisioning.md
@@ -119,13 +119,13 @@ region  = "<region>"
 
 Puppet master is provisioned similarly to other Terraform projects but you'll need to make sure that you set the `ssh_public_key` value in `common/<environment>/<stack name>.tfvars` to the public portion of a key that you have the private portion of.
 
-Now run
+When you run the Terraform below, explicitly setting the `enable_bootstrap` variable will create an ELB which will allow you to SSH to the Puppetmaster.
 
 ```
 # Make sure STACKNAME & ENVIRONMENT are set
-tools/build-terraform-project.sh -c plan -p app-puppetmaster
+tools/build-terraform-project.sh -c plan -p app-puppetmaster -- -var 'enable_bootstrap=true'
 ...terraform output...
-tools/build-terraform-project.sh -c apply -p app-puppetmaster
+tools/build-terraform-project.sh -c apply -p app-puppetmaster -- -var 'enable_bootstrap=true'
 ...terraform output...
 ```
 
@@ -178,6 +178,17 @@ Notice: Compiled catalog for ip-10-1-2-123.eu-west-1.compute.internal in environ
 Notice: hello world
 Notice: /Stage[main]/Main/Notify[hello world]/message: defined 'message' as 'hello world'
 Notice: Finished catalog run in 0.01 seconds
+```
+
+## Remove the Puppetmaster bootstrap ELB
+
+Run the Terraform again for the Puppetmaster, but removing the variable should destroy the load balancer and security group.
+
+```
+tools/build-terraform-project.sh -c plan -p app-puppetmaster
+...terraform output...
+tools/build-terraform-project.sh -c apply -p app-puppetmaster
+...terraform output...
 ```
 
 ## Build the deploy Jenkins

--- a/terraform/projects/app-puppetmaster/README.md
+++ b/terraform/projects/app-puppetmaster/README.md
@@ -9,6 +9,7 @@ Puppetmaster node
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| enable_bootstrap | Whether to create the ELB which allows a user to SSH to the Puppetmaster from the office | string | `false` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -30,6 +30,12 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
+variable "enable_bootstrap" {
+  type        = "string"
+  description = "Whether to create the ELB which allows a user to SSH to the Puppetmaster from the office"
+  default     = false
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -43,6 +49,7 @@ provider "aws" {
 }
 
 resource "aws_elb" "puppetmaster_bootstrap_elb" {
+  count           = "${var.enable_bootstrap}"
   name            = "${var.stackname}-puppetmaster-bootstrap"
   subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_offsite_ssh_id}"]
@@ -80,6 +87,7 @@ resource "aws_elb" "puppetmaster_bootstrap_elb" {
 }
 
 resource "aws_security_group_rule" "puppetmaster_from_elb_in_22" {
+  count                    = "${var.enable_bootstrap}"
   type                     = "ingress"
   from_port                = "22"
   to_port                  = "22"


### PR DESCRIPTION
When browsing the puppetmaster manifest I thought it might easy enough to add in a variable which defaults to having no bootstrap ELB, but upon deployment we can set the var to true.

The story (referenced below) suggests that we should entirely extract the bootstrap ELB into it's own module. Personally this feels like overkill, and Terraform should be able to handle creating/destroy an ELB without issue. However, I am not aware of the context when the story was created so there may be something I'm not aware of.

https://trello.com/c/yDjFSzOX/652-aws-migration-refactor-puppetmaster-bootstrap