### PR TITLE
Add db_admin security group to the redis one

### DIFF
--- a/terraform/projects/infra-security-groups/backend-redis.tf
+++ b/terraform/projects/infra-security-groups/backend-redis.tf
@@ -111,3 +111,16 @@ resource "aws_security_group_rule" "backend-redis_ingress_deploy_redis" {
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.deploy.id}"
 }
+
+resource "aws_security_group" "db-admin" {
+  type      = "ingress"
+  from_port = 6379
+  to_port   = 6379
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.backend-redis.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.db-admin.id}"
+}


### PR DESCRIPTION
Gives access to redis for `db_admin`

Related to this PR: https://github.com/alphagov/govuk-puppet/pull/7397

For: https://trello.com/c/CA3PFmY1/129-install-redis-tools-on-aws-integration