### PR TITLE
Adding security group to logs-cdn ELB

### DIFF
--- a/terraform/projects/app-logs-cdn/main.tf
+++ b/terraform/projects/app-logs-cdn/main.tf
@@ -45,7 +45,7 @@ provider "aws" {
 resource "aws_elb" "logs-cdn_external_elb" {
   name            = "${var.stackname}-logs-cdn"
   subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_offsite_ssh_id}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_offsite_ssh_id}", "${data.terraform_remote_state.infra_security_groups.sg_logs-cdn_elb_id}"]
   internal        = "false"
 
   access_logs {


### PR DESCRIPTION
  The ELB need to have the govuk_logs-cdn_elb_access security group to allow traffic from fastly to the ELB, and from the ELB to the instances