### PR TITLE
Add two new S3 mirrors to be used by mirrorer.

### DIFF
--- a/terraform/policies/s3_govuk_mirror_1_replication_policy.tpl
+++ b/terraform/policies/s3_govuk_mirror_1_replication_policy.tpl
@@ -1,0 +1,33 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${govuk-mirror-1}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${govuk-mirror-1}/*"
+      ]
+    },
+    {
+      "Action": [
+        "s3:ReplicateObject",
+        "s3:ReplicateDelete"
+      ],
+      "Effect": "Allow",
+      "Resource": "${govuk-mirror-2}/*"
+    }
+  ]
+}

--- a/terraform/policies/s3_govuk_mirror_1_replication_role.tpl
+++ b/terraform/policies/s3_govuk_mirror_1_replication_role.tpl
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [ 
+    {
+    "Action": "sts:AssumeRole",
+    "Principal": { 
+      "Service": "s3.amazonaws.com"
+    },
+    "Effect": "Allow",
+    "Sid": ""
+    }
+  ]
+}

--- a/terraform/projects/infra-mirror-bucket/README.md
+++ b/terraform/projects/infra-mirror-bucket/README.md
@@ -1,0 +1,19 @@
+## Project: database-backups-bucket
+
+This creates an s3 bucket
+
+database-backups: The bucket that will hold database backups
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_backup_region | AWS region | string | `eu-west-2` | no |
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
+| stackname | Stackname | string | - | yes |
+

--- a/terraform/projects/infra-mirror-bucket/integration.govuk.backend
+++ b/terraform/projects/infra-mirror-bucket/integration.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "govuk/infra-database-backups-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -1,0 +1,165 @@
+/**
+* ## Project: database-backups-bucket
+*
+* This creates an s3 bucket
+*
+* database-backups: The bucket that will hold database backups
+*
+*/
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "aws_backup_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-2"
+}
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "S3 bucket we store our terraform state in"
+}
+
+variable "remote_state_infra_monitoring_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_monitoring remote state "
+  default     = ""
+}
+
+# Set up the backend & provider for each region
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.2"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.0.0"
+}
+
+provider "aws" {
+  region  = "${var.aws_backup_region}"
+  alias   = "aws_secondary"
+  version = "1.0.0"
+}
+
+data "terraform_remote_state" "infra_monitoring" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+resource "aws_s3_bucket" "govuk-mirror-1" {
+  bucket = "govuk-${var.aws_environment}-mirror-1"
+
+  tags {
+    Name            = "govuk-${var.aws_environment}-mirror-1"
+    aws_environment = "${var.aws_environment}"
+  }
+
+  logging {
+    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    target_prefix = "s3/govuk-${var.aws_environment}-mirror-1/"
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  replication_configuration {
+    role = "${aws_iam_role.govuk_mirror_1_replication_role.arn}"
+
+    rules {
+      prefix = ""
+      status = "Enabled"
+
+      destination {
+        bucket        = "${aws_s3_bucket.govuk-mirror-2.arn}"
+        storage_class = "STANDARD"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket" "govuk-mirror-2" {
+  bucket   = "govuk-${var.aws_environment}-mirror-2"
+  region   = "${var.aws_backup_region}"
+  provider = "aws.aws_secondary"
+
+  tags {
+    Name            = "govuk-${var.aws_environment}-mirror-2"
+    aws_environment = "${var.aws_environment}"
+  }
+
+  logging {
+    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    target_prefix = "s3/govuk-${var.aws_environment}-mirror-2/"
+  }
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_s3_bucket_policy" "govuk_mirror_1_read_policy" {
+  bucket = "${aws_s3_bucket.govuk-mirror-1.id}"
+  policy = "${data.aws_iam_policy_document.s3_mirrors_read_policy_doc.json}"
+}
+
+resource "aws_s3_bucket_policy" "govuk_mirror_2_read_policy" {
+  bucket = "${aws_s3_bucket.govuk-mirror-2.id}"
+  policy = "${data.aws_iam_policy_document.s3_mirrors_read_policy_doc.json}"
+}
+
+# S3 backup replica role configuration
+data "template_file" "s3_govuk_mirror_1_replication_role_template" {
+  template = "${file("${path.module}/../../policies/s3_mirror_replica_role.tpl")}"
+}
+
+# Adding backup replication role
+resource "aws_iam_role" "govuk_mirror_1_replication_role" {
+  name               = "${var.stackname}-mirror-1-replication-role"
+  assume_role_policy = "${data.template_file.s3_govuk_mirror_1_replication_role_template.rendered}"
+}
+
+data "template_file" "" s3_govuk_mirror_1_replication_policy_template "" {
+  template = "${file("${path.module}/../../policies/s3_role_replica_policy.tpl")}"
+
+  vars {
+    govuk_s3_bucket = "arn:aws:s3:::${govuk-mirror-1}.bucket.arn"
+    govuk_s3_backup = "arn:aws:s3:::${govuk-mirror-2}.bucket.arn"
+    aws_account_id  = "${data.aws_caller_identity.current.account_id}"
+  }
+}
+
+# Adding backup replication policy
+resource "aws_iam_policy" "govuk_mirror_1_replication_policy" {
+  name        = "govuk-${var.aws_environment}-backup-bucket-replication-policy"
+  policy      = "${data.template_file.s3_backup_replica_policy_template.rendered}"
+  description = "Allows replication of the backup buckets"
+}
+
+# Combine the role and policy
+resource "aws_iam_policy_attachment" "govuk_mirror_1_replication_policy_attachment" {
+  name       = "s3-govuk-mirror-1-replication-policy-attachment"
+  roles      = ["${aws_iam_role.govuk-mirror-1-replication-role.name}"]
+  policy_arn = "${aws_iam_policy.govuk-mirror-1-replication-policy.arn}"
+}

--- a/terraform/projects/infra-mirror-bucket/mirror-crawler-write-policy.tf
+++ b/terraform/projects/infra-mirror-bucket/mirror-crawler-write-policy.tf
@@ -1,0 +1,39 @@
+data "aws_iam_policy_document" "s3_mirrors_crawler_writer_policy_doc" {
+  statement {
+    sid = "S3SyncReadLists"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    sid     = "S3SyncReadWriteBucket"
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-1.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-1.id}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "s3_mirrors_writer_policy" {
+  name   = "s3_mirrors_writer_policy_for_${aws_s3_bucket.govuk-mirror-1.id}"
+  policy = "${data.aws_iam_policy_document.s3_mirrors_crawler_writer_policy_doc.json}"
+}
+
+resource "aws_iam_user" "s3_mirrors_writer_user" {
+  name = "s3_mirrors_writer"
+}
+
+resource "aws_iam_policy_attachment" "s3_mirrors_writer_user_policy" {
+  name       = "s3_mirrors_writers_user_policy_attachement"
+  users      = ["${aws_iam_user.s3_mirrors_writers_user.name}"]
+  policy_arn = "${aws_iam_policy.s3_mirrors_writer_policy.arn}"
+}

--- a/terraform/projects/infra-mirror-bucket/mirror-read-policy.tf
+++ b/terraform/projects/infra-mirror-bucket/mirror-read-policy.tf
@@ -1,0 +1,58 @@
+provider "fastly" {
+  # We only want to use fastly's data API
+  api_key = "test"
+}
+
+data "fastly_ip_ranges" "fastly" {}
+
+data "external" "pingdom" {
+  program = ["/bin/bash", "${path.module}/pingdom_probe_ips.sh"]
+}
+
+data "aws_iam_policy_document" "s3_mirrors_read_policy_doc" {
+  statement {
+    sid     = "S3FastlyReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-1.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-1.id}/*",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-2.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-2.id}/*",
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["${data.fastly_ip_ranges.fastly.cidr_blocks}"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+
+  statement {
+    sid     = "S3PingdomReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-1.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-1.id}/*",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-2.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-2.id}/*",
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["${split(",",data.external.pingdom.result.pingdom_probe_ips)}"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}

--- a/terraform/projects/infra-mirror-bucket/pingdom_probe_ips.sh
+++ b/terraform/projects/infra-mirror-bucket/pingdom_probe_ips.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# This script pulls Pingdom probe IPs from the feed page and prints a sorted
+# list of CIDR blocks to the standard output in JSON format.
+#
+# Pingdom probe IPs information:
+# https://help.pingdom.com/hc/en-us/articles/203682601-Pingdom-probe-servers-IP-addresses
+#
+# The JSON output needs to meet Terraform external data sources requirements
+# and limitations (at the moment Terraform only supports string data types)
+# https://www.terraform.io/docs/providers/external/data_source.html
+# https://github.com/hashicorp/terraform/issues/12256
+
+curl -s https://my.pingdom.com/probes/feed | grep "pingdom:ip" | sed -e 's|</.*||' -e 's|.*>||' | sort -n -t . -k 1,1 -k 2,2 -k 3,3 -k 4,4 | grep -v ":" | awk '
+BEGIN { ORS = ""; print " { \"pingdom_probe_ips\": \""}
+{ if (NR == 1) { print $1"/32" } else { print ","$1"/32" } }
+END { print "\" }" }
+'
+

--- a/terraform/projects/infra-mirror-bucket/production.govuk.backend
+++ b/terraform/projects/infra-mirror-bucket/production.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "govuk/infra-database-backups-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-mirror-bucket/staging.govuk.backend
+++ b/terraform/projects/infra-mirror-bucket/staging.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+key     = "govuk/infra-database-backups-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"


### PR DESCRIPTION
- One instance, govuk-mirror-1, is written to directly by mirrorer, a second
  instance, govuk-mirror-2, is replicated via Amazon services

Pair: @jljalderman @schmie