### PR TITLE
Postgresql Instance Class

### DIFF
--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -69,7 +69,7 @@ module "postgresql-primary_rds_instance" {
   username            = "${var.username}"
   password            = "${var.password}"
   allocated_storage   = "190"
-  instance_class      = "db.m4.large"
+  instance_class      = "db.m4.xlarge"
   multi_az            = "${var.multi_az}"
   security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]
   event_sns_topic_arn = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
@@ -89,7 +89,7 @@ module "postgresql-standby_rds_instance" {
 
   name                       = "${var.stackname}-postgresql-standby"
   default_tags               = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "postgresql_standby")}"
-  instance_class             = "db.m4.large"
+  instance_class             = "db.m4.xlarge"
   security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]
   create_replicate_source_db = "1"
   replicate_source_db        = "${module.postgresql-primary_rds_instance.rds_instance_id}"


### PR DESCRIPTION
- We have noticed performance problems with the current instance class
  (db.m4.large). Also, this class provides a lower resource capacity
compared to what was available in Carranza. Due to these reasons we are
changing the instance class to match Carranza Integration instance
resource capacity.

https://trello.com/c/dNgZpaVf/1098-the-postgres-rds-instance-needs-to-be-more-powerful

Solo: @suthagarht