### PR TITLE
infra buckets use shared logging

### DIFF
--- a/terraform/projects/infra-artefact-bucket/README.md
+++ b/terraform/projects/infra-artefact-bucket/README.md
@@ -21,6 +21,9 @@ artefact_reader: used by instances to fetch artefacts
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | aws_secondary_region | Secondary region for cross-replication | string | `eu-west-2` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
+| stackname | Stackname | string | - | yes |
 
 ## Outputs
 

--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -12,6 +12,9 @@ database-backups: The bucket that will hold database backups
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
+| stackname | Stackname | string | - | yes |
 
 ## Outputs
 

--- a/terraform/projects/infra-monitoring/main.tf
+++ b/terraform/projects/infra-monitoring/main.tf
@@ -54,7 +54,7 @@ data "template_file" "s3_aws_logging_policy_template" {
 # Create a bucket that allows AWS services to write to it
 resource "aws_s3_bucket" "aws-logging" {
   bucket = "govuk-${var.aws_environment}-aws-logging"
-  acl    = "private"
+  acl    = "log-delivery-write"
 
   tags {
     Name        = "govuk-${var.aws_environment}-aws-logging"


### PR DESCRIPTION
Update the infra-*-bucket proejcts to use the shared logging bucket
for S3 access logs. These projects were initially configured
without logging or a separate access log bucket, but since then we
enabled a shared bucket in infra-monitoring.

S3 buckets will use the prefix `s3/bucket_name/` to store logs.