### PR TITLE
Add variable for Carrenza Production IPs

### DIFF
--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -34,6 +34,11 @@ variable "carrenza_integration_ips" {
   description = "An array of CIDR blocks that will be allowed to SSH to the jumpbox."
 }
 
+variable "carrenza_production_ips" {
+  type        = "list"
+  description = "An array of CIDR blocks that will be allowed to SSH to the jumpbox."
+}
+
 variable "traffic_replay_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will replay traffic against an environment"


### PR DESCRIPTION
I forgot to add the variable in 7b677d5229d86b2489f4dfc693e4d617cb8e7d11.

I added it as an additional rather than updating the current variable for Integration as in the future we may wish to use the Integration variable.