### PR TITLE
Update elasticache_redis_cluster module for 0.11.1

### DIFF
--- a/terraform/modules/aws/elasticache_redis_cluster/main.tf
+++ b/terraform/modules/aws/elasticache_redis_cluster/main.tf
@@ -88,12 +88,12 @@ resource "aws_elasticache_replication_group" "redis_master_with_replica" {
 
 // Configuration endpoint address of the redis cluster.
 output "configuration_endpoint_address" {
-  value       = "${var.enable_clustering > 0 ? join("", aws_elasticache_replication_group.redis_cluster.*.configuration_endpoint_address) : aws_elasticache_replication_group.redis_master_with_replica.*.primary_endpoint_address}"
+  value       = "${var.enable_clustering > 0 ? join("", aws_elasticache_replication_group.redis_cluster.*.configuration_endpoint_address) : join("", aws_elasticache_replication_group.redis_master_with_replica.*.primary_endpoint_address)}"
   description = "Configuration endpoint address of the redis cluster."
 }
 
 // The ID of the ElastiCache Replication Group.
 output "replication_group_id" {
-  value       = "${var.enable_clustering > 0 ? aws_elasticache_replication_group.redis_cluster.0.id : aws_elasticache_replication_group.redis_master_with_replica.*.id}"
+  value       = "${var.enable_clustering > 0 ? join("", aws_elasticache_replication_group.redis_cluster.*.id) : join("", aws_elasticache_replication_group.redis_master_with_replica.*.id)}"
   description = "The ID of the ElastiCache Replication Group."
 }


### PR DESCRIPTION
The module shows errors when evaluating the conditional in the output
resources. Both vals of the conditional need to be of the same type,
currently they are string and list. Also, match the format of the
output _id resource.