### PR TITLE
Clarify documentation on infra-public-services

### DIFF
--- a/doc/guides/environment-provisioning.md
+++ b/doc/guides/environment-provisioning.md
@@ -144,6 +144,17 @@ export PUPPETMASTER_ELB=<stack name>-puppetmaster-bootstrap-1234567890.eu-west-1
 ssh ubuntu@$PUPPETMASTER_ELB
 ```
 
+## Build infra-public-services
+
+Before creating an application machines, build the `infra-public-services` project. This creates a set of CNAME DNS records that point the top level internal domain
+to the current live stack service.
+
+All services rely on the top level DNS records, so they must exist before we deploy any instances.
+
+```
+tools/build-terraform-project.sh -c apply -p infra-public-services
+```
+
 ## Deploy the Puppet code and secrets
 
 We currently get the GPG key from the integration puppet master (in future this should be kept in the `deployment/pass` store)
@@ -234,7 +245,11 @@ Jenkins does not allow admins to view other users tokens, so there is a manual s
 8. The hiera key you're looking to update is called: `govuk::node::s_jenkins::jenkins_api_token`
 9. As the Deploy_Puppet job won't yet exist, you will be unable to deploy Puppet at this point. Manually edit `/etc/jenkins_jobs/jenkins_jobs.ini` with the new token, and run the update job by running `sudo jenkins-jobs update /etc/jenkins_jobs/jobs/`.
 
-When Jenkins Job Builder has successfully created jobs, you should then be able to deploy Puppet and applications via Jenkins to finish off the rest of the stack.
+When Jenkins Job Builder has successfully created jobs, deploy Puppet.
+
+## Deploy the rest of the stack
+
+All other projects can now be created. They should automatically deploy their own applications.
 
 ## Glossary
 

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -118,7 +118,7 @@ output "sg_draft-cache_elb_id" {
   value = "${aws_security_group.draft-cache_elb.id}"
 }
 
-output "sg_draft-cache_elb_external_id" {
+output "sg_draft-cache_external_elb_id" {
   value = "${aws_security_group.draft-cache_external_elb.id}"
 }
 

--- a/terraform/userdata/00-base
+++ b/terraform/userdata/00-base
@@ -52,15 +52,14 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: install Puppet ..."
 apt-get -y install make ruby1.9.3 puppet='3.8.*' puppet-common='3.8.*'
 service puppet stop
 
-echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: add search domain for local stack ..."
-F_STACKNAME=$(facter aws_stackname)
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: add search domains ..."
 F_AWS_ENVIRONMENT=$(facter aws_environment)
-if [[ -z $F_STACKNAME ]] || [[ -z $F_AWS_ENVIRONMENT ]] ; then
-  echo "ERROR aws_stackname is null"
+if [[ -z $F_AWS_ENVIRONMENT ]] ; then
+  echo "ERROR aws_environment is null"
 else
-  echo "append domain-search \""$F_STACKNAME"."$F_AWS_ENVIRONMENT".govuk-internal.digital\", \""$F_AWS_ENVIRONMENT".govuk-internal.digital\", \"govuk-internal.digital\";" >> /etc/dhcp/dhclient.conf
+  echo "append domain-search \""$F_AWS_ENVIRONMENT".govuk-internal.digital\", \"govuk-internal.digital\";" >> /etc/dhcp/dhclient.conf
   dhclient -r; dhclient
-  echo "search "$F_STACKNAME"."$F_AWS_ENVIRONMENT".govuk-internal.digital "$F_AWS_ENVIRONMENT".govuk-internal.digital govuk-internal.digital" >> /etc/resolvconf/resolv.conf.d/base
+  echo "search "$F_AWS_ENVIRONMENT".govuk-internal.digital govuk-internal.digital" >> /etc/resolvconf/resolv.conf.d/base
 fi
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END SNIPPET: base"


### PR DESCRIPTION
This reverts commit 0b787c1.

I reverted because machines were unable to communicate with the Puppetmaster. This is because infra-public-services should be deployed both before and after instances are created.

Before to create a set of CNAMEs for the top level DNS, and after to create the public load balancers.

I believe these items should be separated for "internal" and "external" domains, although I need to clarify if there is a dependency when we have created a public load balancer on the node_group that it is attached to. I thought I had failed to destroy a project when it had an LB attached due to a dependency issue, so destroyed the entire infra-public-services project, but this caused issues when building the environment from scratch.