### PR TITLE
Increase the assume-role MFA expiry time to 8 hours (28800 seconds)

### DIFF
--- a/terraform/modules/aws/iam/role_user/main.tf
+++ b/terraform/modules/aws/iam/role_user/main.tf
@@ -62,15 +62,6 @@ data "aws_iam_policy_document" "assume_policy_document" {
         "true",
       ]
     }
-
-    condition {
-      test     = "NumericLessThan"
-      variable = "aws:MultiFactorAuthAge"
-
-      values = [
-        "43200",
-      ]
-    }
   }
 }
 
@@ -79,11 +70,12 @@ locals {
 }
 
 resource "aws_iam_role" "user_role" {
-  count              = "${local.create_role}"
-  name               = "${var.role_name}"
-  path               = "/"
-  description        = "Role to Delegate Permissions to an IAM User: ${var.role_name}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_policy_document.json}"
+  count                = "${local.create_role}"
+  name                 = "${var.role_name}"
+  path                 = "/"
+  description          = "Role to Delegate Permissions to an IAM User: ${var.role_name}"
+  assume_role_policy   = "${data.aws_iam_policy_document.assume_policy_document.json}"
+  max_session_duration = 28800
 }
 
 resource "aws_iam_role_policy_attachment" "user_policy_attachment" {


### PR DESCRIPTION
- AWS recently increased the assume-role session token expiry time to a
  maximum of 12 hours. This makes our sessions last for eight hours, the
  length of the working day, to avoid having to re-assume role multiple
  times a day.
- This will revert the changes I made in
  https://github.com/alphagov/govuk-aws/pull/498, and I'll have to
  change the docs again, but it makes it simpler in the long run - you
  only have to remember an `assume-role` command, not also
  `get-session-token`.

(I'll test this in the test account first.)