### PR TITLE
Expand disk size for PostgreSQL machines to 190GB

### DIFF
--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -68,7 +68,7 @@ module "postgresql-primary_rds_instance" {
   subnet_ids          = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
   username            = "${var.username}"
   password            = "${var.password}"
-  allocated_storage   = "120"
+  allocated_storage   = "190"
   instance_class      = "db.m4.large"
   multi_az            = "${var.multi_az}"
   security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]


### PR DESCRIPTION
This matches the disk size with the equivalent machines in production and staging and prevents "out of space" errors.