### PR TITLE
Add verbose error for no backend file

### DIFF
--- a/tools/build-terraform-project.sh
+++ b/tools/build-terraform-project.sh
@@ -128,6 +128,12 @@ cd "$PROJECT_DIR"
 
 # Actually run the command
 function init() {
+  if [[ ! -f $BACKEND_FILE ]]; then
+    echo "Could not find backend file for $STACKNAME stack."
+    echo "Possible stacks to deploy in $ENVIRONMENT for $PROJECT are: "
+    find . -name "${ENVIRONMENT}.*.backend" |cut -d "." -f3
+    exit 1
+  fi
   rm -rf .terraform && \
   rm -rf terraform.tfstate.backup && \
   terraform init \


### PR DESCRIPTION
When a backend file is missing, a misleading error is shown. We should produce an error that guides the user to try the correct thing. This should produce a list of possible stacks to deploy to if the backend file does not exist for that stack in the specified environment.