### PR TITLE
Require the passwords to meet a minimum criteria

### DIFF
--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -70,3 +70,12 @@ module "role_user" {
   role_user_arns   = ["${var.role_user_user_arns}"]
   role_policy_arns = ["${var.role_user_policy_arns}"]
 }
+
+resource "aws_iam_account_password_policy" "tighten_passwords" {
+  allow_users_to_change_password = true
+  minimum_password_length        = 12
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_symbols                = true
+  require_uppercase_characters   = true
+}


### PR DESCRIPTION
This helps stop people using simple passwords and complies with the CIS
security docs (and scanners). We previously had everything apart from upper and special characters set so this is a little tighter.

This could have a param for each of those but I don't think we need that at this time.