### PR TITLE
Increate the RDS alarm replicalag_threshold

### DIFF
--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -140,7 +140,7 @@ module "alarms-rds-mysql-replica" {
   name_prefix          = "${var.stackname}-mysql-replica"
   alarm_actions        = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
   db_instance_id       = "${module.mysql_replica_rds_instance.rds_replica_id}"
-  replicalag_threshold = "120"
+  replicalag_threshold = "300"
 }
 
 module "mysql_replica_log_exporter" {

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -116,7 +116,7 @@ module "alarms-rds-postgresql-standby" {
   name_prefix          = "${var.stackname}-postgresql-standby"
   alarm_actions        = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
   db_instance_id       = "${module.postgresql-standby_rds_instance.rds_replica_id}"
-  replicalag_threshold = "120"
+  replicalag_threshold = "300"
 }
 
 module "postgresql-primary_log_exporter" {

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -116,7 +116,7 @@ module "alarms-rds-transition-postgresql-standby" {
   name_prefix          = "${var.stackname}-transition-postgresql-standby"
   alarm_actions        = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
   db_instance_id       = "${module.transition-postgresql-standby_rds_instance.rds_replica_id}"
-  replicalag_threshold = "120"
+  replicalag_threshold = "300"
 }
 
 module "transition-postgresql-primary_log_exporter" {


### PR DESCRIPTION
Replica lag can spike to up to 300 secs, we are getting
alarms all the time.