### PR TITLE
Update the govukcli script to only use `aws assume-role`

### DIFF
--- a/tools/govukcli
+++ b/tools/govukcli
@@ -297,35 +297,24 @@ EOF
   if ! _check_credentials; then
     unset AWS_SESSION_TOKEN
 
-    # check if GDS session is valid
-    GDS_SESSION=~/.aws/gds/session
-    test -f ${GDS_SESSION} && source ${GDS_SESSION}
-    if ! _check_credentials; then
-      unset AWS_SESSION_TOKEN
-
-      # setup AWS access
-      SESSION_NAME=$(whoami)-$(date +%d-%m-%y_%H-%M)
-      MFA_SERIAL=$(_get_aws_config gds mfa_serial)
-
-      prompt='Enter MFA token: '
-      if [ ! -z "${AWS_EXPIRATION-}" ]; then
-        prompt="Your AWS session has expired. ${prompt}"
-      fi
-      read -rp "${prompt}" MFA_TOKEN
-
-      CREDENTIALS=$(aws sts get-session-token --profile gds \
-        --serial-number=${MFA_SERIAL} --token-code=${MFA_TOKEN}) || exit $?
-
-      _write_credentials_file ${GDS_SESSION}
-      source ${GDS_SESSION}
-    fi
-
-    # assume role
+    # setup AWS access
     SESSION_NAME=$(whoami)-$(date +%d-%m-%y_%H-%M)
-    ROLE_ARN=$(_get_aws_config govuk-${GOVUK_ENV} role_arn)
-    CREDENTIALS=$(aws sts assume-role \
-                    --role-session-name $SESSION_NAME \
-                    --role-arn $ROLE_ARN) || exit $?
+    MFA_SERIAL=$(_get_aws_config gds mfa_serial)
+    ROLE_ARN=$(_get_aws_config govuk-${CONTEXT} role_arn)
+
+    prompt='Enter MFA token: '
+    if [ ! -z "${AWS_EXPIRATION-}" ]; then
+      prompt="Your AWS session has expired. ${prompt}"
+    fi
+    read -rp "${prompt}" MFA_TOKEN
+
+    CREDENTIALS=$(aws \
+                  --profile gds \
+                  sts assume-role \
+                  --role-session-name $SESSION_NAME \
+                  --role-arn $ROLE_ARN \
+                  --serial-number $MFA_SERIAL \
+                  --token-code $MFA_TOKEN) || exit $?
 
     _write_credentials_file ${GOVUK_SESSION}
     source ${GOVUK_SESSION}


### PR DESCRIPTION
- Now that tokens last for 8 hours
  (23dd074dbfaf4b7201d3fd11d9c948e6806cfbf2), we don't need to
  re-assume-role every hour.
- Now we don't need to do that, we can just use `aws assume-role` once
  every eight hours, we don't need the intermediary step of `aws sts
  get-session-token`.

(This requires #533 to be merged and deployed first.)
Reviewers will find the `?w=1` query string useful to ignore whitespace changes.