### PR TITLE
Revert "Configure the source security group for bouncer"

### DIFF
--- a/terraform/projects/infra-security-groups/bouncer.tf
+++ b/terraform/projects/infra-security-groups/bouncer.tf
@@ -109,8 +109,8 @@ resource "aws_security_group_rule" "bouncer-external-elb_ingress_monitoring_http
   to_port                  = 443
   from_port                = 443
   protocol                 = "tcp"
-  security_group_id        = "${aws_security_group.monitoring.id}"
-  source_security_group_id = "${aws_security_group.bouncer_elb.id}"
+  security_group_id        = "${aws_security_group.bouncer_elb.id}"
+  source_security_group_id = "${aws_security_group.monitoring.id}"
 }
 
 resource "aws_security_group_rule" "bouncer-external-elb_ingress_monitoring_http" {
@@ -118,8 +118,8 @@ resource "aws_security_group_rule" "bouncer-external-elb_ingress_monitoring_http
   to_port                  = 80
   from_port                = 80
   protocol                 = "tcp"
-  security_group_id        = "${aws_security_group.monitoring.id}"
-  source_security_group_id = "${aws_security_group.bouncer_elb.id}"
+  security_group_id        = "${aws_security_group.bouncer_elb.id}"
+  source_security_group_id = "${aws_security_group.monitoring.id}"
 }
 
 resource "aws_security_group_rule" "bouncer-internal-elb_egress_any_any" {


### PR DESCRIPTION
Reverts alphagov/govuk-aws#528

These are inbound rules, so the source should be where the traffic is coming from.