### PR TITLE
Use splat syntax to access attributes with counts

### DIFF
--- a/terraform/projects/infra-root-dns-zones/main.tf
+++ b/terraform/projects/infra-root-dns-zones/main.tf
@@ -94,21 +94,21 @@ resource "aws_route53_zone" "external_zone" {
 # --------------------------------------------------------------
 
 output "internal_root_zone_id" {
-  value       = "${aws_route53_zone.internal_zone.zone_id}"
+  value       = "${join("", aws_route53_zone.internal_zone.*.zone_id)}"
   description = "Route53 Internal Root Zone ID"
 }
 
 output "internal_root_domain_name" {
-  value       = "${aws_route53_zone.internal_zone.name}"
+  value       = "${join("", aws_route53_zone.internal_zone.*.name)}"
   description = "Route53 Internal Root Domain Name"
 }
 
 output "external_root_zone_id" {
-  value       = "${aws_route53_zone.external_zone.zone_id}"
+  value       = "${join("", aws_route53_zone.external_zone.*.zone_id)}"
   description = "Route53 External Root Zone ID"
 }
 
 output "external_root_domain_name" {
-  value       = "${aws_route53_zone.external_zone.name}"
+  value       = "${join("", aws_route53_zone.external_zone.*.name)}"
   description = "Route53 External Root Domain Name"
 }

--- a/terraform/projects/infra-stack-dns-zones/main.tf
+++ b/terraform/projects/infra-stack-dns-zones/main.tf
@@ -126,11 +126,11 @@ output "internal_domain_name" {
 }
 
 output "external_zone_id" {
-  value       = "${aws_route53_zone.external_zone.zone_id}"
+  value       = "${join("", aws_route53_zone.external_zone.*.zone_id)}"
   description = "Route53 External Zone ID"
 }
 
 output "external_domain_name" {
-  value       = "${aws_route53_zone.external_zone.name}"
+  value       = "${join("", aws_route53_zone.external_zone.*.name)}"
   description = "Route53 External Domain Name"
 }


### PR DESCRIPTION
```
Warning: output "internal_root_zone_id": must use splat syntax to
access aws_route53_zone.internal_zone attribute "zone_id", because it
has "count" set; use aws_route53_zone.internal_zone.*.zone_id to obtain
a list of the attributes across all instances.
```