### PR TITLE
Add root DNS records for app services

### DIFF
--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -237,7 +237,7 @@ output "service_dns_name_internal" {
 }
 
 output "app_service_records_internal_dns_name" {
-  value       = "${aws_route53_record.app_service_records_internal.name}"
+  value       = "${aws_route53_record.app_service_records_internal.*.name}"
   description = "DNS name to access the app service records"
 }
 
@@ -252,6 +252,6 @@ output "service_dns_name_external" {
 }
 
 output "app_service_records_external_dns_name" {
-  value       = "${aws_route53_record.app_service_records_external.name}"
+  value       = "${aws_route53_record.app_service_records_external.*.name}"
   description = "DNS name to access the app service records"
 }

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -217,7 +217,7 @@ output "puppetmaster_internal_elb_dns_name" {
 }
 
 output "puppetmaster_bootstrap_elb_dns_name" {
-  value       = "${aws_elb.puppetmaster_bootstrap_elb.dns_name}"
+  value       = "${join("", aws_elb.puppetmaster_bootstrap_elb.*.dns_name)}"
   description = "DNS name to access the puppetmaster bootstrap service"
 }
 

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -1,28 +1,59 @@
 ## Project: infra-public-services
 
-This project adds public facing LBs and DNS entries
-for the app components of the infrastructure
+This project adds global resources for app components:
+  - public facing LBs and DNS entries
+  - internal DNS entries
+
 
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| apt_public_service_cnames | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| apt_public_service_names | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
+| apt_internal_service_names |  | list | `<list>` | no |
+| apt_public_service_cnames |  | list | `<list>` | no |
+| apt_public_service_names |  | list | `<list>` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
-| backend_public_service_cnames | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| backend_public_service_names | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| bouncer_public_service_names | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| cache_public_service_cnames | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| cache_public_service_names | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| deploy_public_service_names | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
+| backend_internal_service_cnames |  | list | `<list>` | no |
+| backend_internal_service_names |  | list | `<list>` | no |
+| backend_public_service_cnames |  | list | `<list>` | no |
+| backend_public_service_names |  | list | `<list>` | no |
+| backend_redis_internal_service_names |  | list | `<list>` | no |
+| bouncer_internal_service_names |  | list | `<list>` | no |
+| bouncer_public_service_names |  | list | `<list>` | no |
+| cache_internal_service_cnames |  | list | `<list>` | no |
+| cache_internal_service_names |  | list | `<list>` | no |
+| cache_public_service_cnames |  | list | `<list>` | no |
+| cache_public_service_names |  | list | `<list>` | no |
+| calculators_frontend_internal_service_cnames |  | list | `<list>` | no |
+| calculators_frontend_internal_service_names |  | list | `<list>` | no |
+| content_store_internal_service_names |  | list | `<list>` | no |
+| db_admin_internal_service_names |  | list | `<list>` | no |
+| deploy_internal_service_names |  | list | `<list>` | no |
+| deploy_public_service_names |  | list | `<list>` | no |
+| docker_management_internal_service_names |  | list | `<list>` | no |
+| draft_cache_internal_service_cnames |  | list | `<list>` | no |
+| draft_cache_internal_service_names |  | list | `<list>` | no |
+| draft_content_store_internal_service_names |  | list | `<list>` | no |
+| draft_frontend_internal_service_cnames |  | list | `<list>` | no |
+| draft_frontend_internal_service_names |  | list | `<list>` | no |
 | elb_public_certname | The ACM cert domain name to find the ARN of | string | - | yes |
-| graphite_public_service_names | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| jumpbox_public_service_names | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| logs_cdn_public_service_names | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| monitoring_public_service_names | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
+| frontend_internal_service_cnames |  | list | `<list>` | no |
+| frontend_internal_service_names |  | list | `<list>` | no |
+| graphite_internal_service_names |  | list | `<list>` | no |
+| graphite_public_service_names |  | list | `<list>` | no |
+| jumpbox_public_service_names |  | list | `<list>` | no |
+| logs_cdn_public_service_names |  | list | `<list>` | no |
+| mapit_internal_service_names |  | list | `<list>` | no |
+| mongo_internal_service_names |  | list | `<list>` | no |
+| monitoring_internal_service_names |  | list | `<list>` | no |
+| monitoring_public_service_names |  | list | `<list>` | no |
+| mysql_internal_service_names |  | list | `<list>` | no |
+| postgresql_internal_service_names |  | list | `<list>` | no |
+| publishing_api_internal_service_names |  | list | `<list>` | no |
+| puppetmaster_internal_service_names |  | list | `<list>` | no |
+| rabbitmq_internal_service_names |  | list | `<list>` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
@@ -30,7 +61,8 @@ for the app components of the infrastructure
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| router_backend_internal_service_names |  | list | `<list>` | no |
 | stackname | Stackname | string | - | yes |
-| whitehall_backend_public_service_cnames | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| whitehall_backend_public_service_names | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
+| whitehall_backend_public_service_cnames |  | list | `<list>` | no |
+| whitehall_backend_public_service_names |  | list | `<list>` | no |
 

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1,8 +1,10 @@
 /**
 * ## Project: infra-public-services
 *
-* This project adds public facing LBs and DNS entries
-* for the app components of the infrastructure
+* This project adds global resources for app components:
+*   - public facing LBs and DNS entries
+*   - internal DNS entries
+* 
 */
 variable "aws_region" {
   type        = "string"
@@ -26,87 +28,263 @@ variable "elb_public_certname" {
 }
 
 variable "apt_public_service_names" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
 }
 
 variable "apt_public_service_cnames" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
 }
 
 variable "backend_public_service_names" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
 }
 
 variable "backend_public_service_cnames" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
 }
 
 variable "bouncer_public_service_names" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
 }
 
 variable "cache_public_service_names" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
 }
 
 variable "cache_public_service_cnames" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
 }
 
 variable "deploy_public_service_names" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
 }
 
 variable "graphite_public_service_names" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
 }
 
 variable "jumpbox_public_service_names" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
 }
 
 variable "logs_cdn_public_service_names" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
 }
 
 variable "monitoring_public_service_names" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
 }
 
 variable "whitehall_backend_public_service_names" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
 }
 
 variable "whitehall_backend_public_service_cnames" {
-  type        = "list"
-  description = "List of application service names that get traffic via this loadbalancer"
-  default     = []
+  type    = "list"
+  default = []
+}
+
+variable "apt_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "backend_redis_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "backend_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "backend_internal_service_cnames" {
+  type    = "list"
+  default = []
+}
+
+variable "bouncer_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "cache_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "cache_internal_service_cnames" {
+  type    = "list"
+  default = []
+}
+
+variable "calculators_frontend_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "calculators_frontend_internal_service_cnames" {
+  type    = "list"
+  default = []
+}
+
+variable "content_store_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "db_admin_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "deploy_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "docker_management_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "draft_cache_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "draft_cache_internal_service_cnames" {
+  type    = "list"
+  default = []
+}
+
+variable "draft_content_store_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "draft_frontend_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "draft_frontend_internal_service_cnames" {
+  type    = "list"
+  default = []
+}
+
+variable "frontend_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "frontend_internal_service_cnames" {
+  type    = "list"
+  default = []
+}
+
+variable "graphite_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "mapit_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "mongo_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "monitoring_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "mysql_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "postgresql_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "publishing_api_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "puppetmaster_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "rabbitmq_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "router_backend_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "rummager_elasticsearch_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "search_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "search_internal_service_cnames" {
+  type    = "list"
+  default = []
+}
+
+variable "transition_db_admin_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "transition_postgresql_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "whitehall_backend_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "whitehall_backend_internal_service_cnames" {
+  type    = "list"
+  default = []
+}
+
+variable "whitehall_frontend_internal_service_names" {
+  type    = "list"
+  default = []
 }
 
 # Resources
@@ -122,8 +300,30 @@ provider "aws" {
 }
 
 #
-# Apt: TODO
+# Apt: TODO EXTERNAL
 #
+
+resource "aws_route53_record" "apt_internal_service_names" {
+  count   = "${length(var.apt_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.apt_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.apt_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# Backend-redis
+#
+
+resource "aws_route53_record" "backend_redis_internal_service_names" {
+  count   = "${length(var.backend_redis_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.backend_redis_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.backend_redis_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
 
 #
 # Backend
@@ -183,6 +383,24 @@ resource "aws_autoscaling_attachment" "backend_asg_attachment_alb" {
   alb_target_group_arn   = "${element(module.backend_public_lb.target_group_arns, 0)}"
 }
 
+resource "aws_route53_record" "backend_internal_service_names" {
+  count   = "${length(var.backend_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.backend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.backend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+resource "aws_route53_record" "backend_internal_service_cnames" {
+  count   = "${length(var.backend_internal_service_cnames)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.backend_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.backend_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
 #
 # Bouncer
 #
@@ -230,6 +448,15 @@ data "aws_autoscaling_groups" "bouncer" {
 resource "aws_autoscaling_attachment" "bouncer_asg_attachment_alb" {
   autoscaling_group_name = "${element(data.aws_autoscaling_groups.bouncer.names, 0)}"
   alb_target_group_arn   = "${element(module.bouncer_public_lb.target_group_arns, 0)}"
+}
+
+resource "aws_route53_record" "bouncer_internal_service_names" {
+  count   = "${length(var.bouncer_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.bouncer_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.bouncer_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
 }
 
 #
@@ -290,6 +517,66 @@ resource "aws_autoscaling_attachment" "cache_asg_attachment_alb" {
   alb_target_group_arn   = "${element(module.cache_public_lb.target_group_arns, 0)}"
 }
 
+resource "aws_route53_record" "cache_internal_service_names" {
+  count   = "${length(var.cache_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.cache_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.cache_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+resource "aws_route53_record" "cache_internal_service_cnames" {
+  count   = "${length(var.cache_internal_service_cnames)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.cache_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.cache_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+# Calculators-frontend
+
+resource "aws_route53_record" "calculators_frontend_internal_service_names" {
+  count   = "${length(var.calculators_frontend_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.calculators_frontend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.calculators_frontend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+resource "aws_route53_record" "calculators_frontend_internal_service_cnames" {
+  count   = "${length(var.calculators_frontend_internal_service_cnames)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.calculators_frontend_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.calculators_frontend_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+# Content-store
+
+resource "aws_route53_record" "content_store_internal_service_names" {
+  count   = "${length(var.content_store_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.content_store_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.content_store_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+# Db-admin
+
+resource "aws_route53_record" "db_admin_internal_service_names" {
+  count   = "${length(var.db_admin_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.db_admin_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.db_admin_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
 # Deploy
 
 module "deploy_public_lb" {
@@ -337,9 +624,106 @@ resource "aws_autoscaling_attachment" "deploy_asg_attachment_alb" {
   alb_target_group_arn   = "${element(module.deploy_public_lb.target_group_arns, 0)}"
 }
 
+resource "aws_route53_record" "deploy_internal_service_names" {
+  count   = "${length(var.deploy_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.deploy_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.deploy_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
 #
-# Draft-cache ?????
+# Docker-management
 #
+
+resource "aws_route53_record" "docker_management_internal_service_names" {
+  count   = "${length(var.docker_management_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.docker_management_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.docker_management_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# Draft-cache DOES IT NEED EXTERNAL?
+#
+
+resource "aws_route53_record" "draft_cache_internal_service_names" {
+  count   = "${length(var.draft_cache_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.draft_cache_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.draft_cache_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+resource "aws_route53_record" "draft_cache_internal_service_cnames" {
+  count   = "${length(var.draft_cache_internal_service_cnames)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.draft_cache_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.draft_cache_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# Draft-content-store
+#
+
+resource "aws_route53_record" "draft_content_store_internal_service_names" {
+  count   = "${length(var.draft_content_store_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.draft_content_store_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.draft_content_store_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# Draft-frontend
+#
+
+resource "aws_route53_record" "draft_frontend_internal_service_names" {
+  count   = "${length(var.draft_frontend_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.draft_frontend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.draft_frontend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+resource "aws_route53_record" "draft_frontend_internal_service_cnames" {
+  count   = "${length(var.draft_frontend_internal_service_cnames)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.draft_frontend_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.draft_frontend_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# frontend
+#
+
+resource "aws_route53_record" "frontend_internal_service_names" {
+  count   = "${length(var.frontend_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.frontend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.frontend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+resource "aws_route53_record" "frontend_internal_service_cnames" {
+  count   = "${length(var.frontend_internal_service_cnames)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.frontend_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.frontend_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
 
 #
 # Graphite
@@ -388,6 +772,15 @@ data "aws_autoscaling_groups" "graphite" {
 resource "aws_autoscaling_attachment" "graphite_asg_attachment_alb" {
   autoscaling_group_name = "${element(data.aws_autoscaling_groups.graphite.names, 0)}"
   alb_target_group_arn   = "${element(module.graphite_public_lb.target_group_arns, 0)}"
+}
+
+resource "aws_route53_record" "graphite_internal_service_names" {
+  count   = "${length(var.graphite_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.graphite_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.graphite_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
 }
 
 #
@@ -509,6 +902,32 @@ resource "aws_autoscaling_attachment" "logs_cdn_asg_attachment_alb" {
 }
 
 #
+# Mapit
+#
+
+resource "aws_route53_record" "mapit_internal_service_names" {
+  count   = "${length(var.mapit_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.mapit_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.mapit_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# Mongo
+#
+
+resource "aws_route53_record" "mongo_internal_service_names" {
+  count   = "${length(var.mongo_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.mongo_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.mongo_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
 # Monitoring
 #
 
@@ -555,6 +974,154 @@ data "aws_autoscaling_groups" "monitoring" {
 resource "aws_autoscaling_attachment" "monitoring_asg_attachment_alb" {
   autoscaling_group_name = "${element(data.aws_autoscaling_groups.monitoring.names, 0)}"
   alb_target_group_arn   = "${element(module.monitoring_public_lb.target_group_arns, 0)}"
+}
+
+resource "aws_route53_record" "monitoring_internal_service_names" {
+  count   = "${length(var.monitoring_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.monitoring_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.monitoring_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# Mysql
+#
+
+resource "aws_route53_record" "mysql_internal_service_names" {
+  count   = "${length(var.mysql_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.mysql_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.mysql_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# postgresql
+#
+
+resource "aws_route53_record" "postgresql_internal_service_names" {
+  count   = "${length(var.postgresql_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.postgresql_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.postgresql_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# publishing_api
+#
+
+resource "aws_route53_record" "publishing_api_internal_service_names" {
+  count   = "${length(var.publishing_api_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.publishing_api_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.publishing_api_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# puppetmaster
+#
+
+resource "aws_route53_record" "puppetmaster_internal_service_names" {
+  count   = "${length(var.puppetmaster_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.puppetmaster_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.puppetmaster_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# rabbitmq
+#
+
+resource "aws_route53_record" "rabbitmq_internal_service_names" {
+  count   = "${length(var.rabbitmq_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.rabbitmq_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.rabbitmq_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# router_backend
+#
+
+resource "aws_route53_record" "router_backend_internal_service_names" {
+  count   = "${length(var.router_backend_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.router_backend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.router_backend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# rummager_elasticsearch
+#
+
+resource "aws_route53_record" "rummager_elasticsearch_internal_service_names" {
+  count   = "${length(var.rummager_elasticsearch_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.rummager_elasticsearch_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.rummager_elasticsearch_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# search
+#
+
+resource "aws_route53_record" "search_internal_service_names" {
+  count   = "${length(var.search_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.search_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.search_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+resource "aws_route53_record" "search_internal_service_cnames" {
+  count   = "${length(var.search_internal_service_cnames)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.search_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.search_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# transition_db_admin
+#
+
+resource "aws_route53_record" "transition_db_admin_internal_service_names" {
+  count   = "${length(var.transition_db_admin_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.transition_db_admin_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.transition_db_admin_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# transition_postgresql
+#
+
+resource "aws_route53_record" "transition_postgresql_internal_service_names" {
+  count   = "${length(var.transition_postgresql_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.transition_postgresql_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.transition_postgresql_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
 }
 
 #
@@ -613,4 +1180,35 @@ data "aws_autoscaling_groups" "whitehall_backend" {
 resource "aws_autoscaling_attachment" "whitehall_backend_asg_attachment_alb" {
   autoscaling_group_name = "${element(data.aws_autoscaling_groups.whitehall_backend.names, 0)}"
   alb_target_group_arn   = "${element(module.whitehall_backend_public_lb.target_group_arns, 0)}"
+}
+
+resource "aws_route53_record" "whitehall_backend_internal_service_names" {
+  count   = "${length(var.whitehall_backend_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.whitehall_backend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.whitehall_backend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+resource "aws_route53_record" "whitehall_backend_internal_service_cnames" {
+  count   = "${length(var.whitehall_backend_internal_service_cnames)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.whitehall_backend_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.whitehall_backend_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# whitehall_frontend
+#
+
+resource "aws_route53_record" "whitehall_frontend_internal_service_names" {
+  count   = "${length(var.whitehall_frontend_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.whitehall_frontend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.whitehall_frontend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
 }


### PR DESCRIPTION
Add `.integration.govuk-internal.digital` CNAMES to blue stack for
app records.