### PR TITLE
Add empty defaults in infra-networking

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,16 +3,15 @@ GEM
   specs:
     coderay (1.1.2)
     colorize (0.8.1)
-    commander (4.4.3)
+    commander (4.4.4)
       highline (~> 1.7.2)
     diff-lcs (1.3)
     git (1.3.0)
     highline (1.7.10)
-    method_source (0.8.2)
-    pry (0.10.4)
+    method_source (0.9.0)
+    pry (0.11.3)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
+      method_source (~> 0.9.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -25,9 +24,8 @@ GEM
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
-    rspec-support (3.7.0)
-    slop (3.6.0)
-    terragov (0.3.2)
+    rspec-support (3.7.1)
+    terragov (0.4.0)
       commander
       git
 

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -64,31 +64,37 @@ variable "private_subnet_nat_gateway_association" {
 variable "private_subnet_elasticache_cidrs" {
   type        = "map"
   description = "Map containing private elasticache subnet names and CIDR associated"
+  default     = {}
 }
 
 variable "private_subnet_elasticache_availability_zones" {
   type        = "map"
   description = "Map containing private elasticache subnet names and availability zones associated"
+  default     = {}
 }
 
 variable "private_subnet_rds_cidrs" {
   type        = "map"
   description = "Map containing private rds subnet names and CIDR associated"
+  default     = {}
 }
 
 variable "private_subnet_rds_availability_zones" {
   type        = "map"
   description = "Map containing private rds subnet names and availability zones associated"
+  default     = {}
 }
 
 variable "private_subnet_reserved_ips_cidrs" {
   type        = "map"
   description = "Map containing private ENI subnet names and CIDR associated"
+  default     = {}
 }
 
 variable "private_subnet_reserved_ips_availability_zones" {
   type        = "map"
   description = "Map containing private ENI subnet names and availability zones associated"
+  default     = {}
 }
 
 # Resources


### PR DESCRIPTION
Within the test environment we do not want to add subnets for things like RDS and Elasticache. Setting empty defaults means the module will not create these subnets. Empty defaults need to be set because otherwise it expects variables to be passed in and will error without.

Also update Gemfile.lock for up to date Ruby dependencies.

https://trello.com/c/4lvHCiOg/965-tidy-up-govuk-infrastructure-test-aws-account