### PR TITLE
Add public facing Draft stack load balancer

### DIFF
--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -67,6 +67,16 @@ variable "deploy_public_service_names" {
   default = []
 }
 
+variable "draft_cache_public_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "draft_cache_public_service_cnames" {
+  type    = "list"
+  default = []
+}
+
 variable "graphite_public_service_names" {
   type    = "list"
   default = []
@@ -669,8 +679,62 @@ resource "aws_route53_record" "docker_management_internal_service_names" {
 }
 
 #
-# Draft-cache DOES IT NEED EXTERNAL?
+# Draft-cache
 #
+module "draft_cache_public_lb" {
+  source                           = "../../modules/aws/lb"
+  name                             = "${var.stackname}-draft-cache-public"
+  internal                         = false
+  vpc_id                           = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix        = "elb/${var.stackname}-draft-cache-public-elb"
+  listener_certificate_domain_name = "${var.elb_public_certname}"
+  listener_action                  = "${map("HTTPS:443", "HTTP:80")}"
+  subnets                          = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups                  = ["${data.terraform_remote_state.infra_security_groups.sg_draft-cache_external_elb_id}"]
+  alarm_actions                    = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  default_tags                     = "${map("Project", var.stackname, "aws_migration", "draft_cache", "aws_environment", var.aws_environment)}"
+}
+
+resource "aws_route53_record" "draft_cache_public_service_names" {
+  count   = "${length(var.draft_cache_public_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.draft_cache_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${module.draft_cache_public_lb.lb_dns_name}"
+    zone_id                = "${module.draft_cache_public_lb.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "draft_cache_public_service_cnames" {
+  count   = "${length(var.draft_cache_public_service_cnames)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.draft_cache_public_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.draft_cache_public_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"]
+  ttl     = "300"
+}
+
+data "aws_autoscaling_groups" "draft_cache" {
+  filter {
+    name   = "key"
+    values = ["Name"]
+  }
+
+  filter {
+    name   = "value"
+    values = ["blue-draft-cache"]
+  }
+}
+
+resource "aws_autoscaling_attachment" "draft_cache_asg_attachment_alb" {
+  count                  = "${length(data.aws_autoscaling_groups.draft_cache.names) > 0 ? 1 : 0}"
+  autoscaling_group_name = "${element(data.aws_autoscaling_groups.draft_cache.names, 0)}"
+  alb_target_group_arn   = "${element(module.draft_cache_public_lb.target_group_arns, 0)}"
+}
 
 resource "aws_route53_record" "draft_cache_internal_service_names" {
   count   = "${length(var.draft_cache_internal_service_names)}"

--- a/tools/migration-hosts.sh
+++ b/tools/migration-hosts.sh
@@ -11,6 +11,7 @@ contacts-admin
 content-performance-manager
 content-tagger
 deploy
+draft-origin
 docs
 grafana
 graphite


### PR DESCRIPTION
The Draft stack is a public facing service, but has authentication which is handled by Signon.

This commit creates a public load balancer.