### PR TITLE
Fix module alarms nat computed count

### DIFF
--- a/terraform/modules/aws/alarms/natgateway/README.md
+++ b/terraform/modules/aws/alarms/natgateway/README.md
@@ -22,6 +22,7 @@ http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/nat-gateway-metric
 | errorportallocation_threshold | The value against which the ErrorPortAllocation metric is compared. | string | `10` | no |
 | name_prefix | The alarm name prefix. | string | - | yes |
 | nat_gateway_ids | List of IDs of the NAT Gateways that we want to monitor. | list | - | yes |
+| nat_gateway_ids_length | Length of the list of IDs of the NAT Gateways that we want to monitor. | string | - | yes |
 | packetsdropcount_threshold | The value against which the PacketsDropCount metric is compared. | string | `100` | no |
 
 ## Outputs

--- a/terraform/modules/aws/alarms/natgateway/main.tf
+++ b/terraform/modules/aws/alarms/natgateway/main.tf
@@ -29,6 +29,11 @@ variable "nat_gateway_ids" {
   description = "List of IDs of the NAT Gateways that we want to monitor."
 }
 
+variable "nat_gateway_ids_length" {
+  type        = "string"
+  description = "Length of the list of IDs of the NAT Gateways that we want to monitor."
+}
+
 variable "errorportallocation_threshold" {
   type        = "string"
   description = "The value against which the ErrorPortAllocation metric is compared."
@@ -44,7 +49,7 @@ variable "packetsdropcount_threshold" {
 # Resources
 #--------------------------------------------------------------
 resource "aws_cloudwatch_metric_alarm" "natgateway_errorportallocation" {
-  count               = "${length(var.nat_gateway_ids)}"
+  count               = "${var.nat_gateway_ids_length}"
   alarm_name          = "${var.name_prefix}-natgateway-errorportallocation-${element(var.nat_gateway_ids, count.index)}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "5"
@@ -63,7 +68,7 @@ resource "aws_cloudwatch_metric_alarm" "natgateway_errorportallocation" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "natgateway_packetsdropcount" {
-  count               = "${length(var.nat_gateway_ids)}"
+  count               = "${var.nat_gateway_ids_length}"
   alarm_name          = "${var.name_prefix}-natgateway-packetsdropcount-${element(var.nat_gateway_ids, count.index)}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "5"

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -201,10 +201,11 @@ module "infra_private_subnet_reserved_ips" {
 }
 
 module "infra_alarms_natgateway" {
-  source          = "../../modules/aws/alarms/natgateway"
-  name_prefix     = "${var.stackname}-natgateway"
-  alarm_actions   = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  nat_gateway_ids = ["${module.infra_nat.nat_gateway_ids}"]
+  source                 = "../../modules/aws/alarms/natgateway"
+  name_prefix            = "${var.stackname}-natgateway"
+  alarm_actions          = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  nat_gateway_ids        = ["${module.infra_nat.nat_gateway_ids}"]
+  nat_gateway_ids_length = "${length(var.public_subnet_nat_gateway_enable)}"
 }
 
 # Outputs


### PR DESCRIPTION
We need to declare a new variable to define the number of elements
in the nat_gateway_ids list, because this list is computed and can't
be used in a count element.