### PR TITLE
Add root-dns to remote-state

### DIFF
--- a/terraform/projects/app-apt/remote_state.tf
+++ b/terraform/projects/app-apt/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-asset-master/remote_state.tf
+++ b/terraform/projects/app-asset-master/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-backend-redis/remote_state.tf
+++ b/terraform/projects/app-backend-redis/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-backend/remote_state.tf
+++ b/terraform/projects/app-backend/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-bouncer/remote_state.tf
+++ b/terraform/projects/app-bouncer/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-cache/remote_state.tf
+++ b/terraform/projects/app-cache/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-calculators-frontend/remote_state.tf
+++ b/terraform/projects/app-calculators-frontend/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-content-store/remote_state.tf
+++ b/terraform/projects/app-content-store/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-db-admin/remote_state.tf
+++ b/terraform/projects/app-db-admin/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-deploy/remote_state.tf
+++ b/terraform/projects/app-deploy/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-docker-management/remote_state.tf
+++ b/terraform/projects/app-docker-management/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-draft-cache/remote_state.tf
+++ b/terraform/projects/app-draft-cache/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-draft-content-store/remote_state.tf
+++ b/terraform/projects/app-draft-content-store/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-draft-frontend/remote_state.tf
+++ b/terraform/projects/app-draft-frontend/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-frontend/remote_state.tf
+++ b/terraform/projects/app-frontend/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-graphite/remote_state.tf
+++ b/terraform/projects/app-graphite/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-jumpbox/remote_state.tf
+++ b/terraform/projects/app-jumpbox/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-logs-cdn/remote_state.tf
+++ b/terraform/projects/app-logs-cdn/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mapit/remote_state.tf
+++ b/terraform/projects/app-mapit/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mirrorer/remote_state.tf
+++ b/terraform/projects/app-mirrorer/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mongo/remote_state.tf
+++ b/terraform/projects/app-mongo/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-monitoring/remote_state.tf
+++ b/terraform/projects/app-monitoring/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-mysql/remote_state.tf
+++ b/terraform/projects/app-mysql/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-postgresql/remote_state.tf
+++ b/terraform/projects/app-postgresql/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-publishing-api/remote_state.tf
+++ b/terraform/projects/app-publishing-api/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-puppetmaster/remote_state.tf
+++ b/terraform/projects/app-puppetmaster/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-rabbitmq/remote_state.tf
+++ b/terraform/projects/app-rabbitmq/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-router-backend/remote_state.tf
+++ b/terraform/projects/app-router-backend/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-rummager-elasticsearch/remote_state.tf
+++ b/terraform/projects/app-rummager-elasticsearch/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-search/remote_state.tf
+++ b/terraform/projects/app-search/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-transition-db-admin/remote_state.tf
+++ b/terraform/projects/app-transition-db-admin/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-transition-postgresql/remote_state.tf
+++ b/terraform/projects/app-transition-postgresql/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-whitehall-backend/remote_state.tf
+++ b/terraform/projects/app-whitehall-backend/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/app-whitehall-frontend/remote_state.tf
+++ b/terraform/projects/app-whitehall-frontend/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -20,12 +20,6 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
-variable "remote_state_infra_root_dns_zones_key_stack" {
-  type        = "string"
-  description = "Override stackname path to infra_root_dns_zones remote state "
-  default     = ""
-}
-
 variable "elb_public_certname" {
   type        = "string"
   description = "The ACM cert domain name to find the ARN of"
@@ -125,16 +119,6 @@ terraform {
 provider "aws" {
   region  = "${var.aws_region}"
   version = "1.3.0"
-}
-
-data "terraform_remote_state" "infra_root_dns_zones" {
-  backend = "s3"
-
-  config {
-    bucket = "${var.remote_state_bucket}"
-    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
-  }
 }
 
 #

--- a/terraform/projects/infra-public-services/remote_state.tf
+++ b/terraform/projects/infra-public-services/remote_state.tf
@@ -29,9 +29,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -70,6 +76,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }

--- a/tools/generate-remote-state-boiler-plate.sh
+++ b/tools/generate-remote-state-boiler-plate.sh
@@ -41,9 +41,15 @@ variable "remote_state_infra_security_groups_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_vpc remote state "
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
@@ -82,6 +88,16 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "eu-west-1"
   }
 }


### PR DESCRIPTION
In order to add stack entries to the root domain, we need to import
the remote state file in the projects.