### PR TITLE
Upgrade RDS Postgres instances to 9.6

### DIFF
--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -63,7 +63,7 @@ module "postgresql-primary_rds_instance" {
 
   name                = "${var.stackname}-postgresql-primary"
   engine_name         = "postgres"
-  engine_version      = "9.3"
+  engine_version      = "9.6"
   default_tags        = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "postgresql_primary")}"
   subnet_ids          = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
   username            = "${var.username}"

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -63,7 +63,7 @@ module "transition-postgresql-primary_rds_instance" {
 
   name                = "${var.stackname}-transition-postgresql-primary"
   engine_name         = "postgres"
-  engine_version      = "9.3"
+  engine_version      = "9.6"
   default_tags        = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "transition_postgresql_primary")}"
   subnet_ids          = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
   username            = "${var.username}"


### PR DESCRIPTION
- In August 2018, Amazon are deprecating PostgreSQL version 9.3 on RDS,
  so we have to upgrade to a newer version.
- GOV.UK have chosen to upgrade to 9.6, to match the new data warehouse
  project and give them more breathing room for future support.