### PR TITLE
infra-security support empty user list

### DIFF
--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -15,11 +15,11 @@ Infrastructure security settings:
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | role_admin_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |
-| role_admin_user_arns | List of ARNs of external users that can assume the role | list | - | yes |
+| role_admin_user_arns | List of ARNs of external users that can assume the role | list | `<list>` | no |
 | role_poweruser_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |
-| role_poweruser_user_arns | List of ARNs of external users that can assume the role | list | - | yes |
+| role_poweruser_user_arns | List of ARNs of external users that can assume the role | list | `<list>` | no |
 | role_user_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |
-| role_user_user_arns | List of ARNs of external users that can assume the role | list | - | yes |
+| role_user_user_arns | List of ARNs of external users that can assume the role | list | `<list>` | no |
 | ssh_public_key | The public part of an SSH keypair | string | - | yes |
 | stackname | Stackname | string | `` | no |
 

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -29,6 +29,7 @@ variable "stackname" {
 variable "role_admin_user_arns" {
   type        = "list"
   description = "List of ARNs of external users that can assume the role"
+  default     = []
 }
 
 variable "role_admin_policy_arns" {
@@ -40,6 +41,7 @@ variable "role_admin_policy_arns" {
 variable "role_poweruser_user_arns" {
   type        = "list"
   description = "List of ARNs of external users that can assume the role"
+  default     = []
 }
 
 variable "role_poweruser_policy_arns" {
@@ -51,6 +53,7 @@ variable "role_poweruser_policy_arns" {
 variable "role_user_user_arns" {
   type        = "list"
   description = "List of ARNs of external users that can assume the role"
+  default     = []
 }
 
 variable "role_user_policy_arns" {


### PR DESCRIPTION
As we add more environments and user roles, sometimes we don't
need to create all of them on each environment. For instance,
the users group doesn't need to be present on the Test environment,
where we want people to be able to create more things.

To support empty lists of users from the data files, the `role_X_user_arns`
parameters in the infra-security manifest need to default to empty list,
and the `role_user` module needs to only create a role when the list
of users is not null. This is needed because the `Principal` section in
the policy can't be an empty string.