### PR TITLE
Remove stackname from search domain

### DIFF
--- a/terraform/userdata/00-base
+++ b/terraform/userdata/00-base
@@ -52,15 +52,14 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: install Puppet ..."
 apt-get -y install make ruby1.9.3 puppet='3.8.*' puppet-common='3.8.*'
 service puppet stop
 
-echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: add search domain for local stack ..."
-F_STACKNAME=$(facter aws_stackname)
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: add search domains ..."
 F_AWS_ENVIRONMENT=$(facter aws_environment)
-if [[ -z $F_STACKNAME ]] || [[ -z $F_AWS_ENVIRONMENT ]] ; then
-  echo "ERROR aws_stackname is null"
+if [[ -z $F_AWS_ENVIRONMENT ]] ; then
+  echo "ERROR aws_environment is null"
 else
-  echo "append domain-search \""$F_STACKNAME"."$F_AWS_ENVIRONMENT".govuk-internal.digital\", \""$F_AWS_ENVIRONMENT".govuk-internal.digital\", \"govuk-internal.digital\";" >> /etc/dhcp/dhclient.conf
+  echo "append domain-search \""$F_AWS_ENVIRONMENT".govuk-internal.digital\", \"govuk-internal.digital\";" >> /etc/dhcp/dhclient.conf
   dhclient -r; dhclient
-  echo "search "$F_STACKNAME"."$F_AWS_ENVIRONMENT".govuk-internal.digital "$F_AWS_ENVIRONMENT".govuk-internal.digital govuk-internal.digital" >> /etc/resolvconf/resolv.conf.d/base
+  echo "search "$F_AWS_ENVIRONMENT".govuk-internal.digital govuk-internal.digital" >> /etc/resolvconf/resolv.conf.d/base
 fi
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END SNIPPET: base"


### PR DESCRIPTION
I was trying to decide if this was the correct behaviour or not; I *think* it is.

Hosts should not resolve to their own stack when doing searches because we're providing resolution by the "top level" domain to assign which services go where.

If we need something to go to a specific stack we can still specify the FQDN, but a default lookup should resolve to the top level. For example, if we want to connect to redis, we should be connecting by default to `redis.integration.govuk-internal.digital`, rather than `redis.blue.integration.govuk-internal.digital`.