### PR TITLE
Update infra-artefact-bucket key name

### DIFF
--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -60,7 +60,7 @@ data "terraform_remote_state" "artefact_bucket" {
 
   config {
     bucket = "${var.remote_state_bucket}"
-    key    = "${coalesce(var.remote_state_infra_artefact_bucket_key_stack, var.stackname)}/artefact-bucket.tfstate"
+    key    = "${coalesce(var.remote_state_infra_artefact_bucket_key_stack, var.stackname)}/infra-artefact-bucket.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/projects/infra-artefact-bucket/integration.govuk.backend
+++ b/terraform/projects/infra-artefact-bucket/integration.govuk.backend
@@ -1,4 +1,4 @@
 bucket  = "govuk-terraform-steppingstone-integration"
-key     = "govuk/artefact-bucket.tfstate"
+key     = "govuk/infra-artefact-bucket.tfstate"
 encrypt = true
 region  = "eu-west-1"

--- a/terraform/projects/infra-artefact-bucket/production.govuk.backend
+++ b/terraform/projects/infra-artefact-bucket/production.govuk.backend
@@ -1,4 +1,4 @@
 bucket  = "govuk-terraform-steppingstone-production"
-key     = "govuk/artefact-bucket.tfstate"
+key     = "govuk/infra-artefact-bucket.tfstate"
 encrypt = true
 region  = "eu-west-1"


### PR DESCRIPTION
Staging Jenkins failed to deploy because the key used was inconsistent.  We have updated it to use the consistent naming scheme across all backend files, and will update Integration to migrate the statefile.

https://trello.com/c/licP4V2x/925-build-staging-in-aws-and-review