### PR TITLE
Make our monitoring instances m5.large instead of t2

### DIFF
--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -141,7 +141,7 @@ module "monitoring" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "monitoring", "aws_hostname", "monitoring-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_monitoring_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "m5.large"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "2"
   instance_elb_ids              = ["${aws_elb.monitoring_external_elb.id}", "${aws_elb.monitoring_internal_elb.id}"]


### PR DESCRIPTION
The monitoring instance that runs Icinga and Smokey in Integration has
begun running out of CPU credits. This is making it difficult to
diagnose problems elsewhere in the stack. Making it an m5.large costs
~$77pcm instead of ~$36pcm, and doubles the RAM.

<img width="889" alt="screen shot 2018-04-16 at 09 49 19" src="https://user-images.githubusercontent.com/18276/38799617-d5005dea-415c-11e8-9329-b27bc22b9f3b.png">