### PR TITLE
Allow deploy to access redis

### DIFF
--- a/terraform/projects/infra-security-groups/backend-redis.tf
+++ b/terraform/projects/infra-security-groups/backend-redis.tf
@@ -85,3 +85,16 @@ resource "aws_security_group_rule" "backend-redis_ingress_search_redis" {
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.search.id}"
 }
+
+resource "aws_security_group_rule" "backend-redis_ingress_deploy_redis" {
+  type      = "ingress"
+  from_port = 6379
+  to_port   = 6379
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.backend-redis.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.deploy.id}"
+}


### PR DESCRIPTION
This commit adds a security group rule to allow deploy machines to access redis machines. This allows the emergency banner job to work since it writes data directly to redis.