### PR TITLE
Fix Bouncer LB health check

### DIFF
--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -124,6 +124,7 @@ module "bouncer_internal_lb" {
   access_logs_bucket_prefix        = "elb/${var.stackname}-bouncer-internal-elb"
   listener_certificate_domain_name = "${var.elb_internal_certname}"
   listener_action                  = "${local.internal_lb_map}"
+  target_group_health_check_path   = "/healthcheck"
   subnets                          = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups                  = ["${data.terraform_remote_state.infra_security_groups.sg_bouncer_internal_elb_id}"]
   alarm_actions                    = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -443,6 +443,7 @@ module "bouncer_public_lb" {
   access_logs_bucket_prefix        = "elb/${var.stackname}-bouncer-public-elb"
   listener_certificate_domain_name = "${var.elb_public_certname}"
   listener_action                  = "${map("HTTPS:443", "HTTP:80")}"
+  target_group_health_check_path   = "/healthcheck"
   subnets                          = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                  = ["${data.terraform_remote_state.infra_security_groups.sg_bouncer_elb_id}"]
   alarm_actions                    = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]


### PR DESCRIPTION
On the bouncer machines, Nginx is configured to use the 'bouncer'
vhost as the default one. The Puppet template does not allow to
insert custom code before the 'location /' block, so we can't set
our health check to '/_healthcheck' as we have done in the other
machines.

Bouncer already deploys a heath check on `/healthcheck`, so use
that instead.