### PR TITLE
Update module rds_instance 0.11.1

### DIFF
--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -244,33 +244,33 @@ resource "aws_db_event_subscription" "event_subscription_replica" {
 #
 
 output "rds_instance_id" {
-  value = "${aws_db_instance.db_instance.id}"
+  value = "${join("", aws_db_instance.db_instance.*.id)}"
 }
 
 output "rds_replica_id" {
-  value = "${aws_db_instance.db_instance_replica.id}"
+  value = "${join("", aws_db_instance.db_instance_replica.*.id)}"
 }
 
 output "rds_instance_resource_id" {
-  value = "${aws_db_instance.db_instance.resource_id}"
+  value = "${join("", aws_db_instance.db_instance.*.resource_id)}"
 }
 
 output "rds_replica_resource_id" {
-  value = "${aws_db_instance.db_instance_replica.resource_id}"
+  value = "${join("", aws_db_instance.db_instance_replica.*.resource_id)}"
 }
 
 output "rds_instance_endpoint" {
-  value = "${aws_db_instance.db_instance.endpoint}"
+  value = "${join("", aws_db_instance.db_instance.*.endpoint)}"
 }
 
 output "rds_replica_endpoint" {
-  value = "${aws_db_instance.db_instance_replica.endpoint}"
+  value = "${join("", aws_db_instance.db_instance_replica.*.endpoint)}"
 }
 
 output "rds_instance_address" {
-  value = "${aws_db_instance.db_instance.address}"
+  value = "${join("", aws_db_instance.db_instance.*.address)}"
 }
 
 output "rds_replica_address" {
-  value = "${aws_db_instance.db_instance_replica.address}"
+  value = "${join("", aws_db_instance.db_instance_replica.*.address)}"
 }


### PR DESCRIPTION
Fix splat syntax warnings:

```
Warning: output "rds_replica_resource_id": must use splat syntax to access aws_db_instance.db_instance_replica attribute "resource_id", because it has "count" set; use aws_db_instance.db_instance_replica.*.resource_id to obtain a list of the attributes across all instances
```

Ensure the output is type string by using `join`. The output is used as variable in
other parts of the code and it's already expecting a string (not list).