### PR TITLE
Increase mongo disk size to cope with dumps

### DIFF
--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -131,7 +131,7 @@ module "mongo-1" {
 resource "aws_ebs_volume" "mongo-1" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mongo_1_subnet)}"
   type              = "io1"
-  size              = 150
+  size              = 300
   iops              = 100
 
   tags {
@@ -189,7 +189,7 @@ module "mongo-2" {
 resource "aws_ebs_volume" "mongo-2" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mongo_2_subnet)}"
   type              = "io1"
-  size              = 150
+  size              = 300
   iops              = 100
 
   tags {
@@ -247,7 +247,7 @@ module "mongo-3" {
 resource "aws_ebs_volume" "mongo-3" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mongo_3_subnet)}"
   type              = "io1"
-  size              = 150
+  size              = 300
   iops              = 100
 
   tags {


### PR DESCRIPTION
https://alert.integration.publishing.service.gov.uk/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-1-4-78.eu-west-1.compute.internal&service=low+available+disk+space

The disk on mongo integration is nearly full, which is preventing the
sync from production from working. Doubling the disk size should tie us
over for the foreseable future.