### PR TITLE
Only ask for MFA on assume-role once in 12 hours

### DIFF
--- a/terraform/modules/aws/iam/role_user/main.tf
+++ b/terraform/modules/aws/iam/role_user/main.tf
@@ -62,6 +62,15 @@ data "aws_iam_policy_document" "assume_policy_document" {
         "true",
       ]
     }
+
+    condition {
+      test     = "NumericLessThan"
+      variable = "aws:MultiFactorAuthAge"
+
+      values = [
+        "43200",
+      ]
+    }
   }
 }
 


### PR DESCRIPTION
- Previously, every time we called "aws assume-role" on the command
  line, we'd have to get our phones (or other designated MFA solution)
  and type in a code. This would have to happen every hour, which was
  tedious for long-running builds like building an environment.
- With this change, AWS won't require an MFA token upon assuming a role
  if `sts get-session-token` with an MFA code has been successful within
  the last 12 hours (43200 seconds).
- This doesn't remove the requirement to refresh your assume-role tokens
  every hour, as that's a different AWS limitation.