### PR TITLE
Create static assets bucket

### DIFF
--- a/terraform/projects/app-static-assets-bucket/README.md
+++ b/terraform/projects/app-static-assets-bucket/README.md
@@ -1,0 +1,24 @@
+## Project: static-assets-bucket
+
+This creates an s3 bucket
+
+static-assets: The bucket that will hold static assets
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
+| stackname | Stackname | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| write_static_assets_bucket_policy_arn | ARN of the write static_assets-bucket policy |
+

--- a/terraform/projects/app-static-assets-bucket/integration.govuk.backend
+++ b/terraform/projects/app-static-assets-bucket/integration.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "govuk/app-static-assets-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/app-static-assets-bucket/main.tf
+++ b/terraform/projects/app-static-assets-bucket/main.tf
@@ -1,0 +1,71 @@
+/**
+* ## Project: static-assets-bucket
+*
+* This creates an S3 bucket
+*
+* static-assets: The bucket that will hold static assets
+*
+*/
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "S3 bucket we store our terraform state in"
+}
+
+variable "remote_state_infra_monitoring_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_monitoring remote state "
+  default     = ""
+}
+
+# Set up the backend & provider for each region
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.2"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.0.0"
+}
+
+data "terraform_remote_state" "infra_monitoring" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+resource "aws_s3_bucket" "static_assets" {
+  bucket = "govuk-${var.aws_environment}-static-assets"
+  acl    = "public-read"
+
+  tags {
+    Name            = "govuk-${var.aws_environment}-static-assets"
+    aws_environment = "${var.aws_environment}"
+  }
+
+  logging {
+    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    target_prefix = "s3/govuk-${var.aws_environment}-static-assets/"
+  }
+}

--- a/terraform/projects/app-static-assets-bucket/production.govuk.backend
+++ b/terraform/projects/app-static-assets-bucket/production.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "govuk/app-static-assets-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/app-static-assets-bucket/staging.govuk.backend
+++ b/terraform/projects/app-static-assets-bucket/staging.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+key     = "govuk/app-static-assets-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/app-static-assets-bucket/writer.tf
+++ b/terraform/projects/app-static-assets-bucket/writer.tf
@@ -1,0 +1,46 @@
+/**
+* ## Project: static-assets-bucket
+*
+* Create a policy that allows writing of the static-assets-bucket bucket. This
+* doesn't create a role as the calling instance is assumed to already
+* have one which should be attached to this policy.
+*
+*/
+
+resource "aws_iam_policy" "static_assets_writer" {
+  name        = "govuk-${var.aws_environment}-static_assets-writer-policy"
+  policy      = "${data.aws_iam_policy_document.static_assets_writer.json}"
+  description = "Allows writing of the static_assets bucket"
+}
+
+data "aws_iam_policy_document" "static_assets_writer" {
+  statement {
+    sid = "ReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    # In theory  should work but it doesn't so use * instead
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    sid     = "WriteGovukStaticAssets"
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.static_assets.id}",
+      "arn:aws:s3:::${aws_s3_bucket.static_assets.id}/*",
+    ]
+  }
+}
+
+output "write_static_assets_bucket_policy_arn" {
+  value       = "${aws_iam_policy.static_assets_writer.arn}"
+  description = "ARN of the write static_assets-bucket policy"
+}


### PR DESCRIPTION
This is to implement alphagov/govuk-rfcs#91.

This PR creates a world-readable bucket to hold the assets. The code is mostly taken from the infra-database-backups-bucket project, minus the cross-region replication and lifecycle rules.

Next step is to set up a point Fastly at this bucket.

https://trello.com/c/dCXLbdBH
