### PR TITLE
Fix email alert api public service

### DIFF
--- a/terraform/modules/aws/lb/main.tf
+++ b/terraform/modules/aws/lb/main.tf
@@ -210,7 +210,6 @@ locals {
 
 resource "aws_lb_target_group" "tg_default" {
   count                = "${length(local.target_groups)}"
-  name                 = "${var.name}-${replace(element(local.target_groups, count.index), ":", "-")}"
   port                 = "${element(split(":", element(local.target_groups, count.index)), 1)}"
   protocol             = "${element(split(":", element(local.target_groups, count.index)), 0)}"
   vpc_id               = "${var.vpc_id}"
@@ -226,6 +225,13 @@ resource "aws_lb_target_group" "tg_default" {
     unhealthy_threshold = 2
     timeout             = "${var.target_group_health_check_timeout}"
   }
+
+  tags = "${merge(
+    var.default_tags,
+    map(
+      "Name", "${var.name}-${replace(element(local.target_groups, count.index), ":", "-")}"
+    )
+  )}"
 }
 
 locals {

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -814,7 +814,7 @@ module "email_alert_api_public_lb" {
   listener_certificate_domain_name = "${var.elb_public_certname}"
   listener_action                  = "${map("HTTPS:443", "HTTP:80")}"
   subnets                          = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups                  = ["${data.terraform_remote_state.infra_security_groups.sg_email_alert_api_elb_external_id}"]
+  security_groups                  = ["${data.terraform_remote_state.infra_security_groups.sg_email-alert-api_elb_external_id}"]
   alarm_actions                    = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
   default_tags                     = "${map("Project", var.stackname, "aws_migration", "email_alert_api", "aws_environment", var.aws_environment)}"
 }


### PR DESCRIPTION
Firstly, use correct name for email alert api external elb security group output. It should use dashes not underscores for `email-alert-api`.

Also, we hit the character limit on an ELB target group name. This changes the naming to be managed by TF, and moves the previously specified naming into tags.