### PR TITLE
Add script for Jenkins deploy

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# This script invokes the build-terraform-project.sh tool to deploy the code.
+#
+if [[ ! $(which sops) ]]; then
+  echo "sops not installed, exiting"
+  exit 1
+fi
+
+# Set the Terraform version to enable testing new versions.
+if [[ $TERRAFORM_VERSION != '' ]]; then
+  BIN='tmp-bin'
+
+  echo "Creating temporary bin directory"
+  rm -rf $BIN && mkdir $BIN && cd $BIN/
+
+  echo "Downloading Terraform ${TERRAFORM_VERSION}"
+
+  wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+  wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS
+
+  SHASUM256=$(shasum -a 256 terraform_${TERRAFORM_VERSION}_linux_amd64.zip |cut -d ' ' -f1)
+
+  echo "Checking integrity of file"
+  grep -q $SHASUM256 terraform_${TERRAFORM_VERSION}_SHA256SUMS || (echo "SHASUM256 does not match, exiting"; exit 1)
+
+  echo "Checked, unpacking"
+  unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
+  cd ..
+
+  echo "Setting path:"
+  PATH=$(pwd)/$BIN:$PATH
+  echo $PATH
+
+  echo "Terraform binary: $(which terraform)"
+fi
+
+echo "Cloning govuk-aws-data"
+git clone https://github.com/alphagov/govuk-aws-data.git
+
+if $COMMAND == 'apply'; then
+  $EXTRA='-auto-approve'
+fi
+
+if $COMMAND == 'destroy'; then
+  $EXTRA='-force'
+fi
+
+tools/build-terraform-project.sh -d './govuk-aws-data/data' \
+                                 -c $COMMAND \
+                                 -p $PROJECT \
+                                 -s $STACKNAME \
+                                 -e $ENVIRONMENT \
+                                 -- $EXTRA


### PR DESCRIPTION
This script invokes the `build-terraform-project.sh` script and should be triggered using Jenkins.

Sops is a precursor as an install to run these scripts, and should be managed by Puppet as it is less liable to change than Terraform.

If the Terraform version is not specified using TERRAFORM_VERSION, then it will use the default installed on the system where it is being run.

If you wish to test newer versions of Terraform (quite a common occurrence at this point in the Terraform lifecycle), then you can specify a version and the script will download, verify and set the path for that version of Terraform.

https://trello.com/c/qAzTAU4p/952-build-box-spike-on-adding-tf-deploys-to-current-integration-carrenza-deploy-jenkins