### PR TITLE
Allow SSH to jumpbox from Carrenza Staging

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -10,6 +10,7 @@ Manage the security groups for the entire infrastructure
 | aws_region | AWS region | string | `eu-west-1` | no |
 | carrenza_integration_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_production_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
+| carrenza_staging_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | office_ips | An array of CIDR blocks that will be allowed offsite access. | list | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |

--- a/terraform/projects/infra-security-groups/offsite_ssh.tf
+++ b/terraform/projects/infra-security-groups/offsite_ssh.tf
@@ -26,7 +26,7 @@ resource "aws_security_group_rule" "offsite-ssh_ingress_office-and-carrenza_ssh"
   from_port   = 22
   to_port     = 22
   protocol    = "tcp"
-  cidr_blocks = ["${concat(var.office_ips, var.carrenza_production_ips)}"]
+  cidr_blocks = ["${concat(var.office_ips, var.carrenza_production_ips, var.carrenza_staging_ips)}"]
 
   security_group_id = "${aws_security_group.offsite_ssh.id}"
 }

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -34,6 +34,11 @@ variable "carrenza_integration_ips" {
   description = "An array of CIDR blocks that will be allowed to SSH to the jumpbox."
 }
 
+variable "carrenza_staging_ips" {
+  type        = "list"
+  description = "An array of CIDR blocks that will be allowed to SSH to the jumpbox."
+}
+
 variable "carrenza_production_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will be allowed to SSH to the jumpbox."


### PR DESCRIPTION
Allow SSH to jumpbox from Carrenza Staging to sync attachments. We
can remove the rule when we finish syncing data or leave it after
the switchover.