### PR TITLE
Puppet Master Instance Type

### DIFF
--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -19,6 +19,12 @@ variable "aws_environment" {
   description = "AWS environment"
 }
 
+variable "puppetmaster_instance_type" {
+  type        = "string"
+  description = "Instance type for the mirrorer instance"
+  default     = "m5.xlarge"
+}
+
 variable "instance_ami_filter_name" {
   type        = "string"
   description = "Name to use to find AMI images"
@@ -176,7 +182,7 @@ module "puppetmaster" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "puppetmaster", "aws_hostname", "puppetmaster-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_puppetmaster_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.xlarge"
+  instance_type                 = "${var.puppetmaster_instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.puppetmaster_bootstrap_elb.*.id}", "${aws_elb.puppetmaster_internal_elb.id}"]
   instance_elb_ids_length       = "${var.enable_bootstrap > 0 ? 2 : 1}"


### PR DESCRIPTION
- We have noticed high CPU usage in the AWS staging puppet master. While
comparing with the Carrenza staging server, we noticed that we have less
CPU cores in AWS. Hence we have performed the following change.

Please check here for history:
https://trello.com/c/nr8kuCOv/1170-aws-staging-puppet-is-broken

Solo: @suthagarht