### PR TITLE
Increase backend-redis to cache.m3.large

### DIFF
--- a/terraform/projects/app-backend-redis/main.tf
+++ b/terraform/projects/app-backend-redis/main.tf
@@ -46,12 +46,13 @@ resource "aws_route53_record" "service_record" {
 }
 
 module "backend_redis_cluster" {
-  source             = "../../modules/aws/elasticache_redis_cluster"
-  enable_clustering  = "${var.enable_clustering}"
-  name               = "${var.stackname}-backend-redis"
-  default_tags       = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend-redis")}"
-  subnet_ids         = "${data.terraform_remote_state.infra_networking.private_subnet_elasticache_ids}"
-  security_group_ids = ["${data.terraform_remote_state.infra_security_groups.sg_backend-redis_id}"]
+  source                = "../../modules/aws/elasticache_redis_cluster"
+  enable_clustering     = "${var.enable_clustering}"
+  name                  = "${var.stackname}-backend-redis"
+  default_tags          = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend-redis")}"
+  subnet_ids            = "${data.terraform_remote_state.infra_networking.private_subnet_elasticache_ids}"
+  security_group_ids    = ["${data.terraform_remote_state.infra_security_groups.sg_backend-redis_id}"]
+  elasticache_node_type = "cache.m4.large"
 }
 
 module "alarms-elasticache-backend-redis" {


### PR DESCRIPTION
This is required due to out of memory errors that occur as a result of
elasticsearch reindexing on a nightly basis.

3rd line ticket:
https://govuk.zendesk.com/agent/tickets/2587672

https://trello.com/c/JHcwDJc0/81-compress-rummager-data-in-sidekiq-when-updating-pageviews