### PR TITLE
Specify the `--duration-seconds` parameter for assume-role in govukcli

### DIFF
--- a/tools/govukcli
+++ b/tools/govukcli
@@ -314,6 +314,7 @@ EOF
                   --role-session-name $SESSION_NAME \
                   --role-arn $ROLE_ARN \
                   --serial-number $MFA_SERIAL \
+                  --duration-seconds 28800 \
                   --token-code $MFA_TOKEN) || exit $?
 
     _write_credentials_file ${GOVUK_SESSION}


### PR DESCRIPTION
- It turns out that in 23dd074, setting the `max_session_duration`
  parameter doesn't actually apply it to individual users' sessions
  without specifying `--duration-seconds` in the `assume-role` command,
  so people were still having their session tokens expire after an hour.
- This updates `govukcli` to request tokens valid for eight hours on
  `assume-role`.