### PR TITLE
Add completion for govukcli

### DIFF
--- a/doc/guides/connecting-to-the-environment.md
+++ b/doc/guides/connecting-to-the-environment.md
@@ -48,3 +48,25 @@ To view current context:
 To list available contexts:
 
 `govukcli list-contexts`
+
+### Completion
+
+The script comes with tab completion to make it easier to work with.
+
+#### Bash and Homebrew
+
+`brew install bash-completion`
+
+Follow the instructions after install to ensure completions work, and link the file
+to the completion directory:
+
+`ln -s ~/govuk/govuk-aws/tools/govukcli.completion /usr/local/etc/bash_completion/govukcli`
+
+#### Zsh
+
+There are no Zsh completions for the script, but it does load bash completion compatability
+for Zsh.
+
+The easiest way to install is to load it in `~/.zshrc`:
+
+`echo "source ~/govuk/govuk-aws/tools/govukcli.completion" >> ~/.zshrc`

--- a/tools/govukcli.completion
+++ b/tools/govukcli.completion
@@ -1,0 +1,114 @@
+# == govukcli completion ==
+#
+# Shamelessly stolen from the best example I managed to find:
+# https://github.com/syncany/syncany/blob/7a15d5f17e1a894de97f05389aaa133d7c0acd95/gradle/bash/syncany.bash-completion
+#
+# If shell is ZSH then make it compatible
+if [[ -n "$ZSH_VERSION" ]]; then
+  autoload bashcompinit
+  bashcompinit
+fi
+
+_govukcli ()
+{
+  local cur prev firstword lastword complete_words complete_options
+
+  # Don't break words at : and =, see [1] and [2]
+  COMP_WORDBREAKS=${COMP_WORDBREAKS//[:=]}
+
+  cur=${COMP_WORDS[COMP_CWORD]}
+  prev=${COMP_WORDS[COMP_CWORD-1]}
+  firstword=$(_govukcli_get_firstword)
+  lastword=$(_govukcli_get_lastword)
+
+  GLOBAL_COMMANDS="\
+    get-context\
+    list-contexts\
+    set-context\
+    ssh\
+    help"
+
+  SSH_COMMANDS="\
+    set-user\
+    node-types\
+    <node>"
+
+  case $firstword in
+    ssh)
+      case "${lastword}" in
+        node-types)
+          ;;
+        set-user)
+          complete_words='<username>'
+          ;;
+        *)
+          complete_words="$SSH_COMMANDS"
+          ;;
+      esac
+      ;;
+
+    set-context)
+      case "${lastword}" in
+        *)
+          complete_words="$(govukcli list-contexts)"
+          ;;
+      esac
+      ;;
+
+    list-contexts)
+      case "${lastword}" in
+        *)
+          complete_words=""
+          ;;
+      esac
+      ;;
+
+    help)
+      case "${lastword}" in
+        *)
+          complete_words=""
+          ;;
+      esac
+      ;;
+
+    *)
+      complete_words="$GLOBAL_COMMANDS"
+      ;;
+  esac
+
+  COMPREPLY=( $( compgen -W "$complete_words" -- $cur ))
+  return 0
+}
+
+# Determines the first non-option word of the command line. This
+# is usually the command
+_govukcli_get_firstword() {
+  local firstword i
+
+  firstword=
+  for ((i = 1; i < ${#COMP_WORDS[@]}; ++i)); do
+    if [[ ${COMP_WORDS[i]} != -* ]]; then
+      firstword=${COMP_WORDS[i]}
+      break
+    fi
+  done
+
+  echo $firstword
+}
+
+# Determines the last non-option word of the command line. This
+# is usally a sub-command
+_govukcli_get_lastword() {
+  local lastword i
+
+  lastword=
+  for ((i = 1; i < ${#COMP_WORDS[@]}; ++i)); do
+    if [[ ${COMP_WORDS[i]} != -* ]] && [[ -n ${COMP_WORDS[i]} ]] && [[ ${COMP_WORDS[i]} != $cur ]]; then
+      lastword=${COMP_WORDS[i]}
+    fi
+  done
+
+  echo $lastword
+}
+
+complete -F _govukcli govukcli


### PR DESCRIPTION
Someone mentioned about bash completion (/cc @boffbowsh), so as a firebreak task I thought I'd add it to govukcli as it makes it easier to get to instances.

The `$lastword` variable is useful as it stops recursive completion against commands, which is why it's use in all the commands across these gross case statements. Writing in case statements does make it easier to add in further options in the future, though.