### PR TITLE
Update Security Group rule names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,10 @@ node ("terraform") {
       sh "find . -name '*.json' |xargs tools/json-check.sh"
     }
 
+    stage("Security group rule name validation") {
+      sh "tools/validate-sg-rule-names terraform"
+    }
+
     if (env.BRANCH_NAME == 'master'){
       stage("Push release tag") {
         echo 'Pushing tag'

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -91,7 +91,7 @@ resource "aws_elb" "puppetmaster_bootstrap_elb" {
   }
 }
 
-resource "aws_security_group_rule" "puppetmaster_from_elb_in_22" {
+resource "aws_security_group_rule" "puppetmaster_ingress_offsite-ssh_22" {
   count                    = "${var.enable_bootstrap}"
   type                     = "ingress"
   from_port                = "22"

--- a/terraform/projects/infra-security-groups/apt.tf
+++ b/terraform/projects/infra-security-groups/apt.tf
@@ -23,7 +23,7 @@ resource "aws_security_group" "apt" {
   }
 }
 
-resource "aws_security_group_rule" "allow_apt_external_elb_in" {
+resource "aws_security_group_rule" "apt_ingress_apt-external-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -36,7 +36,7 @@ resource "aws_security_group_rule" "allow_apt_external_elb_in" {
   source_security_group_id = "${aws_security_group.apt_external_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_apt_internal_elb_in" {
+resource "aws_security_group_rule" "apt_ingress_apt-internal-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -59,7 +59,7 @@ resource "aws_security_group" "apt_external_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_apt_external_elb_office_in" {
+resource "aws_security_group_rule" "apt-external-elb_ingress_office_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -69,7 +69,7 @@ resource "aws_security_group_rule" "allow_apt_external_elb_office_in" {
   cidr_blocks       = ["${var.office_ips}"]
 }
 
-resource "aws_security_group_rule" "allow_apt_external_elb_egress" {
+resource "aws_security_group_rule" "apt-external-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -88,7 +88,7 @@ resource "aws_security_group" "apt_internal_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_management_to_apt_elb" {
+resource "aws_security_group_rule" "apt-internal-elb_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -98,7 +98,7 @@ resource "aws_security_group_rule" "allow_management_to_apt_elb" {
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-resource "aws_security_group_rule" "allow_management_to_apt_elb_80" {
+resource "aws_security_group_rule" "apt-internal-elb_ingress_management_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -108,7 +108,7 @@ resource "aws_security_group_rule" "allow_management_to_apt_elb_80" {
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-resource "aws_security_group_rule" "allow_apt_internal_elb_egress" {
+resource "aws_security_group_rule" "apt-internal-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/asset-master.tf
+++ b/terraform/projects/infra-security-groups/asset-master.tf
@@ -30,7 +30,7 @@ resource "aws_security_group" "asset-master-efs" {
 }
 
 # Allow both TCP and UDP for NFS
-resource "aws_security_group_rule" "allow_asset-master-efs_from_asset-master" {
+resource "aws_security_group_rule" "asset-master-efs_ingress_asset-master_nfs" {
   type      = "ingress"
   from_port = 111
   to_port   = 111
@@ -44,7 +44,7 @@ resource "aws_security_group_rule" "allow_asset-master-efs_from_asset-master" {
 }
 
 # Allow both TCP and UDP for NFS
-resource "aws_security_group_rule" "allow_asset-master-efs_from_backend" {
+resource "aws_security_group_rule" "asset-master-efs_ingress_backend_nfs" {
   type      = "ingress"
   from_port = 111
   to_port   = 111
@@ -58,7 +58,7 @@ resource "aws_security_group_rule" "allow_asset-master-efs_from_backend" {
 }
 
 # Allow both TCP and UDP for NFS
-resource "aws_security_group_rule" "allow_asset-master-efs_from_whitehall-backend" {
+resource "aws_security_group_rule" "asset-master-efs_ingress_whitehall-backend_nfs" {
   type      = "ingress"
   from_port = 111
   to_port   = 111

--- a/terraform/projects/infra-security-groups/backend-redis.tf
+++ b/terraform/projects/infra-security-groups/backend-redis.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "backend-redis" {
   }
 }
 
-resource "aws_security_group_rule" "allow_backend-redis_from_backend" {
+resource "aws_security_group_rule" "backend-redis_ingress_backend_redis" {
   type      = "ingress"
   from_port = 6379
   to_port   = 6379
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "allow_backend-redis_from_backend" {
   source_security_group_id = "${aws_security_group.backend.id}"
 }
 
-resource "aws_security_group_rule" "allow_backend-redis_from_whitehall-backend" {
+resource "aws_security_group_rule" "backend-redis_ingress_whitehall-backend_redis" {
   type      = "ingress"
   from_port = 6379
   to_port   = 6379
@@ -47,7 +47,7 @@ resource "aws_security_group_rule" "allow_backend-redis_from_whitehall-backend" 
   source_security_group_id = "${aws_security_group.whitehall-backend.id}"
 }
 
-resource "aws_security_group_rule" "allow_backend-redis_from_whitehall-frontend" {
+resource "aws_security_group_rule" "backend-redis_ingress_whitehall-frontend_redis" {
   type      = "ingress"
   from_port = 6379
   to_port   = 6379
@@ -60,7 +60,7 @@ resource "aws_security_group_rule" "allow_backend-redis_from_whitehall-frontend"
   source_security_group_id = "${aws_security_group.whitehall-frontend.id}"
 }
 
-resource "aws_security_group_rule" "allow_publishing_api_in_redis" {
+resource "aws_security_group_rule" "backend-redis_ingress_publishing-api_redis" {
   type      = "ingress"
   from_port = 6379
   to_port   = 6379
@@ -73,7 +73,7 @@ resource "aws_security_group_rule" "allow_publishing_api_in_redis" {
   source_security_group_id = "${aws_security_group.publishing-api.id}"
 }
 
-resource "aws_security_group_rule" "allow_search_in_redis" {
+resource "aws_security_group_rule" "backend-redis_ingress_search_redis" {
   type      = "ingress"
   from_port = 6379
   to_port   = 6379

--- a/terraform/projects/infra-security-groups/backend.tf
+++ b/terraform/projects/infra-security-groups/backend.tf
@@ -22,7 +22,7 @@ resource "aws_security_group" "backend" {
   }
 }
 
-resource "aws_security_group_rule" "allow_backend_elb_internal_in" {
+resource "aws_security_group_rule" "backend_ingress_backend-elb-internal_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -35,7 +35,7 @@ resource "aws_security_group_rule" "allow_backend_elb_internal_in" {
   source_security_group_id = "${aws_security_group.backend_elb_internal.id}"
 }
 
-resource "aws_security_group_rule" "allow_backend_elb_external_in" {
+resource "aws_security_group_rule" "backend_ingress_backend-elb-external_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -58,8 +58,8 @@ resource "aws_security_group" "backend_elb_internal" {
   }
 }
 
-# TODO: replace this with specific routes from application servers
-resource "aws_security_group_rule" "allow_management_to_backend_elb_internal" {
+# TODO: Audit
+resource "aws_security_group_rule" "backend-elb-internal_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -79,8 +79,8 @@ resource "aws_security_group" "backend_elb_external" {
   }
 }
 
-# Allow office access to access backend services
-resource "aws_security_group_rule" "allow_public_to_backend_elb_external" {
+# Allow public access to access backend services
+resource "aws_security_group_rule" "backend-elb-external_ingress_public_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -90,8 +90,7 @@ resource "aws_security_group_rule" "allow_public_to_backend_elb_external" {
   cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}"]
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_backend_elb_internal_egress" {
+resource "aws_security_group_rule" "backend-elb-internal_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -100,8 +99,7 @@ resource "aws_security_group_rule" "allow_backend_elb_internal_egress" {
   security_group_id = "${aws_security_group.backend_elb_internal.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_backend_elb_external_egress" {
+resource "aws_security_group_rule" "backend-elb-external_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/bouncer.tf
+++ b/terraform/projects/infra-security-groups/bouncer.tf
@@ -22,7 +22,7 @@ resource "aws_security_group" "bouncer" {
   }
 }
 
-resource "aws_security_group_rule" "allow_bouncer_elb_in" {
+resource "aws_security_group_rule" "bouncer_ingress_bouncer-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -35,7 +35,7 @@ resource "aws_security_group_rule" "allow_bouncer_elb_in" {
   source_security_group_id = "${aws_security_group.bouncer_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_bouncer_internal_elb_in" {
+resource "aws_security_group_rule" "bouncer_ingress_bouncer-internal-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -58,7 +58,7 @@ resource "aws_security_group" "bouncer_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_fastly_to_bouncer_elb_http" {
+resource "aws_security_group_rule" "bouncer-elb_ingress_fastly_http" {
   type              = "ingress"
   to_port           = 80
   from_port         = 80
@@ -67,7 +67,7 @@ resource "aws_security_group_rule" "allow_fastly_to_bouncer_elb_http" {
   cidr_blocks       = ["${data.fastly_ip_ranges.fastly.cidr_blocks}", "${var.office_ips}"]
 }
 
-resource "aws_security_group_rule" "allow_traffic-replay_to_bouncer_elb_http" {
+resource "aws_security_group_rule" "bouncer-elb_ingress_traffic-replay_http" {
   type              = "ingress"
   to_port           = 80
   from_port         = 80
@@ -76,7 +76,7 @@ resource "aws_security_group_rule" "allow_traffic-replay_to_bouncer_elb_http" {
   cidr_blocks       = ["${var.traffic_replay_ips}"]
 }
 
-resource "aws_security_group_rule" "allow_fastly_to_bouncer_elb_https" {
+resource "aws_security_group_rule" "bouncer-elb_ingress_fastly_https" {
   type              = "ingress"
   to_port           = 443
   from_port         = 443
@@ -85,8 +85,7 @@ resource "aws_security_group_rule" "allow_fastly_to_bouncer_elb_https" {
   cidr_blocks       = ["${data.fastly_ip_ranges.fastly.cidr_blocks}", "${var.office_ips}"]
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_bouncer_elb_egress" {
+resource "aws_security_group_rule" "bouncer-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -105,7 +104,7 @@ resource "aws_security_group" "bouncer_internal_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_monitoring_to_bouncer_internal_elb_https" {
+resource "aws_security_group_rule" "bouncer-internal-elb_ingress_monitoring_https" {
   type                     = "ingress"
   to_port                  = 443
   from_port                = 443
@@ -114,7 +113,7 @@ resource "aws_security_group_rule" "allow_monitoring_to_bouncer_internal_elb_htt
   source_security_group_id = "${aws_security_group.monitoring.id}"
 }
 
-resource "aws_security_group_rule" "allow_monitoring_to_bouncer_internal_elb_http" {
+resource "aws_security_group_rule" "bouncer-internal-elb_ingress_monitoring_http" {
   type                     = "ingress"
   to_port                  = 80
   from_port                = 80
@@ -123,7 +122,7 @@ resource "aws_security_group_rule" "allow_monitoring_to_bouncer_internal_elb_htt
   source_security_group_id = "${aws_security_group.monitoring.id}"
 }
 
-resource "aws_security_group_rule" "allow_bouncer_internal_elb_egress" {
+resource "aws_security_group_rule" "bouncer-internal-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/cache.tf
+++ b/terraform/projects/infra-security-groups/cache.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "cache" {
   }
 }
 
-resource "aws_security_group_rule" "allow_cache_elb_in" {
+resource "aws_security_group_rule" "cache_ingress_cache-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "allow_cache_elb_in" {
   source_security_group_id = "${aws_security_group.cache_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_cache_external_elb_in" {
+resource "aws_security_group_rule" "cache_ingress_cache-external-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -48,7 +48,7 @@ resource "aws_security_group_rule" "allow_cache_external_elb_in" {
 }
 
 # Allow the router-backend instances to reload router routes
-resource "aws_security_group_rule" "allow_cache_from_router-backend" {
+resource "aws_security_group_rule" "cache_ingress_router-backend_router" {
   type      = "ingress"
   from_port = 3055
   to_port   = 3055
@@ -73,7 +73,7 @@ resource "aws_security_group" "cache_elb" {
 
 # Allow cache to speak to it's own ELB to reroute publicapi traffic
 # to itself
-resource "aws_security_group_rule" "allow_cache_to_cache_elb" {
+resource "aws_security_group_rule" "cache-elb_ingress_cache_https" {
   type      = "ingress"
   to_port   = 443
   from_port = 443
@@ -86,8 +86,7 @@ resource "aws_security_group_rule" "allow_cache_to_cache_elb" {
   source_security_group_id = "${aws_security_group.cache.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_cache_elb_egress" {
+resource "aws_security_group_rule" "cache-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -106,7 +105,7 @@ resource "aws_security_group" "cache_external_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_public_to_cache_external_elb" {
+resource "aws_security_group_rule" "cache-external-elb_ingress_public_https" {
   type              = "ingress"
   to_port           = 443
   from_port         = 443
@@ -115,8 +114,7 @@ resource "aws_security_group_rule" "allow_public_to_cache_external_elb" {
   cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}"]
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_cache_external_elb_egress" {
+resource "aws_security_group_rule" "cache-external-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/calculators-frontend.tf
+++ b/terraform/projects/infra-security-groups/calculators-frontend.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "calculators-frontend" {
   }
 }
 
-resource "aws_security_group_rule" "allow_calculators-frontend_elb_in" {
+resource "aws_security_group_rule" "calculators-frontend_ingress_calculators-frontend-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -44,8 +44,8 @@ resource "aws_security_group" "calculators-frontend_elb" {
   }
 }
 
-# TODO: replace this with ingress from the frontend LBs when we build them.
-resource "aws_security_group_rule" "allow_management_to_calculators-frontend_elb" {
+# TODO: Audit
+resource "aws_security_group_rule" "calculators-frontend-elb_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -55,8 +55,7 @@ resource "aws_security_group_rule" "allow_management_to_calculators-frontend_elb
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_calculators-frontend_elb_egress" {
+resource "aws_security_group_rule" "calculators-frontends-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/content-store.tf
+++ b/terraform/projects/infra-security-groups/content-store.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "content-store" {
   }
 }
 
-resource "aws_security_group_rule" "allow_content-store_internal_elb_in" {
+resource "aws_security_group_rule" "content-store_ingress_content-store-internal-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "allow_content-store_internal_elb_in" {
   source_security_group_id = "${aws_security_group.content-store_internal_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_content-store_external_elb_in" {
+resource "aws_security_group_rule" "content-store_ingress_content-store-external-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -57,8 +57,8 @@ resource "aws_security_group" "content-store_internal_elb" {
   }
 }
 
-# Content Store should be available internally
-resource "aws_security_group_rule" "allow_management_to_content-store_internal_elb" {
+# TODO: Audit
+resource "aws_security_group_rule" "content-store-internal-elb_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -68,8 +68,7 @@ resource "aws_security_group_rule" "allow_management_to_content-store_internal_e
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_content-store_internal_elb_egress" {
+resource "aws_security_group_rule" "content-store-internal-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -88,8 +87,8 @@ resource "aws_security_group" "content-store_external_elb" {
   }
 }
 
-# Content Store should be available externally
-resource "aws_security_group_rule" "allow_public_to_content-store_external_elb" {
+# TODO: Audit
+resource "aws_security_group_rule" "content-store-external-elb_ingress_public_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -99,8 +98,7 @@ resource "aws_security_group_rule" "allow_public_to_content-store_external_elb" 
   cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}"]
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_content-store_external_elb_egress" {
+resource "aws_security_group_rule" "content-store-external-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/db-admin.tf
+++ b/terraform/projects/infra-security-groups/db-admin.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "db-admin" {
   }
 }
 
-resource "aws_security_group_rule" "allow_db-admin_elb_in" {
+resource "aws_security_group_rule" "db-admin_ingress_db-admin-elb_ssh" {
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -44,7 +44,8 @@ resource "aws_security_group" "db-admin_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_management_to_db-admin_elb" {
+# TODO: Audit
+resource "aws_security_group_rule" "db-admin-elb_ingress_management_ssh" {
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -54,8 +55,7 @@ resource "aws_security_group_rule" "allow_management_to_db-admin_elb" {
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_db-admin_elb_egress" {
+resource "aws_security_group_rule" "db-admin-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/deploy.tf
+++ b/terraform/projects/infra-security-groups/deploy.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "deploy" {
   }
 }
 
-resource "aws_security_group_rule" "allow_deploy_elb_in" {
+resource "aws_security_group_rule" "deploy_ingress_deploy-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "allow_deploy_elb_in" {
   source_security_group_id = "${aws_security_group.deploy_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_deploy_internal_elb_in" {
+resource "aws_security_group_rule" "deploy_ingress_deploy-internal-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -57,7 +57,7 @@ resource "aws_security_group" "deploy_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_office_to_deploy" {
+resource "aws_security_group_rule" "deploy-elb_ingress_office_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -68,7 +68,7 @@ resource "aws_security_group_rule" "allow_office_to_deploy" {
 }
 
 # Allow Carrenza Integration access to trigger automated deployments
-resource "aws_security_group_rule" "allow_carrenza_to_deploy" {
+resource "aws_security_group_rule" "deploy-elb_ingress_carrenza_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -78,8 +78,7 @@ resource "aws_security_group_rule" "allow_carrenza_to_deploy" {
   cidr_blocks       = ["${var.carrenza_integration_ips}"]
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_deploy_elb_egress" {
+resource "aws_security_group_rule" "deploy-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -88,8 +87,7 @@ resource "aws_security_group_rule" "allow_deploy_elb_egress" {
   security_group_id = "${aws_security_group.deploy_elb.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_deploy_internal_elb_egress" {
+resource "aws_security_group_rule" "deploy-internal-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -108,7 +106,7 @@ resource "aws_security_group" "deploy_internal_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_deploy_internal_elb_management_in" {
+resource "aws_security_group_rule" "deploy-internal-elb_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443

--- a/terraform/projects/infra-security-groups/docker-management.tf
+++ b/terraform/projects/infra-security-groups/docker-management.tf
@@ -22,7 +22,7 @@ resource "aws_security_group" "docker_management" {
   }
 }
 
-resource "aws_security_group_rule" "allow_docker_management_etcd_elb_in" {
+resource "aws_security_group_rule" "docker-management_ingress_docker-management-etcd-elb_etcd-client" {
   type      = "ingress"
   from_port = 2379
   to_port   = 2379
@@ -35,7 +35,7 @@ resource "aws_security_group_rule" "allow_docker_management_etcd_elb_in" {
   source_security_group_id = "${aws_security_group.docker_management_etcd_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_docker_management_to_docker_management" {
+resource "aws_security_group_rule" "docker-management_ingress_docker-management_etcd-transport" {
   type      = "ingress"
   from_port = 2380
   to_port   = 2380
@@ -55,7 +55,7 @@ resource "aws_security_group" "docker_management_etcd_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_management_to_docker_management_etcd_elb" {
+resource "aws_security_group_rule" "docker-management-etcd-elb_ingress_management_etcd-client" {
   type      = "ingress"
   from_port = 2379
   to_port   = 2379
@@ -65,8 +65,7 @@ resource "aws_security_group_rule" "allow_management_to_docker_management_etcd_e
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_docker_management_etcd_elb_egress" {
+resource "aws_security_group_rule" "docker-management-etcd-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/draft-cache.tf
+++ b/terraform/projects/infra-security-groups/draft-cache.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "draft-cache" {
   }
 }
 
-resource "aws_security_group_rule" "allow_draft-cache_elb_in" {
+resource "aws_security_group_rule" "draft-cache_ingress_draft-cache-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "allow_draft-cache_elb_in" {
   source_security_group_id = "${aws_security_group.draft-cache_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_draft-cache_external_elb_in" {
+resource "aws_security_group_rule" "draft-cache_ingress_draft-cache-external-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -49,7 +49,7 @@ resource "aws_security_group_rule" "allow_draft-cache_external_elb_in" {
 
 # We need to allow draft-cache instances to speak to their own to reload router
 # routes
-resource "aws_security_group_rule" "allow_draft-cache_from_draft-cache" {
+resource "aws_security_group_rule" "draft-cache_ingress_draft-cache_router" {
   type      = "ingress"
   from_port = 3055
   to_port   = 3055
@@ -82,7 +82,7 @@ resource "aws_security_group" "draft-cache_external_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_public_to_draft-cache_external_elb" {
+resource "aws_security_group_rule" "draft-cache-external-elb_ingress_public_https" {
   type              = "ingress"
   to_port           = 443
   from_port         = 443
@@ -92,7 +92,7 @@ resource "aws_security_group_rule" "allow_public_to_draft-cache_external_elb" {
 }
 
 # This is required to commit routes using router-api at the end of the data sync
-resource "aws_security_group_rule" "allow_draft-cache_from_draft-content-store" {
+resource "aws_security_group_rule" "draft-cache-elb_ingress_draft-content-store_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -105,8 +105,7 @@ resource "aws_security_group_rule" "allow_draft-cache_from_draft-content-store" 
   source_security_group_id = "${aws_security_group.draft-content-store.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_draft-cache_elb_egress" {
+resource "aws_security_group_rule" "draft-cache-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -115,8 +114,7 @@ resource "aws_security_group_rule" "allow_draft-cache_elb_egress" {
   security_group_id = "${aws_security_group.draft-cache_elb.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_draft-cache_external_elb_egress" {
+resource "aws_security_group_rule" "draft-cache-external-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/draft-content-store.tf
+++ b/terraform/projects/infra-security-groups/draft-content-store.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "draft-content-store" {
   }
 }
 
-resource "aws_security_group_rule" "allow_draft-content-store_internal_elb_in" {
+resource "aws_security_group_rule" "draft-content-store_ingress_draft-content-store-internal-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "allow_draft-content-store_internal_elb_in" {
   source_security_group_id = "${aws_security_group.draft-content-store_internal_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_draft-content-store_external_elb_in" {
+resource "aws_security_group_rule" "draft-content-store_ingress_draft-content-store-external-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -57,8 +57,8 @@ resource "aws_security_group" "draft-content-store_internal_elb" {
   }
 }
 
-# Content Store should be available internally
-resource "aws_security_group_rule" "allow_management_to_draft-content-store_internal_elb" {
+# TODO: Audit
+resource "aws_security_group_rule" "draft-content-store-internal-elb_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -69,7 +69,7 @@ resource "aws_security_group_rule" "allow_management_to_draft-content-store_inte
 }
 
 # TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_draft-content-store_internal_elb_egress" {
+resource "aws_security_group_rule" "draft-content-store-internal-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -88,8 +88,8 @@ resource "aws_security_group" "draft-content-store_external_elb" {
   }
 }
 
-# Content Store should be available externally
-resource "aws_security_group_rule" "allow_public_to_draft-content-store_external_elb" {
+# TODO: Audit
+resource "aws_security_group_rule" "draft-content-store-external-elb_ingress_office_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -99,8 +99,7 @@ resource "aws_security_group_rule" "allow_public_to_draft-content-store_external
   cidr_blocks       = ["${var.office_ips}"]
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_draft-content-store_external_elb_egress" {
+resource "aws_security_group_rule" "draft-content-store-external-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/draft-frontend.tf
+++ b/terraform/projects/infra-security-groups/draft-frontend.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "draft-frontend" {
   }
 }
 
-resource "aws_security_group_rule" "allow_draft-frontend_elb_in" {
+resource "aws_security_group_rule" "draft-frontend-elb_ingress_draft-frontend-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -44,9 +44,8 @@ resource "aws_security_group" "draft-frontend_elb" {
   }
 }
 
-# TODO: most application instances need to talk to draft-frontend - we could
-# split out some security for application and service instances?
-resource "aws_security_group_rule" "allow_management_to_draft-frontend_elb_https" {
+# TODO: Audit
+resource "aws_security_group_rule" "draft-frontend-elb_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -56,8 +55,7 @@ resource "aws_security_group_rule" "allow_management_to_draft-frontend_elb_https
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_draft-frontend_elb_egress" {
+resource "aws_security_group_rule" "draft-frontend-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/frontend.tf
+++ b/terraform/projects/infra-security-groups/frontend.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "frontend" {
   }
 }
 
-resource "aws_security_group_rule" "allow_frontend_elb_in" {
+resource "aws_security_group_rule" "frontend_ingress_frontend-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -44,9 +44,8 @@ resource "aws_security_group" "frontend_elb" {
   }
 }
 
-# TODO: most application instances need to talk to frontend - we could
-# split out some security for application and service instances?
-resource "aws_security_group_rule" "allow_management_to_frontend_elb_https" {
+# TODO: Audit
+resource "aws_security_group_rule" "frontend-elb_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -56,8 +55,7 @@ resource "aws_security_group_rule" "allow_management_to_frontend_elb_https" {
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_frontend_elb_egress" {
+resource "aws_security_group_rule" "frontend-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/graphite.tf
+++ b/terraform/projects/infra-security-groups/graphite.tf
@@ -23,7 +23,7 @@ resource "aws_security_group" "graphite" {
   }
 }
 
-resource "aws_security_group_rule" "allow_graphite_external_elb_in" {
+resource "aws_security_group_rule" "graphite_ingress_graphite-external-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -36,7 +36,7 @@ resource "aws_security_group_rule" "allow_graphite_external_elb_in" {
   source_security_group_id = "${aws_security_group.graphite_external_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_graphite_internal_elb_in" {
+resource "aws_security_group_rule" "graphite_ingress_graphite-internal-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -49,7 +49,7 @@ resource "aws_security_group_rule" "allow_graphite_internal_elb_in" {
   source_security_group_id = "${aws_security_group.graphite_internal_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_graphite_carbon_aggregator_line_internal_elb_in" {
+resource "aws_security_group_rule" "graphite_ingress_graphite-internal-elb_carbon" {
   type      = "ingress"
   from_port = 2003
   to_port   = 2003
@@ -62,7 +62,7 @@ resource "aws_security_group_rule" "allow_graphite_carbon_aggregator_line_intern
   source_security_group_id = "${aws_security_group.graphite_internal_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_graphite_carbon_aggregator_pickle_internal_elb_in" {
+resource "aws_security_group_rule" "graphite_ingress_graphite-internal-elb_pickle" {
   type      = "ingress"
   from_port = 2004
   to_port   = 2004
@@ -85,7 +85,7 @@ resource "aws_security_group" "graphite_external_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_graphite_external_elb_office_in" {
+resource "aws_security_group_rule" "graphite-external-elb_ingress_office_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -95,8 +95,8 @@ resource "aws_security_group_rule" "allow_graphite_external_elb_office_in" {
   cidr_blocks       = ["${var.office_ips}"]
 }
 
-# Maybe we don't need this one, depending on what endpoint internal clients are using
-resource "aws_security_group_rule" "allow_graphite_external_elb_management_in" {
+# TODO: Audit
+resource "aws_security_group_rule" "graphite-external-elb_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -106,7 +106,7 @@ resource "aws_security_group_rule" "allow_graphite_external_elb_management_in" {
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-resource "aws_security_group_rule" "allow_graphite_external_elb_egress" {
+resource "aws_security_group_rule" "graphite-external-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -125,7 +125,7 @@ resource "aws_security_group" "graphite_internal_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_graphite_internal_elb_management_in" {
+resource "aws_security_group_rule" "graphite-internal-elb_ingress_monitoring_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -135,7 +135,7 @@ resource "aws_security_group_rule" "allow_graphite_internal_elb_management_in" {
   source_security_group_id = "${aws_security_group.monitoring.id}"
 }
 
-resource "aws_security_group_rule" "allow_management_to_graphite_carbon_aggregator_line_elb" {
+resource "aws_security_group_rule" "graphite-internal-elb_ingress_management_carbon" {
   type      = "ingress"
   from_port = 2003
   to_port   = 2003
@@ -145,7 +145,7 @@ resource "aws_security_group_rule" "allow_management_to_graphite_carbon_aggregat
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-resource "aws_security_group_rule" "allow_management_to_graphite_carbon_aggregator_pickle_elb" {
+resource "aws_security_group_rule" "graphite-internal-elb_ingress_management_pickle" {
   type      = "ingress"
   from_port = 2004
   to_port   = 2004
@@ -155,7 +155,7 @@ resource "aws_security_group_rule" "allow_management_to_graphite_carbon_aggregat
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-resource "aws_security_group_rule" "allow_graphite_internal_elb_egress" {
+resource "aws_security_group_rule" "graphite-internal-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/jumpbox.tf
+++ b/terraform/projects/infra-security-groups/jumpbox.tf
@@ -20,7 +20,7 @@ resource "aws_security_group" "jumpbox" {
   }
 }
 
-resource "aws_security_group_rule" "allow_offsite_ssh_to_jumpbox" {
+resource "aws_security_group_rule" "jumpbox_ingress_offsite-ssh_ssh" {
   type                     = "ingress"
   to_port                  = 22
   from_port                = 22

--- a/terraform/projects/infra-security-groups/logs-cdn.tf
+++ b/terraform/projects/infra-security-groups/logs-cdn.tf
@@ -22,7 +22,7 @@ resource "aws_security_group" "logs-cdn" {
   }
 }
 
-resource "aws_security_group_rule" "allow_logs-cdn_elb_in" {
+resource "aws_security_group_rule" "logs-cdn_ingress_logs-cdn-elb_syslog-tls" {
   type      = "ingress"
   from_port = 6514
   to_port   = 6516
@@ -45,7 +45,7 @@ resource "aws_security_group" "logs-cdn_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_fastly_to_logs-cdn_elb" {
+resource "aws_security_group_rule" "logs-cdn-elb_ingress_fastly_syslog-tls" {
   type              = "ingress"
   to_port           = 6516
   from_port         = 6514
@@ -54,8 +54,7 @@ resource "aws_security_group_rule" "allow_fastly_to_logs-cdn_elb" {
   cidr_blocks       = ["${data.fastly_ip_ranges.fastly.cidr_blocks}"]
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_logs-cdn_elb_egress" {
+resource "aws_security_group_rule" "logs-cdn-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/management.tf
+++ b/terraform/projects/infra-security-groups/management.tf
@@ -22,7 +22,7 @@ resource "aws_security_group" "management" {
   }
 }
 
-resource "aws_security_group_rule" "allow_ssh_from_jumpbox" {
+resource "aws_security_group_rule" "management_ingress_jumpbox_ssh" {
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -35,7 +35,7 @@ resource "aws_security_group_rule" "allow_ssh_from_jumpbox" {
   source_security_group_id = "${aws_security_group.jumpbox.id}"
 }
 
-resource "aws_security_group_rule" "allow_ssh_from_deploy" {
+resource "aws_security_group_rule" "management_ingress_deploy_ssh" {
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -48,7 +48,7 @@ resource "aws_security_group_rule" "allow_ssh_from_deploy" {
   source_security_group_id = "${aws_security_group.deploy.id}"
 }
 
-resource "aws_security_group_rule" "allow_nrpe_ingress_from_monitoring" {
+resource "aws_security_group_rule" "management_ingress_monitoring_nrpe" {
   type      = "ingress"
   from_port = 5666
   to_port   = 5666
@@ -61,7 +61,7 @@ resource "aws_security_group_rule" "allow_nrpe_ingress_from_monitoring" {
   source_security_group_id = "${aws_security_group.monitoring.id}"
 }
 
-resource "aws_security_group_rule" "allow_icmp_ingress_from_monitoring" {
+resource "aws_security_group_rule" "management_ingress_monitoring_ping" {
   type      = "ingress"
   from_port = 8
   to_port   = 0
@@ -74,7 +74,7 @@ resource "aws_security_group_rule" "allow_icmp_ingress_from_monitoring" {
   source_security_group_id = "${aws_security_group.monitoring.id}"
 }
 
-resource "aws_security_group_rule" "allow_mangement_egress" {
+resource "aws_security_group_rule" "mangement_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/mapit.tf
+++ b/terraform/projects/infra-security-groups/mapit.tf
@@ -20,7 +20,7 @@ resource "aws_security_group" "mapit" {
   }
 }
 
-resource "aws_security_group_rule" "allow_mapit_elb_in" {
+resource "aws_security_group_rule" "mapit_ingress_mapit-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -43,7 +43,7 @@ resource "aws_security_group" "mapit_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_management_to_mapit_elb" {
+resource "aws_security_group_rule" "mapit-elb_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -53,7 +53,7 @@ resource "aws_security_group_rule" "allow_management_to_mapit_elb" {
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-resource "aws_security_group_rule" "allow_mapit_elb_egress" {
+resource "aws_security_group_rule" "mapit-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/mongo.tf
+++ b/terraform/projects/infra-security-groups/mongo.tf
@@ -22,7 +22,7 @@ resource "aws_security_group" "mongo" {
 }
 
 # the nodes need to speak among themselves for clustering
-resource "aws_security_group_rule" "allow_mongo_cluster_in" {
+resource "aws_security_group_rule" "mongo_ingress_mongo_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
@@ -35,7 +35,7 @@ resource "aws_security_group_rule" "allow_mongo_cluster_in" {
   source_security_group_id = "${aws_security_group.mongo.id}"
 }
 
-resource "aws_security_group_rule" "allow_frontend_to_mongo" {
+resource "aws_security_group_rule" "mongo_ingress_frontend_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
@@ -46,7 +46,7 @@ resource "aws_security_group_rule" "allow_frontend_to_mongo" {
   source_security_group_id = "${aws_security_group.frontend.id}"
 }
 
-resource "aws_security_group_rule" "allow_calculators-frontend_to_mongo" {
+resource "aws_security_group_rule" "mongo_ingress_calculators-frontend_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
@@ -57,7 +57,7 @@ resource "aws_security_group_rule" "allow_calculators-frontend_to_mongo" {
   source_security_group_id = "${aws_security_group.calculators-frontend.id}"
 }
 
-resource "aws_security_group_rule" "allow_backend_to_mongo" {
+resource "aws_security_group_rule" "mongo_ingress_backend_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
@@ -68,7 +68,7 @@ resource "aws_security_group_rule" "allow_backend_to_mongo" {
   source_security_group_id = "${aws_security_group.backend.id}"
 }
 
-resource "aws_security_group_rule" "allow_content-store_to_mongo" {
+resource "aws_security_group_rule" "mongo_ingress_content-store_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
@@ -79,7 +79,7 @@ resource "aws_security_group_rule" "allow_content-store_to_mongo" {
   source_security_group_id = "${aws_security_group.content-store.id}"
 }
 
-resource "aws_security_group_rule" "allow_draft-content-store_to_mongo" {
+resource "aws_security_group_rule" "mongo_ingress_draft-content-store_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017

--- a/terraform/projects/infra-security-groups/monitoring.tf
+++ b/terraform/projects/infra-security-groups/monitoring.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "monitoring" {
   }
 }
 
-resource "aws_security_group_rule" "allow_monitoring_external_elb_in" {
+resource "aws_security_group_rule" "monitoring_ingress_monitoring-external-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "allow_monitoring_external_elb_in" {
   source_security_group_id = "${aws_security_group.monitoring_external_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_monitoring_internal_elb_in" {
+resource "aws_security_group_rule" "monitoring_ingress_monitoring-internal-elb_nsca" {
   type      = "ingress"
   from_port = 5667
   to_port   = 5667
@@ -47,7 +47,7 @@ resource "aws_security_group_rule" "allow_monitoring_internal_elb_in" {
   source_security_group_id = "${aws_security_group.monitoring_internal_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_monitoring_internal_elb_http_in" {
+resource "aws_security_group_rule" "monitoring_ingress_monitoring-internal-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -70,7 +70,7 @@ resource "aws_security_group" "monitoring_external_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_office_to_monitoring" {
+resource "aws_security_group_rule" "monitoring-external-elb_ingress_office_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -80,8 +80,7 @@ resource "aws_security_group_rule" "allow_office_to_monitoring" {
   cidr_blocks       = ["${var.office_ips}"]
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_monitoring_external_elb_egress" {
+resource "aws_security_group_rule" "monitoring-external-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -100,7 +99,7 @@ resource "aws_security_group" "monitoring_internal_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_management_to_monitoring_internal_elb_ncsa" {
+resource "aws_security_group_rule" "monitoring-internal-elb_ingress_management_ncsa" {
   type      = "ingress"
   from_port = 5667
   to_port   = 5667
@@ -110,9 +109,9 @@ resource "aws_security_group_rule" "allow_management_to_monitoring_internal_elb_
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-resource "aws_security_group_rule" "allow_management_to_monitoring_internal_elb_https" {
+resource "aws_security_group_rule" "monitoring-internal-elb_ingress_management_https" {
   type      = "ingress"
-  from_port = 80
+  from_port = 443
   to_port   = 443
   protocol  = "tcp"
 
@@ -120,8 +119,7 @@ resource "aws_security_group_rule" "allow_management_to_monitoring_internal_elb_
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_monitoring_internal_elb_egress" {
+resource "aws_security_group_rule" "monitoring-internal-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/mysql.tf
+++ b/terraform/projects/infra-security-groups/mysql.tf
@@ -18,7 +18,7 @@ resource "aws_security_group" "mysql-primary" {
   }
 }
 
-resource "aws_security_group_rule" "allow_mysql-primary_from_backend" {
+resource "aws_security_group_rule" "mysql-primary_ingress_backend_mysql" {
   type      = "ingress"
   from_port = 3306
   to_port   = 3306
@@ -31,7 +31,7 @@ resource "aws_security_group_rule" "allow_mysql-primary_from_backend" {
   source_security_group_id = "${aws_security_group.backend.id}"
 }
 
-resource "aws_security_group_rule" "allow_mysql-primary_from_whitehall-backend" {
+resource "aws_security_group_rule" "mysql-primary_ingress_whitehall-backend_mysql" {
   type      = "ingress"
   from_port = 3306
   to_port   = 3306
@@ -44,7 +44,7 @@ resource "aws_security_group_rule" "allow_mysql-primary_from_whitehall-backend" 
   source_security_group_id = "${aws_security_group.whitehall-backend.id}"
 }
 
-resource "aws_security_group_rule" "allow_mysql-primary_from_whitehall-frontend" {
+resource "aws_security_group_rule" "mysql-primary_ingress_whitehall-frontend_mysql" {
   type      = "ingress"
   from_port = 3306
   to_port   = 3306
@@ -57,7 +57,7 @@ resource "aws_security_group_rule" "allow_mysql-primary_from_whitehall-frontend"
   source_security_group_id = "${aws_security_group.whitehall-frontend.id}"
 }
 
-resource "aws_security_group_rule" "allow_mysql-primary_db-admin_in" {
+resource "aws_security_group_rule" "mysql-primary_ingress_db-admin_mysql" {
   type      = "ingress"
   from_port = 3306
   to_port   = 3306
@@ -81,7 +81,7 @@ resource "aws_security_group" "mysql-replica" {
 }
 
 # Contacts is the only application that reads from the MySQL replica
-resource "aws_security_group_rule" "allow_frontend_to_mysql-replica_3306" {
+resource "aws_security_group_rule" "mysql-replica_ingress_frontend_mysql" {
   type      = "ingress"
   from_port = 3306
   to_port   = 3306

--- a/terraform/projects/infra-security-groups/offsite_ssh.tf
+++ b/terraform/projects/infra-security-groups/offsite_ssh.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "offsite_ssh" {
   }
 }
 
-resource "aws_security_group_rule" "allow_offsite_ssh" {
+resource "aws_security_group_rule" "offsite-ssh_ingress_office-and-carrenza_ssh" {
   type        = "ingress"
   from_port   = 22
   to_port     = 22
@@ -31,7 +31,7 @@ resource "aws_security_group_rule" "allow_offsite_ssh" {
   security_group_id = "${aws_security_group.offsite_ssh.id}"
 }
 
-resource "aws_security_group_rule" "allow_egress" {
+resource "aws_security_group_rule" "offsite-ssh_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/postgresql.tf
+++ b/terraform/projects/infra-security-groups/postgresql.tf
@@ -18,7 +18,7 @@ resource "aws_security_group" "postgresql-primary" {
   }
 }
 
-resource "aws_security_group_rule" "allow_postgresql_from_backend_in" {
+resource "aws_security_group_rule" "postgresql-primary_ingress_backend_postgres" {
   type      = "ingress"
   from_port = 5432
   to_port   = 5432
@@ -31,7 +31,7 @@ resource "aws_security_group_rule" "allow_postgresql_from_backend_in" {
   source_security_group_id = "${aws_security_group.backend.id}"
 }
 
-resource "aws_security_group_rule" "allow_postgresql_from_publishing-api_in" {
+resource "aws_security_group_rule" "postgresql-primary_ingress_publishing-api_postgres" {
   type      = "ingress"
   from_port = 5432
   to_port   = 5432
@@ -44,7 +44,7 @@ resource "aws_security_group_rule" "allow_postgresql_from_publishing-api_in" {
   source_security_group_id = "${aws_security_group.publishing-api.id}"
 }
 
-resource "aws_security_group_rule" "allow_postgresql_db-admin_in" {
+resource "aws_security_group_rule" "postgresql-primary_ingress_db-admin_postgres" {
   type      = "ingress"
   from_port = 5432
   to_port   = 5432

--- a/terraform/projects/infra-security-groups/publishing-api.tf
+++ b/terraform/projects/infra-security-groups/publishing-api.tf
@@ -24,7 +24,7 @@ resource "aws_security_group" "publishing-api" {
   }
 }
 
-resource "aws_security_group_rule" "allow_publishing-api_internal_elb_in" {
+resource "aws_security_group_rule" "publishing-api_ingress_publishing-api-elb-internal_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -37,7 +37,7 @@ resource "aws_security_group_rule" "allow_publishing-api_internal_elb_in" {
   source_security_group_id = "${aws_security_group.publishing-api_elb_internal.id}"
 }
 
-resource "aws_security_group_rule" "allow_publishing-api_external_elb_in" {
+resource "aws_security_group_rule" "publishing-api_ingress_publishing-api-elb-external_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -60,9 +60,8 @@ resource "aws_security_group" "publishing-api_elb_internal" {
   }
 }
 
-# TODO: application machines need access to publishing-api - create an application
-# group that needs access?
-resource "aws_security_group_rule" "allow_management_to_publishing-api_https" {
+# TODO: Audit
+resource "aws_security_group_rule" "publishing-api-elb-internal_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -75,8 +74,7 @@ resource "aws_security_group_rule" "allow_management_to_publishing-api_https" {
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-# TODO: test whether egress rules are needed on elbs
-resource "aws_security_group_rule" "allow_publishing-api_elb_internal_egress" {
+resource "aws_security_group_rule" "publishing-api-elb-internal_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -95,7 +93,7 @@ resource "aws_security_group" "publishing-api_elb_external" {
   }
 }
 
-resource "aws_security_group_rule" "allow_office_to_publishing-api_https" {
+resource "aws_security_group_rule" "publishing-api-elb-external_ingress_office_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -106,8 +104,7 @@ resource "aws_security_group_rule" "allow_office_to_publishing-api_https" {
   cidr_blocks       = ["${var.office_ips}"]
 }
 
-# TODO: test whether egress rules are needed on elbs
-resource "aws_security_group_rule" "allow_publishing-api_elb_external_egress" {
+resource "aws_security_group_rule" "publishing-api-elb-external_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/puppetmaster.tf
+++ b/terraform/projects/infra-security-groups/puppetmaster.tf
@@ -21,8 +21,7 @@ resource "aws_security_group" "puppetmaster" {
   }
 }
 
-# All VMs will need to talk to the puppetmaster.
-resource "aws_security_group_rule" "allow_puppet_elb_in" {
+resource "aws_security_group_rule" "puppetmaster_ingress_puppetmaster-elb_puppet" {
   type      = "ingress"
   from_port = 8140
   to_port   = 8140
@@ -35,7 +34,8 @@ resource "aws_security_group_rule" "allow_puppet_elb_in" {
   source_security_group_id = "${aws_security_group.puppetmaster_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_puppetdb_elb_in" {
+# PuppetDB
+resource "aws_security_group_rule" "puppetmaster_ingress_puppetmaster-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -58,7 +58,7 @@ resource "aws_security_group" "puppetmaster_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_management_to_puppet" {
+resource "aws_security_group_rule" "puppetmaster-elb_ingress_management_puppet" {
   type      = "ingress"
   from_port = 8140
   to_port   = 8140
@@ -69,7 +69,7 @@ resource "aws_security_group_rule" "allow_management_to_puppet" {
 }
 
 # This allows the unattended reboot monitoring script to work
-resource "aws_security_group_rule" "allow_monitoring_to_puppetdb" {
+resource "aws_security_group_rule" "puppetmaster-elb_ingress_monitoring_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -80,7 +80,7 @@ resource "aws_security_group_rule" "allow_monitoring_to_puppetdb" {
 }
 
 # This allows full use of our Fabric scripts
-resource "aws_security_group_rule" "allow_jumpbox_to_puppetdb" {
+resource "aws_security_group_rule" "puppetmaster-elb_ingress_jumpbox_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -90,8 +90,7 @@ resource "aws_security_group_rule" "allow_jumpbox_to_puppetdb" {
   source_security_group_id = "${aws_security_group.jumpbox.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_puppetmaster_elb_egress" {
+resource "aws_security_group_rule" "puppetmaster-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/rabbitmq.tf
+++ b/terraform/projects/infra-security-groups/rabbitmq.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "rabbitmq" {
   }
 }
 
-resource "aws_security_group_rule" "allow_rabbitmq_elb_amqp_in" {
+resource "aws_security_group_rule" "rabbitmq_ingress_rabbitmq-elb_amqp" {
   type      = "ingress"
   from_port = 5672
   to_port   = 5672
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "allow_rabbitmq_elb_amqp_in" {
   source_security_group_id = "${aws_security_group.rabbitmq_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_rabbitmq_elb_stomp_in" {
+resource "aws_security_group_rule" "rabbitmq_ingress_rabbitmq-elb_rabbitmq-stomp" {
   type      = "ingress"
   from_port = 6163
   to_port   = 6163
@@ -47,7 +47,7 @@ resource "aws_security_group_rule" "allow_rabbitmq_elb_stomp_in" {
   source_security_group_id = "${aws_security_group.rabbitmq_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_rabbitmq_clustering_in" {
+resource "aws_security_group_rule" "rabbitmq_ingress_rabbitmq_rabbitmq-transport" {
   type      = "ingress"
   from_port = 9100
   to_port   = 9100
@@ -60,7 +60,7 @@ resource "aws_security_group_rule" "allow_rabbitmq_clustering_in" {
   source_security_group_id = "${aws_security_group.rabbitmq.id}"
 }
 
-resource "aws_security_group_rule" "allow_rabbitmq_epmd_in" {
+resource "aws_security_group_rule" "rabbitmq_ingress_rabbitmq_rabbitmq-epmd" {
   type      = "ingress"
   from_port = 4369
   to_port   = 4369
@@ -83,7 +83,8 @@ resource "aws_security_group" "rabbitmq_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_management_to_rabbitmq_amqp_elb" {
+# TODO: Audit
+resource "aws_security_group_rule" "rabbitmq-elb_ingress_management_amqp" {
   type      = "ingress"
   from_port = 5672
   to_port   = 5672
@@ -93,7 +94,7 @@ resource "aws_security_group_rule" "allow_management_to_rabbitmq_amqp_elb" {
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-resource "aws_security_group_rule" "allow_management_to_rabbitmq_stomp_elb" {
+resource "aws_security_group_rule" "rabbitmq-elb_ingress_management_rabbitmq-stomp" {
   type      = "ingress"
   from_port = 6163
   to_port   = 6163
@@ -103,7 +104,7 @@ resource "aws_security_group_rule" "allow_management_to_rabbitmq_stomp_elb" {
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-resource "aws_security_group_rule" "allow_rabbitmq_elb_egress" {
+resource "aws_security_group_rule" "rabbitmq-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/router-backend.tf
+++ b/terraform/projects/infra-security-groups/router-backend.tf
@@ -24,7 +24,7 @@ resource "aws_security_group" "router-backend" {
 }
 
 # the nodes need to speak among themselves for clustering
-resource "aws_security_group_rule" "allow_router-backend_cluster_in" {
+resource "aws_security_group_rule" "router-backend_ingress_router-backend_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
@@ -37,7 +37,7 @@ resource "aws_security_group_rule" "allow_router-backend_cluster_in" {
   source_security_group_id = "${aws_security_group.router-backend.id}"
 }
 
-resource "aws_security_group_rule" "router-backend_elb_in" {
+resource "aws_security_group_rule" "router-backend_ingress_router-backend-elb_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
@@ -50,7 +50,7 @@ resource "aws_security_group_rule" "router-backend_elb_in" {
   source_security_group_id = "${aws_security_group.router-backend_elb.id}"
 }
 
-resource "aws_security_group_rule" "router-api_elb_in" {
+resource "aws_security_group_rule" "router-backend_ingress_router-api-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -73,7 +73,7 @@ resource "aws_security_group" "router-backend_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_router-backend_to_router-backend_elb" {
+resource "aws_security_group_rule" "router-backend-elb_ingress_router-backend_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
@@ -84,7 +84,7 @@ resource "aws_security_group_rule" "allow_router-backend_to_router-backend_elb" 
   source_security_group_id = "${aws_security_group.router-backend.id}"
 }
 
-resource "aws_security_group_rule" "allow_draft-cache_to_router-backend_elb" {
+resource "aws_security_group_rule" "router-backend-elb_ingress_draft-cache_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
@@ -95,7 +95,7 @@ resource "aws_security_group_rule" "allow_draft-cache_to_router-backend_elb" {
   source_security_group_id = "${aws_security_group.draft-cache.id}"
 }
 
-resource "aws_security_group_rule" "allow_cache_to_router-backend_elb" {
+resource "aws_security_group_rule" "router-backend-elb_ingress_cache_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
@@ -116,7 +116,8 @@ resource "aws_security_group" "router-api_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_management_to_router-api_elb" {
+# TODO: Audit
+resource "aws_security_group_rule" "router-api-elb_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -124,13 +125,10 @@ resource "aws_security_group_rule" "allow_management_to_router-api_elb" {
 
   security_group_id = "${aws_security_group.router-api_elb.id}"
 
-  # TODO: does anything other than icinga and logging need this?
-  # content store needs this.
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_router-backend_elb_egress" {
+resource "aws_security_group_rule" "router-backend-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -139,7 +137,7 @@ resource "aws_security_group_rule" "allow_router-backend_elb_egress" {
   security_group_id = "${aws_security_group.router-backend_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_router-api_elb_egress" {
+resource "aws_security_group_rule" "router-api-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/rummager-elasticsearch.tf
+++ b/terraform/projects/infra-security-groups/rummager-elasticsearch.tf
@@ -24,7 +24,7 @@ resource "aws_security_group" "rummager-elasticsearch" {
 }
 
 # the nodes need to speak among themselves for clustering
-resource "aws_security_group_rule" "allow_rummager-elasticsearch_cluster_in" {
+resource "aws_security_group_rule" "rummager-elasticsearch_ingress_rummager-elasticsearch_elasticsearch-transport" {
   type      = "ingress"
   from_port = 9300
   to_port   = 9300
@@ -37,7 +37,7 @@ resource "aws_security_group_rule" "allow_rummager-elasticsearch_cluster_in" {
   source_security_group_id = "${aws_security_group.rummager-elasticsearch.id}"
 }
 
-resource "aws_security_group_rule" "rummager-elasticsearch_elb_in" {
+resource "aws_security_group_rule" "rummager-elasticsearch_ingress_rummager-elasticsearch-elb_elasticsearch-api" {
   type      = "ingress"
   from_port = 9200
   to_port   = 9200
@@ -60,7 +60,7 @@ resource "aws_security_group" "rummager-elasticsearch_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_search_to_rummager-elasticsearch_elb" {
+resource "aws_security_group_rule" "rummager-elasticsearch-elb_ingress_search_elasticsearch-api" {
   type      = "ingress"
   from_port = 9200
   to_port   = 9200
@@ -71,7 +71,7 @@ resource "aws_security_group_rule" "allow_search_to_rummager-elasticsearch_elb" 
   source_security_group_id = "${aws_security_group.search.id}"
 }
 
-resource "aws_security_group_rule" "allow_backend_to_rummager-elasticsearch_elb" {
+resource "aws_security_group_rule" "rummager-elasticsearch-elb_ingress_backend_elasticsearch-api" {
   type      = "ingress"
   from_port = 9200
   to_port   = 9200
@@ -82,7 +82,7 @@ resource "aws_security_group_rule" "allow_backend_to_rummager-elasticsearch_elb"
   source_security_group_id = "${aws_security_group.backend.id}"
 }
 
-resource "aws_security_group_rule" "allow_calculators-frontend_to_rummager-elasticsearch_elb" {
+resource "aws_security_group_rule" "rummager-elasticsearch-elb_ingress_calculators-frontend_elasticsearch-api" {
   type      = "ingress"
   from_port = 9200
   to_port   = 9200
@@ -93,8 +93,7 @@ resource "aws_security_group_rule" "allow_calculators-frontend_to_rummager-elast
   source_security_group_id = "${aws_security_group.calculators-frontend.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_rummager-elasticsearch_elb_egress" {
+resource "aws_security_group_rule" "rummager-elasticsearch-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/search.tf
+++ b/terraform/projects/infra-security-groups/search.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "search" {
   }
 }
 
-resource "aws_security_group_rule" "allow_search_elb_in" {
+resource "aws_security_group_rule" "search_ingress_search-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -44,8 +44,8 @@ resource "aws_security_group" "search_elb" {
   }
 }
 
-# TODO: replace this with ingress from the frontend LBs when we build them.
-resource "aws_security_group_rule" "allow_management_to_search_elb" {
+# TODO: Audit
+resource "aws_security_group_rule" "search-elb_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -55,8 +55,7 @@ resource "aws_security_group_rule" "allow_management_to_search_elb" {
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_search_elb_egress" {
+resource "aws_security_group_rule" "search-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/transition-db-admin.tf
+++ b/terraform/projects/infra-security-groups/transition-db-admin.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "transition-db-admin" {
   }
 }
 
-resource "aws_security_group_rule" "allow_transition-db-admin_elb_in" {
+resource "aws_security_group_rule" "transition-db-admin_ingress_transition-db-admin-elb_ssh" {
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -44,7 +44,7 @@ resource "aws_security_group" "transition-db-admin_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_management_to_transition-db-admin_elb" {
+resource "aws_security_group_rule" "transition-db-admin-elb_ingress_management_ssh" {
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -54,8 +54,7 @@ resource "aws_security_group_rule" "allow_management_to_transition-db-admin_elb"
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_transition-db-admin_elb_egress" {
+resource "aws_security_group_rule" "transition-db-admin-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/transition-postgresql.tf
+++ b/terraform/projects/infra-security-groups/transition-postgresql.tf
@@ -28,7 +28,7 @@ resource "aws_security_group" "transition-postgresql-standby" {
   }
 }
 
-resource "aws_security_group_rule" "allow_transition-postgresql_from_backend_in" {
+resource "aws_security_group_rule" "transition-postgresql-primary_ingress_backend_postgres" {
   type      = "ingress"
   from_port = 5432
   to_port   = 5432
@@ -41,7 +41,7 @@ resource "aws_security_group_rule" "allow_transition-postgresql_from_backend_in"
   source_security_group_id = "${aws_security_group.backend.id}"
 }
 
-resource "aws_security_group_rule" "allow_transition-postgresql_db-admin_in" {
+resource "aws_security_group_rule" "transition-postgresql-primary_ingress_db-admin_postgres" {
   type      = "ingress"
   from_port = 5432
   to_port   = 5432
@@ -54,7 +54,7 @@ resource "aws_security_group_rule" "allow_transition-postgresql_db-admin_in" {
   source_security_group_id = "${aws_security_group.transition-db-admin.id}"
 }
 
-resource "aws_security_group_rule" "allow_transition-postgresql-standby_from_bouncer_in" {
+resource "aws_security_group_rule" "transition-postgresql-standby_ingress_bouncer_postgres" {
   type      = "ingress"
   from_port = 5432
   to_port   = 5432

--- a/terraform/projects/infra-security-groups/whitehall-backend.tf
+++ b/terraform/projects/infra-security-groups/whitehall-backend.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "whitehall-backend" {
   }
 }
 
-resource "aws_security_group_rule" "allow_whitehall-backend_internal_elb_in" {
+resource "aws_security_group_rule" "whitehall-backend_ingress_whitehall-backend-internal-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "allow_whitehall-backend_internal_elb_in" {
   source_security_group_id = "${aws_security_group.whitehall-backend_internal_elb.id}"
 }
 
-resource "aws_security_group_rule" "allow_whitehall-backend_external_elb_in" {
+resource "aws_security_group_rule" "whitehall-backend_ingress_whitehall-backend-external-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -57,8 +57,8 @@ resource "aws_security_group" "whitehall-backend_internal_elb" {
   }
 }
 
-# TODO: replace this with ingress from the LBs when we build them.
-resource "aws_security_group_rule" "allow_management_to_whitehall-backend_internal_elb" {
+# TODO: Audit
+resource "aws_security_group_rule" "whitehall-backend-internal-elb_ingress_management_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -68,8 +68,7 @@ resource "aws_security_group_rule" "allow_management_to_whitehall-backend_intern
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_whitehall-backend_internal_elb_egress" {
+resource "aws_security_group_rule" "whitehall-backend-internal-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -88,7 +87,7 @@ resource "aws_security_group" "whitehall-backend_external_elb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_public_to_whitehall-backend_external_elb" {
+resource "aws_security_group_rule" "whitehall-backend-external-elb_ingress_public_https" {
   type              = "ingress"
   to_port           = 443
   from_port         = 443
@@ -97,8 +96,7 @@ resource "aws_security_group_rule" "allow_public_to_whitehall-backend_external_e
   cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}"]
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_whitehall-backend_external_elb_egress" {
+resource "aws_security_group_rule" "whitehall-backend-external-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/whitehall-frontend.tf
+++ b/terraform/projects/infra-security-groups/whitehall-frontend.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "whitehall-frontend" {
   }
 }
 
-resource "aws_security_group_rule" "allow_whitehall-frontend_elb_in" {
+resource "aws_security_group_rule" "whitehall-frontend_ingress_whitehall-frontend-elb_http" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -44,8 +44,8 @@ resource "aws_security_group" "whitehall-frontend_elb" {
   }
 }
 
-# TODO: replace this with ingress from the LBs when we build them.
-resource "aws_security_group_rule" "allow_management_to_whitehall-frontend_elb" {
+# TODO: Audit
+resource "aws_security_group_rule" "whitehall-frontend-elb_ingress_management_443" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -55,8 +55,7 @@ resource "aws_security_group_rule" "allow_management_to_whitehall-frontend_elb" 
   source_security_group_id = "${aws_security_group.management.id}"
 }
 
-# TODO test whether egress rules are needed on ELBs
-resource "aws_security_group_rule" "allow_whitehall-frontend_elb_egress" {
+resource "aws_security_group_rule" "whitehall-frontend-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/tools/validate-sg-rule-names
+++ b/tools/validate-sg-rule-names
@@ -21,6 +21,8 @@ end.parse!
 
 code = ARGV.shift
 
+$errors = false
+
 Dir["#{code}/**/*.tf"].each do |file|
   puts "Working on [#{file}]" if options[:verbose]
 
@@ -36,6 +38,7 @@ Dir["#{code}/**/*.tf"].each do |file|
 
     if m.nil?
       puts "#{resource_name[:name]} from #{file} did not pass validation"
+      $errors = true
     else
       if m[:source] == 'allow'
         puts "#{resource_name[:name]} from #{file} did not pass validation"
@@ -45,3 +48,5 @@ Dir["#{code}/**/*.tf"].each do |file|
     end
   end
 end
+
+exit 1 if $errors


### PR DESCRIPTION
Update the names of security group rules so they match the convention detailed in the [ADR](https://github.com/alphagov/govuk-aws/blob/master/doc/architecture/decisions/0032-security-group-naming.md).

This also adds the tool to CI to ensure this is enforced.

https://trello.com/c/sO5UkqnX/896-audit-sg-rule-names