### PR TITLE
Update the default SSL configuration in LBs

### DIFF
--- a/terraform/modules/aws/lb/main.tf
+++ b/terraform/modules/aws/lb/main.tf
@@ -70,7 +70,7 @@ variable "listener_certificate_domain_name" {
 variable "listener_ssl_policy" {
   type        = "string"
   description = "The name of the SSL Policy for HTTPS listeners."
-  default     = "ELBSecurityPolicy-2015-05"
+  default     = "ELBSecurityPolicy-2016-08"
 }
 
 variable "internal" {


### PR DESCRIPTION
The predefined security policy is ELBSecurityPolicy-2016-08, currently
applied on ELBs. Update the default version in the LB module to match
the predefined settings.

https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html