### PR TITLE
Add missing device tags to EBS volumes

### DIFF
--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -212,6 +212,7 @@ resource "aws_ebs_volume" "graphite-1" {
   tags {
     Name            = "${var.stackname}-graphite-1"
     Project         = "${var.stackname}"
+    Device          = "xvdf"
     aws_stackname   = "${var.stackname}"
     aws_environment = "${var.aws_environment}"
     aws_migration   = "graphite"

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -137,6 +137,7 @@ resource "aws_ebs_volume" "mapit-1" {
   tags {
     Name            = "${var.stackname}-mapit"
     Project         = "${var.stackname}"
+    Device          = "xvdf"
     aws_hostname    = "mapit-1"
     aws_migration   = "mapit"
     aws_stackname   = "${var.stackname}"
@@ -168,6 +169,7 @@ resource "aws_ebs_volume" "mapit-2" {
   tags {
     Name            = "${var.stackname}-mapit"
     Project         = "${var.stackname}"
+    Device          = "xvdf"
     aws_hostname    = "mapit-2"
     aws_migration   = "mapit"
     aws_stackname   = "${var.stackname}"


### PR DESCRIPTION
A couple of projects are missing the 'Device' tag in the EBS volume
that helps to attach the disk from Userdata.