### PR TITLE
Set copy_tags_to_snapshot to true by default for RDS databases

### DIFF
--- a/terraform/modules/aws/rds_instance/README.md
+++ b/terraform/modules/aws/rds_instance/README.md
@@ -29,6 +29,7 @@ Create an RDS instance
 | storage_type | One of standard (magnetic), gp2 (general purpose SSD), or io1 (provisioned IOPS SSD). The default is gp2 | string | `gp2` | no |
 | subnet_ids | Subnet IDs to assign to the aws_elasticache_subnet_group | list | `<list>` | no |
 | username | User to create on the database | string | `` | no |
+| copy_tags_to_snapshot | Whether to copy the instance tags to the snapshot. | string | `true` | no
 
 ## Outputs
 

--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -140,6 +140,12 @@ variable "event_sns_topic_arn" {
   default     = ""
 }
 
+variable "copy_tags_to_snapshot" {
+  type        = "string"
+  description = "Whether to copy the instance tags to the snapshot."
+  default     = "true"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -188,6 +194,7 @@ resource "aws_db_instance" "db_instance" {
   maintenance_window      = "${var.maintenance_window}"
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"
+  copy_tags_to_snapshot   = "${var.copy_tags_to_snapshot}"
 
   # TODO this should be enabled in a Production environment:
   final_snapshot_identifier = "${var.name}-final-snapshot"


### PR DESCRIPTION
- This is so that we can tell which database snapshot we want to
  restore, without having to write a script that queries the
  DBInstanceID, finds out its tags, and matches them up to the snapshot
  ID.