### PR TITLE
Add a new S3 bucket for data.gov.uk static data

### DIFF
--- a/terraform/projects/infra-datagovuk-static-bucket/README.md
+++ b/terraform/projects/infra-datagovuk-static-bucket/README.md
@@ -1,0 +1,18 @@
+## Project: datagovuk-static-bucket
+
+This creates an s3 bucket
+
+datagovuk-static-bucket: A bucket to hold legacy CKAN static data and assets
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
+| stackname | Stackname | string | - | yes |
+

--- a/terraform/projects/infra-datagovuk-static-bucket/datagovuk-write-policy.tf
+++ b/terraform/projects/infra-datagovuk-static-bucket/datagovuk-write-policy.tf
@@ -1,0 +1,39 @@
+data "aws_iam_policy_document" "s3_datagovuk_writer_policy_doc" {
+  statement {
+    sid = "S3SyncReadLists"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    sid     = "S3SyncReadWriteBucket"
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.datagovuk-static.id}",
+      "arn:aws:s3:::${aws_s3_bucket.datagovuk-static.id}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "s3_datagovuk_writer_policy" {
+  name   = "s3_datagovuk_writer_policy_for_${aws_s3_bucket.datagovuk-static.id}"
+  policy = "${data.aws_iam_policy_document.s3_datagovuk_writer_policy_doc.json}"
+}
+
+resource "aws_iam_user" "s3_datagovuk_writer_user" {
+  name = "s3_datagovuk_writer"
+}
+
+resource "aws_iam_policy_attachment" "s3_datagovuk_writer_user_policy" {
+  name       = "s3_datagovuk_writers_user_policy_attachment"
+  users      = ["${aws_iam_user.s3_datagovuk_writer_user.name}"]
+  policy_arn = "${aws_iam_policy.s3_datagovuk_writer_policy.arn}"
+}

--- a/terraform/projects/infra-datagovuk-static-bucket/fastly-read-policy.tf
+++ b/terraform/projects/infra-datagovuk-static-bucket/fastly-read-policy.tf
@@ -1,0 +1,29 @@
+provider "fastly" {
+  # We only want to use fastly's data API
+  api_key = "test"
+}
+
+data "fastly_ip_ranges" "fastly" {}
+
+data "aws_iam_policy_document" "s3_fastly_read_policy_doc" {
+  statement {
+    sid     = "S3FastlyReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.datagovuk-static.id}",
+      "arn:aws:s3:::${aws_s3_bucket.datagovuk-static.id}/*",
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["${data.fastly_ip_ranges.fastly.cidr_blocks}"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}

--- a/terraform/projects/infra-datagovuk-static-bucket/integration.govuk.backend
+++ b/terraform/projects/infra-datagovuk-static-bucket/integration.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "govuk/infra-datagovuk-static-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-datagovuk-static-bucket/main.tf
+++ b/terraform/projects/infra-datagovuk-static-bucket/main.tf
@@ -1,0 +1,79 @@
+/**
+* ## Project: datagovuk-static-bucket
+*
+* This creates an s3 bucket
+*
+* datagovuk-static-bucket: A bucket to hold legacy CKAN static data and assets
+*
+*/
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "S3 bucket we store our terraform state in"
+}
+
+variable "remote_state_infra_monitoring_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_monitoring remote state "
+  default     = ""
+}
+
+# Set up the backend & provider for each region
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.14.0"
+}
+
+data "terraform_remote_state" "infra_monitoring" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+resource "aws_s3_bucket" "datagovuk-static" {
+  bucket = "datagovuk-${var.aws_environment}-ckan-static-data"
+
+  tags {
+    Name            = "datagovuk-${var.aws_environment}-ckan-static-data"
+    aws_environment = "${var.aws_environment}"
+  }
+
+  logging {
+    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    target_prefix = "s3/datagovuk-${var.aws_environment}-ckan-static-data/"
+  }
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_s3_bucket_policy" "govuk_datagovuk_static_read_policy" {
+  bucket = "${aws_s3_bucket.datagovuk-static.id}"
+  policy = "${data.aws_iam_policy_document.s3_fastly_read_policy_doc.json}"
+}

--- a/terraform/projects/infra-datagovuk-static-bucket/production.govuk.backend
+++ b/terraform/projects/infra-datagovuk-static-bucket/production.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "govuk/infra-datagovuk-static-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-datagovuk-static-bucket/staging.govuk.backend
+++ b/terraform/projects/infra-datagovuk-static-bucket/staging.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+key     = "govuk/infra-datagovuk-static-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"


### PR DESCRIPTION
As part of the migration of DGU's legacy CKAN to GOV.UK infrastructure, we need somewhere to store old static data. This will be routed to directly from Fastly, so we need to give their IPs read access.

This will be around 85GB in total.

This has been planned and applied in integration already.