### PR TITLE
Environment deployment

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,14 @@
+## Deployment
+
+This contains everything required for running a full deployment of the stack. Since
+everything is divided into multiple statefiles, projects have to be deployed in turn.
+
+This is not a replacement for [reading the documentation](https://github.com/alphagov/govuk-aws/blob/master/doc/guides/environment-provisioning.md#build-the-puppet-master).
+
+### Default
+
+To deploy using the `build-terraform-project.sh` tool, use [default deployment configuration](default).
+
+### Terragov
+
+To deploy using [Terragov](https://github.com/surminus/terragov), use [Terragov deployment configuration](terragov).

--- a/deployment/default/README.md
+++ b/deployment/default/README.md
@@ -1,0 +1,1 @@
+## Default deployment

--- a/deployment/terragov/README.md
+++ b/deployment/terragov/README.md
@@ -1,0 +1,23 @@
+## Terragov deployment
+
+You must have Terragov 0.3.1.1 or higher:
+
+`gem install terragov`
+
+### Base
+
+Deploy the base infrastructure:
+
+`terragov deploy --command <plan or apply> --file deployment.yaml --group base --config-file integration.yaml`
+
+### Deploy Puppetmaster and Jenkins
+
+Follow the [environment provisioning guide](https://github.com/alphagov/govuk-aws/blob/master/doc/guides/environment-provisioning.md#build-the-puppet-master).
+
+These projects require some special intervention if you are deploying for the first time.
+
+### Deploy everything else
+
+Check [`deployment.yaml`](deployment.yaml) to see how the projects are split up.
+
+`terragov deploy --command <plan or apply> --file deployment.yaml --config-file integration.yaml -s <stackname> --group <group>`

--- a/deployment/terragov/deployment.yaml
+++ b/deployment/terragov/deployment.yaml
@@ -1,0 +1,100 @@
+# This is everything required for the base infrastructure
+base:
+  - 'infra-monitoring'
+  - 'infra-vpc'
+  - 'infra-networking'
+  - 'infra-root-dns-zones'
+  - 'infra-stack-dns-zones'
+  - 'infra-security-groups'
+  - 'infra-database-backups-bucket'
+  - 'infra-artefact-bucket'
+
+# Management services
+management:
+  - 'app-docker-management'
+  - 'app-graphite'
+  - 'app-monitoring'
+
+# Supporting services
+support:
+  # Enable access to the environment
+  - 'app-jumpbox'
+  # app-apt should be deployed for Gemstash
+  - 'app-apt'
+  - 'app-mirrorer'
+
+# Datastores
+datastores:
+  - 'app-backend-redis'
+  - 'app-db-admin'
+  - 'app-mongo'
+  - 'app-mysql'
+  - 'app-postgresql'
+  - 'app-rabbitmq'
+  - 'app-router-backend'
+  - 'app-rummager-elasticsearch'
+  - 'app-transition-db-admin'
+  - 'app-transition-postgresql'
+
+# Cache
+cache:
+  - 'app-cache'
+  - 'app-draft-cache'
+
+# Core applications
+core:
+  - 'app-publishing-api'
+  - 'app-content-store'
+  - 'app-draft-content-store'
+  - 'app-search'
+
+# Frontend applications
+frontend:
+  - 'app-calculators-frontend'
+  - 'app-draft-frontend'
+  - 'app-frontend'
+  - 'app-bouncer'
+  - 'app-whitehall-frontend'
+
+# Backend applications
+backend:
+  - 'app-asset-master'
+  - 'app-backend'
+  - 'app-mapit'
+  - 'app-whitehall-backend'
+
+# These load balancers have a dependency on all applications
+public:
+  - 'infra-public-services'
+
+# Anything with an EC2 instance except snowflakes. This is ordered
+# to ensure application groups are deployed last, particularly the ones
+# that deploy most apps, like app-backend.
+all_node_groups:
+  - 'app-jumpbox'
+  - 'app-apt'
+  - 'app-mirrorer'
+  - 'app-db-admin'
+  - 'app-transition-db-admin'
+  - 'app-docker-management'
+  - 'app-monitoring'
+  - 'app-graphite'
+  - 'app-rabbitmq'
+  - 'app-rummager-elasticsearch'
+  - 'app-mongo'
+  - 'app-router-backend'
+  - 'app-cache'
+  - 'app-draft-cache'
+  - 'app-publishing-api'
+  - 'app-search'
+  - 'app-content-store'
+  - 'app-draft-content-store'
+  - 'app-asset-master'
+  - 'app-bouncer'
+  - 'app-mapit'
+  - 'app-whitehall-backend'
+  - 'app-whitehall-frontend'
+  - 'app-calculators-frontend'
+  - 'app-draft-frontend'
+  - 'app-frontend'
+  - 'app-backend'

--- a/deployment/terragov/integration.yaml
+++ b/deployment/terragov/integration.yaml
@@ -1,0 +1,32 @@
+default:
+  environment: 'integration'
+  repo_dir: '~/govuk/govuk-aws'
+  data_dir: '~/govuk/govuk-aws-data/data'
+  skip_git_check: true
+
+infra-monitoring:
+  stack: 'govuk'
+
+infra-vpc:
+  stack: 'govuk'
+
+infra-networking:
+  stack: 'govuk'
+
+infra-root-dns-zones:
+  stack: 'govuk'
+
+infra-stack-dns-zones:
+  stack: 'blue'
+
+infra-security-groups:
+  stack: 'govuk'
+
+infra-database-backups-bucket:
+  stack: 'govuk'
+
+infra-artefact-bucket:
+  stack: 'govuk'
+
+infra-public-services:
+  stack: 'govuk'


### PR DESCRIPTION
Adds some configuration files to use with Terragov to deploy an
environment.

We do not have to merge this, but it's useful to have the branch when thinking about deployment order.