### PR TITLE
Create destination for WAL-E backups for the data warehouse

### DIFF
--- a/terraform/projects/infra-wal-e-warehouse-bucket/README.md
+++ b/terraform/projects/infra-wal-e-warehouse-bucket/README.md
@@ -1,0 +1,25 @@
+## Project: wal-e-warehouse-bucket
+
+This creates an s3 bucket
+
+database-backups: The bucket that will hold WAL-E backups for the data warehouse
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_backup_region | AWS region | string | `eu-west-2` | no |
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
+| stackname | Stackname | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| write_database_backups_bucket_policy_arn | ARN of the write database_backups-bucket policy |
+

--- a/terraform/projects/infra-wal-e-warehouse-bucket/main.tf
+++ b/terraform/projects/infra-wal-e-warehouse-bucket/main.tf
@@ -1,0 +1,166 @@
+/**
+* ## Project: wal-e-warehouse-bucket
+*
+* This creates an s3 bucket
+*
+* wal-e-warehouse: The bucket that will hold database backups
+*
+*/
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "aws_backup_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-2"
+}
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "S3 bucket we store our terraform state in"
+}
+
+variable "remote_state_infra_monitoring_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_monitoring remote state "
+  default     = ""
+}
+
+# Set up the backend & provider for each region
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.14.0"
+}
+
+provider "aws" {
+  alias   = "eu-london"
+  region  = "${var.aws_backup_region}"
+  version = "1.14.0"
+}
+
+data "terraform_remote_state" "infra_monitoring" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+resource "aws_s3_bucket" "wal_e_warehouse" {
+  bucket = "govuk-${var.aws_environment}-wal-e-warehouse"
+  region = "${var.aws_region}"
+
+  tags {
+    Name            = "govuk-${var.aws_environment}-wal-e-warehouse"
+    aws_environment = "${var.aws_environment}"
+  }
+
+  logging {
+    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    target_prefix = "s3/govuk-${var.aws_environment}-wal-e-warehouse/"
+  }
+
+  lifecycle_rule {
+    prefix  = "postgres/"
+    enabled = true
+
+    transition {
+      storage_class = "STANDARD_IA"
+      days          = 30
+    }
+
+    transition {
+      storage_class = "GLACIER"
+      days          = 90
+    }
+
+    expiration {
+      days = 120
+    }
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  replication_configuration {
+    role = "${aws_iam_role.wal_e_warehouse_replication_role.arn}"
+
+    rules {
+      prefix = ""
+      status = "Enabled"
+
+      destination {
+        bucket        = "${aws_s3_bucket.wal_e_warehouse_replica.arn}"
+        storage_class = "STANDARD"
+      }
+    }
+  }
+}
+
+# Bucket in the second region (Backup of the backup)
+resource "aws_s3_bucket" "wal_e_warehouse_replica" {
+  bucket   = "govuk-${var.aws_environment}-wal-e-warehouse-replica"
+  region   = "${var.aws_backup_region}"
+  provider = "aws.eu-london"
+
+  versioning {
+    enabled = true
+  }
+}
+
+# S3 backup replica role configuration
+data "template_file" "s3_backup_replica_assume_role_template" {
+  template = "${file("${path.module}/../../policies/s3_backup_replica_role.tpl")}"
+}
+
+# Adding backup replication role
+resource "aws_iam_role" "wal_e_warehouse_replication_role" {
+  name               = "${var.stackname}-wal-e-warehouse-bucket-replication-role"
+  assume_role_policy = "${data.template_file.s3_backup_replica_assume_role_template.rendered}"
+}
+
+# S3 backup replica policy configuration
+data "template_file" "s3_backup_replica_policy_template" {
+  template = "${file("${path.module}/../../policies/s3_backup_replica_policy.json")}"
+
+  vars {
+    govuk_s3_bucket = "${aws_s3_bucket.wal_e_warehouse.arn}"
+    govuk_s3_backup = "${aws_s3_bucket.wal_e_warehouse_replica.arn}"
+  }
+}
+
+# Adding backup replication policy
+resource "aws_iam_policy" "wal_e_warehouse_replication_policy" {
+  name        = "govuk-${var.aws_environment}-wal-e-warehouse-bucket-replication-policy"
+  policy      = "${data.template_file.s3_backup_replica_policy_template.rendered}"
+  description = "Allows replication of the warehouse wal-e buckets"
+}
+
+# Combine the role and policy
+resource "aws_iam_policy_attachment" "wal_e_warehouse_replication_policy_attachment" {
+  name       = "s3-wal-e-warehouse-bucket-replication-policy-attachment"
+  roles      = ["${aws_iam_role.wal_e_warehouse_replication_role.name}"]
+  policy_arn = "${aws_iam_policy.wal_e_warehouse_replication_policy.arn}"
+}

--- a/terraform/projects/infra-wal-e-warehouse-bucket/production.govuk.backend
+++ b/terraform/projects/infra-wal-e-warehouse-bucket/production.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "govuk/infra-wal-e-warehouse-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-wal-e-warehouse-bucket/staging.govuk.backend
+++ b/terraform/projects/infra-wal-e-warehouse-bucket/staging.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+key     = "govuk/infra-wal-e-warehouse-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-wal-e-warehouse-bucket/writer.tf
+++ b/terraform/projects/infra-wal-e-warehouse-bucket/writer.tf
@@ -1,0 +1,56 @@
+/**
+* ## Project: wal-e-warehouse-bucket
+*
+* Create a policy that allows writing of the database-backups bucket. This
+* doesn't create a role as the calling instance is assumed to already
+* have one which should be attached to this policy.
+*
+*/
+
+resource "aws_iam_policy" "wal_e_warehouse_writer" {
+  name        = "govuk-${var.aws_environment}-wal_e_warehouse-writer-policy"
+  policy      = "${data.aws_iam_policy_document.wal_e_warehouse_writer.json}"
+  description = "Allows writing of the database_backups bucket"
+}
+
+data "aws_iam_policy_document" "wal_e_warehouse_writer" {
+  statement {
+    sid = "ReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    # In theory  should work but it doesn't so use * instead
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    sid     = "WriteGovukWalEWarehouseBackups"
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.wal_e_warehouse.id}",
+      "arn:aws:s3:::${aws_s3_bucket.wal_e_warehouse.id}/*",
+    ]
+  }
+}
+
+resource "aws_iam_user" "wal_e_warehouse_writer" {
+  name = "govuk-${var.aws_environment}-wal-e-warehouse-writer"
+}
+
+resource "aws_iam_policy_attachment" "wal_e_warehouse_writer" {
+  name       = "wal_e_warehouse_writer-policy-attachment"
+  users      = ["${aws_iam_user.wal_e_warehouse_writer.name}"]
+  policy_arn = "${aws_iam_policy.wal_e_warehouse_writer.arn}"
+}
+
+output "write_wal_e_warehouse_policy_arn" {
+  value       = "${aws_iam_policy.wal_e_warehouse_writer.arn}"
+  description = "ARN of the write wal_e_warehouse-bucket policy"
+}


### PR DESCRIPTION
Only needed in Staging and Production as Integration uses RDS. Once
this is deployed, credentials need creating in the console and adding
to hieradata.

This is based on the `infra-artefacts-bucket` project, plan passes at least.