### PR TITLE
Add app-logs-cdn to the Terragov deployment file

### DIFF
--- a/deployment/terragov/deployment.yaml
+++ b/deployment/terragov/deployment.yaml
@@ -22,6 +22,7 @@ support:
   # app-apt should be deployed for Gemstash
   - 'app-apt'
   - 'app-mirrorer'
+  - 'app-logs-cdn' # Only used in Staging and Production
 
 # Datastores
 datastores:
@@ -74,6 +75,7 @@ all_node_groups:
   - 'app-jumpbox'
   - 'app-apt'
   - 'app-mirrorer'
+  - 'app-logs-cdn' # Only used in Staging and Production
   - 'app-db-admin'
   - 'app-transition-db-admin'
   - 'app-docker-management'


### PR DESCRIPTION
- I didn't particularly know where to put this, it's on its own in Puppet as
  far as I can see, so I put it with 'app-mirrorer' and 'app-apt' etc.
- Also note that it's only used in staging and production