### PR TITLE
Allow accessing external bouncer from monitoring

### DIFF
--- a/terraform/projects/infra-security-groups/bouncer.tf
+++ b/terraform/projects/infra-security-groups/bouncer.tf
@@ -104,24 +104,6 @@ resource "aws_security_group" "bouncer_internal_elb" {
   }
 }
 
-resource "aws_security_group_rule" "bouncer-internal-elb_ingress_monitoring_https" {
-  type                     = "ingress"
-  to_port                  = 443
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = "${aws_security_group.bouncer_internal_elb.id}"
-  source_security_group_id = "${aws_security_group.monitoring.id}"
-}
-
-resource "aws_security_group_rule" "bouncer-internal-elb_ingress_monitoring_http" {
-  type                     = "ingress"
-  to_port                  = 80
-  from_port                = 80
-  protocol                 = "tcp"
-  security_group_id        = "${aws_security_group.bouncer_internal_elb.id}"
-  source_security_group_id = "${aws_security_group.monitoring.id}"
-}
-
 resource "aws_security_group_rule" "bouncer-external-elb_ingress_monitoring_https" {
   type                     = "ingress"
   to_port                  = 443

--- a/terraform/projects/infra-security-groups/bouncer.tf
+++ b/terraform/projects/infra-security-groups/bouncer.tf
@@ -122,6 +122,24 @@ resource "aws_security_group_rule" "bouncer-internal-elb_ingress_monitoring_http
   source_security_group_id = "${aws_security_group.monitoring.id}"
 }
 
+resource "aws_security_group_rule" "bouncer-external-elb_ingress_monitoring_https" {
+  type                     = "ingress"
+  to_port                  = 443
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.bouncer_external_elb.id}"
+  source_security_group_id = "${aws_security_group.monitoring.id}"
+}
+
+resource "aws_security_group_rule" "bouncer-external-elb_ingress_monitoring_http" {
+  type                     = "ingress"
+  to_port                  = 80
+  from_port                = 80
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.bouncer_external_elb.id}"
+  source_security_group_id = "${aws_security_group.monitoring.id}"
+}
+
 resource "aws_security_group_rule" "bouncer-internal-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0


### PR DESCRIPTION
This was introduced for internal URLs in https://github.com/alphagov/govuk-aws/pull/408 but since then Smokey is now looking for bouncer from the external URL so access needs to be allowed.