### PR TITLE
Add asset-master-efs security groups

### DIFF
--- a/terraform/projects/app-asset-master/main.tf
+++ b/terraform/projects/app-asset-master/main.tf
@@ -38,9 +38,10 @@ resource "aws_efs_file_system" "assets-efs-fs" {
 }
 
 resource "aws_efs_mount_target" "assets-mount-target" {
-  count          = "${length(data.terraform_remote_state.infra_networking.private_subnet_ids)}"
-  file_system_id = "${aws_efs_file_system.assets-efs-fs.id}"
-  subnet_id      = "${element(data.terraform_remote_state.infra_networking.private_subnet_ids, count.index)}"
+  count           = "${length(data.terraform_remote_state.infra_networking.private_subnet_ids)}"
+  file_system_id  = "${aws_efs_file_system.assets-efs-fs.id}"
+  subnet_id       = "${element(data.terraform_remote_state.infra_networking.private_subnet_ids, count.index)}"
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_asset-master-efs_id}"]
 }
 
 resource "aws_route53_record" "assets_service_record" {

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -22,6 +22,7 @@ Manage the security groups for the entire infrastructure
 | sg_apt_external_elb_id |  |
 | sg_apt_id |  |
 | sg_apt_internal_elb_id |  |
+| sg_asset-master-efs_id |  |
 | sg_asset-master_id |  |
 | sg_backend-redis_id |  |
 | sg_backend_elb_external_id |  |
@@ -45,8 +46,8 @@ Manage the security groups for the entire infrastructure
 | sg_deploy_internal_elb_id |  |
 | sg_docker_management_etcd_elb_id |  |
 | sg_docker_management_id |  |
-| sg_draft-cache_elb_external_id |  |
 | sg_draft-cache_elb_id |  |
+| sg_draft-cache_external_elb_id |  |
 | sg_draft-cache_id |  |
 | sg_draft-content-store_external_elb_id |  |
 | sg_draft-content-store_id |  |

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -6,6 +6,10 @@ output "sg_asset-master_id" {
   value = "${aws_security_group.asset-master.id}"
 }
 
+output "sg_asset-master-efs_id" {
+  value = "${aws_security_group.asset-master-efs.id}"
+}
+
 output "sg_postgresql-primary_id" {
   value = "${aws_security_group.postgresql-primary.id}"
 }


### PR DESCRIPTION
asset-master is timing out when it tries to mount the EFS
volume. I think we are missing the security rules.