### PR TITLE
Allow monitoring to speak to Puppetdb

### DIFF
--- a/terraform/projects/infra-security-groups/puppetmaster.tf
+++ b/terraform/projects/infra-security-groups/puppetmaster.tf
@@ -35,6 +35,19 @@ resource "aws_security_group_rule" "allow_puppet_elb_in" {
   source_security_group_id = "${aws_security_group.puppetmaster_elb.id}"
 }
 
+resource "aws_security_group_rule" "allow_puppetdb_elb_in" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.puppetmaster.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.puppetmaster_elb.id}"
+}
+
 resource "aws_security_group" "puppetmaster_elb" {
   name        = "${var.stackname}_puppetmaster_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
@@ -53,6 +66,16 @@ resource "aws_security_group_rule" "allow_management_to_puppet" {
 
   security_group_id        = "${aws_security_group.puppetmaster_elb.id}"
   source_security_group_id = "${aws_security_group.management.id}"
+}
+
+resource "aws_security_group_rule" "allow_monitoring_to_puppetdb" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id        = "${aws_security_group.puppetmaster_elb.id}"
+  source_security_group_id = "${aws_security_group.monitoring.id}"
 }
 
 # TODO test whether egress rules are needed on ELBs


### PR DESCRIPTION
Someone had already added a DNS record for puppetdb, but we didn't allow anything to access it.

We have a check which specifically uses puppetdb to check what nodes require rebooting, and this is always run from the monitoring instance.

For now, only allow that instance access, and if we wish to open it up in the future (to make it accessible with our fabric scripts, for example), then we can do so.