### PR TITLE
Add network policy to router-backend

### DIFF
--- a/terraform/projects/app-router-backend/additional_policy.json
+++ b/terraform/projects/app-router-backend/additional_policy.json
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1499854881000",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:AttachNetworkInterface"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -294,6 +294,18 @@ resource "aws_iam_role_policy_attachment" "router-backend_database_backups_iam_r
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.write_database_backups_bucket_policy_arn}"
 }
 
+resource "aws_iam_policy" "router-backend_iam_policy" {
+  name   = "${var.stackname}-router-backend-additional"
+  path   = "/"
+  policy = "${file("${path.module}/additional_policy.json")}"
+}
+
+resource "aws_iam_role_policy_attachment" "router-backend_iam_role_policy_attachment" {
+  count      = 3
+  role       = "${element(list(module.router-backend-1.instance_iam_role_name, module.router-backend-2.instance_iam_role_name, module.router-backend-3.instance_iam_role_name), count.index)}"
+  policy_arn = "${aws_iam_policy.router-backend_iam_policy.arn}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 


### PR DESCRIPTION
Add missing additional policy to router-backend to attach ENIs,
missing in 4440f5.