### PR TITLE
infra-root-dns-zones add domain outputs

### DIFF
--- a/terraform/projects/infra-root-dns-zones/README.md
+++ b/terraform/projects/infra-root-dns-zones/README.md
@@ -20,6 +20,8 @@ This module creates the internal and external root DNS zones.
 
 | Name | Description |
 |------|-------------|
+| external_root_domain_name | Route53 External Root Domain Name |
 | external_root_zone_id | Route53 External Root Zone ID |
-| internal_root_zone_id | Outputs -------------------------------------------------------------- |
+| internal_root_domain_name | Route53 Internal Root Domain Name |
+| internal_root_zone_id | Route53 Internal Root Zone ID |
 

--- a/terraform/projects/infra-root-dns-zones/main.tf
+++ b/terraform/projects/infra-root-dns-zones/main.tf
@@ -92,12 +92,23 @@ resource "aws_route53_zone" "external_zone" {
 
 # Outputs
 # --------------------------------------------------------------
+
 output "internal_root_zone_id" {
   value       = "${aws_route53_zone.internal_zone.zone_id}"
   description = "Route53 Internal Root Zone ID"
 }
 
+output "internal_root_domain_name" {
+  value       = "${aws_route53_zone.internal_zone.name}"
+  description = "Route53 Internal Root Domain Name"
+}
+
 output "external_root_zone_id" {
   value       = "${aws_route53_zone.external_zone.zone_id}"
   description = "Route53 External Root Zone ID"
+}
+
+output "external_root_domain_name" {
+  value       = "${aws_route53_zone.external_zone.name}"
+  description = "Route53 External Root Domain Name"
 }


### PR DESCRIPTION
Add internal and external domain name output to infra-root-dns-zones
to use with new root domain DNS entries.