### PR TITLE
Add external draft-cache ELB

### DIFF
--- a/terraform/projects/app-draft-cache/README.md
+++ b/terraform/projects/app-draft-cache/README.md
@@ -7,8 +7,10 @@ Draft Cache servers
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -30,6 +30,17 @@ variable "elb_internal_certname" {
   description = "The ACM cert domain name to find the ARN of"
 }
 
+variable "elb_external_certname" {
+  type        = "string"
+  description = "The ACM cert domain name to find the ARN of"
+}
+
+variable "app_service_records" {
+  type        = "list"
+  description = "List of application service names that get traffic via this loadbalancer"
+  default     = []
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -44,6 +55,11 @@ provider "aws" {
 
 data "aws_acm_certificate" "elb_internal_cert" {
   domain   = "${var.elb_internal_certname}"
+  statuses = ["ISSUED"]
+}
+
+data "aws_acm_certificate" "elb_external_cert" {
+  domain   = "${var.elb_external_certname}"
   statuses = ["ISSUED"]
 }
 
@@ -109,6 +125,65 @@ resource "aws_route53_record" "draft-router-api_internal_record" {
   }
 }
 
+resource "aws_elb" "draft-cache_external_elb" {
+  name            = "${var.stackname}-draft-cache-external"
+  subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_draft-cache_external_elb_id}"]
+  internal        = "false"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    bucket_prefix = "elb/${var.stackname}-draft-cache-external-elb"
+    interval      = 60
+  }
+
+  listener {
+    instance_port     = 80
+    instance_protocol = "http"
+    lb_port           = 443
+    lb_protocol       = "https"
+
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+
+    target   = "TCP:80"
+    interval = 30
+  }
+
+  cross_zone_load_balancing   = true
+  idle_timeout                = 400
+  connection_draining         = true
+  connection_draining_timeout = 400
+
+  tags = "${map("Name", "${var.stackname}-draft-cache", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "draft-cache")}"
+}
+
+resource "aws_route53_record" "draft-cache_external_service_record" {
+  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
+  name    = "draft-cache.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_elb.draft-cache_external_elb.dns_name}"
+    zone_id                = "${aws_elb.draft-cache_external_elb.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "app_service_records" {
+  count   = "${length(var.app_service_records)}"
+  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
+  name    = "${element(var.app_service_records, count.index)}.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
+  type    = "CNAME"
+  records = ["draft-cache.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"]
+  ttl     = "300"
+}
+
 module "draft-cache" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-draft-cache"
@@ -118,7 +193,7 @@ module "draft-cache" {
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_draft-cache_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "t2.medium"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
-  instance_elb_ids              = ["${aws_elb.draft-cache_elb.id}"]
+  instance_elb_ids              = ["${aws_elb.draft-cache_elb.id}", "${aws_elb.draft-cache_external_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "2"
   asg_min_size                  = "2"
@@ -139,12 +214,30 @@ module "alarms-elb-draft-cache-internal" {
   healthyhostcount_threshold     = "0"
 }
 
+module "alarms-elb-draft-cache-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-draft-cache-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  elb_name                       = "${aws_elb.draft-cache_external_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 
 output "draft-cache_elb_dns_name" {
   value       = "${aws_elb.draft-cache_elb.dns_name}"
   description = "DNS name to access the draft-cache service"
+}
+
+output "draft-cache_external_elb_dns_name" {
+  value       = "${aws_elb.draft-cache_external_elb.dns_name}"
+  description = "DNS name to access the draft-cache external service"
 }
 
 output "service_dns_name" {
@@ -155,4 +248,9 @@ output "service_dns_name" {
 output "draft-router-api_internal_dns_name" {
   value       = "${aws_route53_record.draft-router-api_internal_record.fqdn}"
   description = "DNS name to access draft-router-api"
+}
+
+output "external_service_dns_name" {
+  value       = "${aws_route53_record.draft-cache_external_service_record.fqdn}"
+  description = "DNS name to access the external service"
 }

--- a/terraform/projects/infra-security-groups/draft-cache.tf
+++ b/terraform/projects/infra-security-groups/draft-cache.tf
@@ -34,6 +34,19 @@ resource "aws_security_group_rule" "allow_draft-cache_elb_in" {
   source_security_group_id = "${aws_security_group.draft-cache_elb.id}"
 }
 
+resource "aws_security_group_rule" "allow_draft-cache_external_elb_in" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.draft-cache.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.draft-cache_external_elb.id}"
+}
+
 # We need to allow draft-cache instances to speak to their own to reload router
 # routes
 resource "aws_security_group_rule" "allow_draft-cache_from_draft-cache" {
@@ -57,6 +70,25 @@ resource "aws_security_group" "draft-cache_elb" {
   tags {
     Name = "${var.stackname}_draft-cache_elb_access"
   }
+}
+
+resource "aws_security_group" "draft-cache_external_elb" {
+  name        = "${var.stackname}_draft-cache_elb_external_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access the draft-cache external ELB"
+
+  tags {
+    Name = "${var.stackname}_draft-cache_external_elb_access"
+  }
+}
+
+resource "aws_security_group_rule" "allow_public_to_draft-cache_external_elb" {
+  type              = "ingress"
+  to_port           = 443
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.draft-cache_external_elb.id}"
+  cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}"]
 }
 
 # This is required to commit routes using router-api at the end of the data sync

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -118,6 +118,10 @@ output "sg_draft-cache_elb_id" {
   value = "${aws_security_group.draft-cache_elb.id}"
 }
 
+output "sg_draft-cache_elb_external_id" {
+  value = "${aws_security_group.draft-cache_external_elb.id}"
+}
+
 output "sg_draft-content-store_external_elb_id" {
   value = "${aws_security_group.draft-content-store_external_elb.id}"
 }


### PR DESCRIPTION
Draft Cache is public, but is accessed via Signon using authenticating-proxy.

Add an external ELB, and update the DNS so that users can access the draft stack.