### PR TITLE
Resize Redis to r4.large

### DIFF
--- a/terraform/projects/app-backend-redis/main.tf
+++ b/terraform/projects/app-backend-redis/main.tf
@@ -52,7 +52,7 @@ module "backend_redis_cluster" {
   default_tags          = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend-redis")}"
   subnet_ids            = "${data.terraform_remote_state.infra_networking.private_subnet_elasticache_ids}"
   security_group_ids    = ["${data.terraform_remote_state.infra_security_groups.sg_backend-redis_id}"]
-  elasticache_node_type = "cache.m4.large"
+  elasticache_node_type = "cache.r4.large"
 }
 
 module "alarms-elasticache-backend-redis" {


### PR DESCRIPTION
This gives almost an extra 6GB of RAM (now 12.3GB) to Redis servers for an extra ~$60 per month per instance. Given the recent incidents caused by running out of memory in Redis, it makes sense to give us a bit of extra headroom.

The CPU count is unchanged at 2. This doesn't matter as our current CPU usage isn't high, and Redis is single-threaded anyway.