### PR TITLE
Specify the mirrorer instance type with a variable

### DIFF
--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -25,6 +25,12 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
+variable "mirrorer_instance_type" {
+  type        = "string"
+  description = "Instance type for the mirrorer instance"
+  default     = "m5.large"
+}
+
 variable "mirrorer_subnet" {
   type        = "string"
   description = "Subnet to contain mirrorer and its EBS volume"
@@ -49,7 +55,7 @@ module "mirrorer" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mirrorer", "aws_hostname", "mirrorer-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mirrorer_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mirrorer_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.micro"
+  instance_type                 = "${var.mirrorer_instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "0"
   instance_elb_ids              = []


### PR DESCRIPTION
- We're using different instance types in integration compared to
  staging and production.