### PR TITLE
Make out-of-date docs fail CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,3 @@
       entry: tools/terraform-validate.sh
       language: script
       files: \.tf$
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,17 @@ node ("terraform") {
       ])
     }
 
+    stage("Check generated docs are up-to-date") {
+      sh "tools/update-docs.sh"
+
+      docsAreUpToDate = sh(script: "git diff --exit-code", returnStatus: true) == 0
+
+      if (!docsAreUpToDate) {
+        error("The documentation isn't up to date. You should run "
+          + "tools/update-docs.sh and commit the results.")
+      }
+    }
+
     stage("ADR check") {
       sh "tools/adr-check.sh"
     }
@@ -63,4 +74,3 @@ node ("terraform") {
   // Wipe the workspace
   deleteDir()
 }
-

--- a/terraform/modules/aws/rds_instance/README.md
+++ b/terraform/modules/aws/rds_instance/README.md
@@ -30,6 +30,9 @@ Create an RDS instance
 | snapshot_identifier | Specifies whether or not to create this database from a snapshot. | string | `` | no |
 | storage_type | One of standard (magnetic), gp2 (general purpose SSD), or io1 (provisioned IOPS SSD). The default is gp2 | string | `gp2` | no |
 | subnet_ids | Subnet IDs to assign to the aws_elasticache_subnet_group | list | `<list>` | no |
+| terraform_create_rds_timeout | Set the timeout time for AWS RDS creation. | string | `2h` | no |
+| terraform_delete_rds_timeout | Set the timeout time for AWS RDS deletion. | string | `2h` | no |
+| terraform_update_rds_timeout | Set the timeout time for AWS RDS modification. | string | `2h` | no |
 | username | User to create on the database | string | `` | no |
 
 ## Outputs

--- a/terraform/projects/app-monitoring/README.md
+++ b/terraform/projects/app-monitoring/README.md
@@ -12,6 +12,7 @@ Monitoring node
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| monitoring_subnet | Name of the subnet to place the monitoring instance and the EBS volume | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-warehouse-db-admin/README.md
+++ b/terraform/projects/app-warehouse-db-admin/README.md
@@ -1,6 +1,6 @@
-## Project: app-transition-db-admin
+## Project: app-warehouse-db-admin
 
- DB admin boxes for Transition's RDS instance
+ DB admin boxes for Warehouse's RDS instance
 
 
 ## Inputs
@@ -24,5 +24,5 @@
 
 | Name | Description |
 |------|-------------|
-| transition-db-admin_elb_dns_name | DNS name to access the transition-db-admin service |
+| warehouse-db-admin_elb_dns_name | DNS name to access the warehouse-db-admin service |
 

--- a/terraform/projects/app-warehouse/README.md
+++ b/terraform/projects/app-warehouse/README.md
@@ -1,4 +1,4 @@
-## Project: projects/app-postgresql
+## Project: projects/app-warehouse
 
 RDS PostgreSQL instance for the GOV.UK data warehouse
 
@@ -27,10 +27,10 @@ RDS PostgreSQL instance for the GOV.UK data warehouse
 
 | Name | Description |
 |------|-------------|
-| postgresql-primary_address | postgresql instance address |
-| postgresql-primary_endpoint | postgresql instance endpoint |
-| postgresql-primary_id | postgresql instance ID |
-| postgresql-primary_resource_id | postgresql instance resource ID |
 | postgresql-standby_address | postgresql replica instance address |
 | postgresql-standby_endpoint | postgresql replica instance endpoint |
+| warehouse-postgresql-primary_address | postgresql instance address |
+| warehouse-postgresql-primary_endpoint | postgresql instance endpoint |
+| warehouse-postgresql-primary_id | postgresql instance ID |
+| warehouse-postgresql-primary_resource_id | postgresql instance resource ID |
 

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -73,6 +73,8 @@ This project adds global resources for app components:
 | stackname | Stackname | string | - | yes |
 | transition_db_admin_internal_service_names |  | list | `<list>` | no |
 | transition_postgresql_internal_service_names |  | list | `<list>` | no |
+| warehouse_db_admin_internal_service_names |  | list | `<list>` | no |
+| warehouse_postgresql_internal_service_names |  | list | `<list>` | no |
 | whitehall_backend_internal_service_cnames |  | list | `<list>` | no |
 | whitehall_backend_internal_service_names |  | list | `<list>` | no |
 | whitehall_backend_public_service_cnames |  | list | `<list>` | no |

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -96,6 +96,9 @@ Manage the security groups for the entire infrastructure
 | sg_transition-db-admin_id |  |
 | sg_transition-postgresql-primary_id |  |
 | sg_transition-postgresql-standby_id |  |
+| sg_warehouse-db-admin_elb_id |  |
+| sg_warehouse-db-admin_id |  |
+| sg_warehouse-postgresql-primary_id |  |
 | sg_whitehall-backend_external_elb_id |  |
 | sg_whitehall-backend_id |  |
 | sg_whitehall-backend_internal_elb_id |  |

--- a/terraform/projects/infra-wal-e-warehouse-bucket/README.md
+++ b/terraform/projects/infra-wal-e-warehouse-bucket/README.md
@@ -2,7 +2,7 @@
 
 This creates an s3 bucket
 
-database-backups: The bucket that will hold WAL-E backups for the data warehouse
+wal-e-warehouse: The bucket that will hold database backups
 
 
 
@@ -21,5 +21,5 @@ database-backups: The bucket that will hold WAL-E backups for the data warehouse
 
 | Name | Description |
 |------|-------------|
-| write_database_backups_bucket_policy_arn | ARN of the write database_backups-bucket policy |
+| write_wal_e_warehouse_policy_arn | ARN of the write wal_e_warehouse-bucket policy |
 


### PR DESCRIPTION
- We often forget to run this script when we update files, so instead
  I'm adding it as a CI step that fails when
  changes are detected by the `terraform-docs` command.