### PR TITLE
AWS RDS Timeout

### DIFF
--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -151,6 +151,24 @@ variable "snapshot_identifier" {
   default     = ""
 }
 
+variable "terraform_create_rds_timeout" {
+  type        = "string"
+  description = "Set the timeout time for AWS RDS creation."
+  default     = "2h"
+}
+
+variable "terraform_update_rds_timeout" {
+  type        = "string"
+  description = "Set the timeout time for AWS RDS modification."
+  default     = "2h"
+}
+
+variable "terraform_delete_rds_timeout" {
+  type        = "string"
+  description = "Set the timeout time for AWS RDS deletion."
+  default     = "2h"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -172,6 +190,12 @@ resource "aws_db_instance" "db_instance_replica" {
   vpc_security_group_ids = ["${var.security_group_ids}"]
   replicate_source_db    = "${var.replicate_source_db}"
   parameter_group_name   = "${var.parameter_group_name}"
+
+  timeouts {
+    create = "${var.terraform_create_rds_timeout}"
+    delete = "${var.terraform_delete_rds_timeout}"
+    update = "${var.terraform_update_rds_timeout}"
+  }
 
   # TODO this should be enabled in a Production environment:
   final_snapshot_identifier = "${var.name}-final-snapshot"
@@ -201,6 +225,12 @@ resource "aws_db_instance" "db_instance" {
   backup_window           = "${var.backup_window}"
   copy_tags_to_snapshot   = "${var.copy_tags_to_snapshot}"
   snapshot_identifier     = "${var.snapshot_identifier}"
+
+  timeouts {
+    create = "${var.terraform_create_rds_timeout}"
+    delete = "${var.terraform_delete_rds_timeout}"
+    update = "${var.terraform_update_rds_timeout}"
+  }
 
   # TODO this should be enabled in a Production environment:
   final_snapshot_identifier = "${var.name}-final-snapshot"


### PR DESCRIPTION
- We have identified that we can change the AWS token TTL. This will
  help terraform apply without timing out soon. However, terrafom sets some
default time outs by default.
 https://www.terraform.io/docs/providers/aws/r/db_instance.html [Please
check Timeouts]

- If this is not addressed, we get a message similar to the following.

"... aws_db_instance.db_instance_replica: timeout while waiting for
state to become 'available, storage-optimization' ..."

- This change is aimed at extending the default time-out to match the
  maximum AWS TTL that we can set (8 hours).

https://trello.com/c/KlI3mK8H/1134-postgresql-rds-integration

https://govuk.zendesk.com/agent/tickets/2629112

Solo: @suthagarht