### PR TITLE
Fix whitehall-frontend LB subnet

### DIFF
--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -54,7 +54,7 @@ data "aws_acm_certificate" "elb_cert" {
 
 resource "aws_elb" "whitehall-frontend_elb" {
   name            = "${var.stackname}-whitehall-frontend"
-  subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-frontend_elb_id}"]
   internal        = "true"
 


### PR DESCRIPTION
The subnet should be private, as the rest of the ELB.