### PR TITLE
Monitoring EBS Volume.

### DIFF
--- a/terraform/projects/app-monitoring/additional_policy.json
+++ b/terraform/projects/app-monitoring/additional_policy.json
@@ -1,0 +1,20 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1524841802000",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:AttachNetworkInterface",
+                "ec2:AttachVolume",
+                "ec2:DetachVolume",
+                "ec2:DescribeVolumeStatus",
+                "ec2:DescribeVolumes"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
- This change will add a persistent EBS volume to the monitoring
instance. The EBS volume will be used to store stats/data collected by
icinga.

https://trello.com/c/b6So3Wxl/1145-integration-monitoring-instance-ebs-volume

https://govuk.zendesk.com/agent/tickets/2747364

Solo: @suthagarht