### PR TITLE
Add bouncer internal LB for monitoring

### DIFF
--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -38,6 +38,10 @@ output "sg_backend-redis_id" {
   value = "${aws_security_group.backend-redis.id}"
 }
 
+output "sg_bouncer_internal_elb_id" {
+  value = "${aws_security_group.bouncer_internal_elb.id}"
+}
+
 output "sg_bouncer_elb_id" {
   value = "${aws_security_group.bouncer_elb.id}"
 }


### PR DESCRIPTION
Smokey tests are failing when trying to connect with bouncer:

```
2017-12-08 17:50:27: Step: [FAIL] When I request "http://www.attorneygeneral.gov.uk" from Bouncer directly
2017-12-08 17:50:27: Error: Unable to fetch 'https://bouncer.blue.integration.govuk.digital/'
```

Currently Bouncer only allow external access from replay traffic and
Fastly IPs, and we don't want to open it to the entire public. So in
order to have the Smokey tests working, we need to enable internal access
from monitoring to Bouncer, and update the app domain in the Smokey
test to use the internal one.