### PR TITLE
Attach ENI to router-backend

### DIFF
--- a/terraform/projects/app-router-backend/README.md
+++ b/terraform/projects/app-router-backend/README.md
@@ -19,8 +19,14 @@ Router backend hosts both Mongo and router-api
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| router-backend_1_ip | IP address of the private IP to assign to the instance | string | - | yes |
+| router-backend_1_reserved_ips_subnet | Name of the subnet to place the reserved IP of the instance | string | - | yes |
 | router-backend_1_subnet | Name of the subnet to place the Router Mongo 1 | string | - | yes |
+| router-backend_2_ip | IP address of the private IP to assign to the instance | string | - | yes |
+| router-backend_2_reserved_ips_subnet | Name of the subnet to place the reserved IP of the instance | string | - | yes |
 | router-backend_2_subnet | Name of the subnet to place the Router Mongo 2 | string | - | yes |
+| router-backend_3_ip | IP address of the private IP to assign to the instance | string | - | yes |
+| router-backend_3_reserved_ips_subnet | Name of the subnet to place the reserved IP of the instance | string | - | yes |
 | router-backend_3_subnet | Name of the subnet to place the Router Mongo 3 | string | - | yes |
 | stackname | Stackname | string | - | yes |
 | user_data_snippets | List of user-data snippets | list | - | yes |

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -9,6 +9,7 @@ Manage the security groups for the entire infrastructure
 |------|-------------|:----:|:-----:|:-----:|
 | aws_region | AWS region | string | `eu-west-1` | no |
 | carrenza_integration_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
+| carrenza_production_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | office_ips | An array of CIDR blocks that will be allowed offsite access. | list | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
@@ -82,7 +83,6 @@ Manage the security groups for the entire infrastructure
 | sg_rabbitmq_elb_id |  |
 | sg_rabbitmq_id |  |
 | sg_router-api_elb_id |  |
-| sg_router-backend_elb_id |  |
 | sg_router-backend_id |  |
 | sg_rummager-elasticsearch_elb_id |  |
 | sg_rummager-elasticsearch_id |  |

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -258,10 +258,6 @@ output "sg_router-api_elb_id" {
   value = "${aws_security_group.router-api_elb.id}"
 }
 
-output "sg_router-backend_elb_id" {
-  value = "${aws_security_group.router-backend_elb.id}"
-}
-
 output "sg_router-backend_id" {
   value = "${aws_security_group.router-backend.id}"
 }

--- a/terraform/projects/infra-security-groups/router-backend.tf
+++ b/terraform/projects/infra-security-groups/router-backend.tf
@@ -10,7 +10,6 @@
 #
 # === Outputs:
 # sg_router-backend_id
-# sg_router-backend_elb_id
 # sg_router-api_elb_id
 #
 resource "aws_security_group" "router-backend" {
@@ -37,19 +36,6 @@ resource "aws_security_group_rule" "router-backend_ingress_router-backend_mongo"
   source_security_group_id = "${aws_security_group.router-backend.id}"
 }
 
-resource "aws_security_group_rule" "router-backend_ingress_router-backend-elb_mongo" {
-  type      = "ingress"
-  from_port = 27017
-  to_port   = 27017
-  protocol  = "tcp"
-
-  # Which security group is the rule assigned to
-  security_group_id = "${aws_security_group.router-backend.id}"
-
-  # Which security group can use this rule
-  source_security_group_id = "${aws_security_group.router-backend_elb.id}"
-}
-
 resource "aws_security_group_rule" "router-backend_ingress_router-api-elb_http" {
   type      = "ingress"
   from_port = 80
@@ -63,45 +49,24 @@ resource "aws_security_group_rule" "router-backend_ingress_router-api-elb_http" 
   source_security_group_id = "${aws_security_group.router-api_elb.id}"
 }
 
-resource "aws_security_group" "router-backend_elb" {
-  name        = "${var.stackname}_router-backend_elb_access"
-  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  description = "Access the Router Mongo cluster"
-
-  tags {
-    Name = "${var.stackname}_router-backend_elb_access"
-  }
-}
-
-resource "aws_security_group_rule" "router-backend-elb_ingress_router-backend_mongo" {
+resource "aws_security_group_rule" "router-backend_ingress_draft-cache_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
   protocol  = "tcp"
 
-  security_group_id = "${aws_security_group.router-backend_elb.id}"
-
-  source_security_group_id = "${aws_security_group.router-backend.id}"
-}
-
-resource "aws_security_group_rule" "router-backend-elb_ingress_draft-cache_mongo" {
-  type      = "ingress"
-  from_port = 27017
-  to_port   = 27017
-  protocol  = "tcp"
-
-  security_group_id = "${aws_security_group.router-backend_elb.id}"
+  security_group_id = "${aws_security_group.router-backend.id}"
 
   source_security_group_id = "${aws_security_group.draft-cache.id}"
 }
 
-resource "aws_security_group_rule" "router-backend-elb_ingress_cache_mongo" {
+resource "aws_security_group_rule" "router-backend_ingress_cache_mongo" {
   type      = "ingress"
   from_port = 27017
   to_port   = 27017
   protocol  = "tcp"
 
-  security_group_id = "${aws_security_group.router-backend_elb.id}"
+  security_group_id = "${aws_security_group.router-backend.id}"
 
   source_security_group_id = "${aws_security_group.cache.id}"
 }
@@ -126,15 +91,6 @@ resource "aws_security_group_rule" "router-api-elb_ingress_management_https" {
   security_group_id = "${aws_security_group.router-api_elb.id}"
 
   source_security_group_id = "${aws_security_group.management.id}"
-}
-
-resource "aws_security_group_rule" "router-backend-elb_egress_any_any" {
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.router-backend_elb.id}"
 }
 
 resource "aws_security_group_rule" "router-api-elb_egress_any_any" {


### PR DESCRIPTION
Same as 14e27bf, we are seeing some issues in apps trying
to connect with the mongo instances in the router-backend
machines.

This change replaces the ELB with ENI and updates the instance
DNS to use the reserved IP assigned to the ENI.

We also update the security groups to apply to the instance
SG the same permissions perviously assigned to the ELB.