### PR TITLE
AWS RDS Instance naming.

### DIFF
--- a/terraform/modules/aws/rds_instance/README.md
+++ b/terraform/modules/aws/rds_instance/README.md
@@ -19,6 +19,7 @@ Create an RDS instance
 | event_categories | A list of event categories for a SourceType that you want to subscribe to. See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide//USER_Events.html | list | `<list>` | no |
 | event_sns_topic_arn | The SNS topic to send events to. | string | `` | no |
 | instance_class | The instance type of the RDS instance. | string | `db.t1.micro` | no |
+| instance_name | The RDS Instance Name. | string | `` | no |
 | maintenance_window | The window to perform maintenance in. | string | `Mon:04:00-Mon:06:00` | no |
 | multi_az | Specifies if the RDS instance is multi-AZ | string | `false` | no |
 | name | The common name for all the resources created by this module | string | - | yes |

--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -62,6 +62,12 @@ variable "instance_class" {
   default     = "db.t1.micro"
 }
 
+variable "instance_name" {
+  type        = "string"
+  description = "The RDS Instance Name."
+  default     = ""
+}
+
 variable "security_group_ids" {
   type        = "list"
   description = "Security group IDs to apply to this cluster"
@@ -186,6 +192,7 @@ resource "aws_db_instance" "db_instance_replica" {
   count = "${var.create_replicate_source_db}"
 
   instance_class         = "${var.instance_class}"
+  identifier             = "${var.instance_name}"
   storage_type           = "${var.storage_type}"
   vpc_security_group_ids = ["${var.security_group_ids}"]
   replicate_source_db    = "${var.replicate_source_db}"
@@ -215,6 +222,7 @@ resource "aws_db_instance" "db_instance" {
   password                = "${var.password}"
   allocated_storage       = "${var.allocated_storage}"
   instance_class          = "${var.instance_class}"
+  identifier              = "${var.instance_name}"
   storage_type            = "${var.storage_type}"
   db_subnet_group_name    = "${aws_db_subnet_group.subnet_group.name}"
   vpc_security_group_ids  = ["${var.security_group_ids}"]

--- a/terraform/projects/app-mysql/README.md
+++ b/terraform/projects/app-mysql/README.md
@@ -10,6 +10,7 @@ RDS Mysql Primary instance
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
+| instance_name | The RDS Instance Name. | string | `` | no |
 | password | DB password | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -19,6 +19,12 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "instance_name" {
+  type        = "string"
+  description = "The RDS Instance Name."
+  default     = ""
+}
+
 variable "cloudwatch_log_retention" {
   type        = "string"
   description = "Number of days to retain Cloudwatch logs for"
@@ -56,6 +62,7 @@ provider "aws" {
 module "mysql_primary_rds_instance" {
   source               = "../../modules/aws/rds_instance"
   name                 = "${var.stackname}-mysql-primary"
+  instance_name        = "${var.stackname}-mysql-primary"
   engine_name          = "mysql"
   engine_version       = "5.6"
   default_tags         = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mysql-primary")}"
@@ -121,6 +128,7 @@ module "mysql_replica_rds_instance" {
   name                       = "${var.stackname}-mysql-replica"
   default_tags               = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mysql-replica")}"
   instance_class             = "db.m4.xlarge"
+  instance_name              = "${var.stackname}-mysql-replica"
   security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_mysql-replica_id}"]
   create_replicate_source_db = "1"
   replicate_source_db        = "${module.mysql_primary_rds_instance.rds_instance_id}"

--- a/terraform/projects/app-postgresql/README.md
+++ b/terraform/projects/app-postgresql/README.md
@@ -10,6 +10,7 @@ RDS PostgreSQL instances
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
+| instance_name | The RDS Instance Name. | string | `` | no |
 | multi_az | Enable multi-az. | string | `false` | no |
 | password | DB password | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -19,6 +19,12 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "instance_name" {
+  type        = "string"
+  description = "The RDS Instance Name."
+  default     = ""
+}
+
 variable "cloudwatch_log_retention" {
   type        = "string"
   description = "Number of days to retain Cloudwatch logs for"
@@ -70,6 +76,7 @@ module "postgresql-primary_rds_instance" {
   password            = "${var.password}"
   allocated_storage   = "190"
   instance_class      = "db.m4.xlarge"
+  instance_name       = "${var.stackname}-postgresql-primary"
   multi_az            = "${var.multi_az}"
   security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]
   event_sns_topic_arn = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
@@ -90,6 +97,7 @@ module "postgresql-standby_rds_instance" {
   name                       = "${var.stackname}-postgresql-standby"
   default_tags               = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "postgresql_standby")}"
   instance_class             = "db.m4.xlarge"
+  instance_name              = "${var.stackname}-postgresql-standby"
   security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]
   create_replicate_source_db = "1"
   replicate_source_db        = "${module.postgresql-primary_rds_instance.rds_instance_id}"

--- a/terraform/projects/app-transition-postgresql/README.md
+++ b/terraform/projects/app-transition-postgresql/README.md
@@ -10,6 +10,7 @@ RDS Transition PostgreSQL Primary instance
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
+| instance_name | The RDS Instance Name. | string | `` | no |
 | multi_az | Enable multi-az. | string | `false` | no |
 | password | DB password | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -19,6 +19,12 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "instance_name" {
+  type        = "string"
+  description = "The RDS Instance Name."
+  default     = ""
+}
+
 variable "cloudwatch_log_retention" {
   type        = "string"
   description = "Number of days to retain Cloudwatch logs for"
@@ -70,6 +76,7 @@ module "transition-postgresql-primary_rds_instance" {
   password            = "${var.password}"
   allocated_storage   = "120"
   instance_class      = "db.m4.large"
+  instance_name       = "${var.stackname}-transition-postgresql-primary"
   multi_az            = "${var.multi_az}"
   security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_transition-postgresql-primary_id}"]
   event_sns_topic_arn = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
@@ -90,6 +97,7 @@ module "transition-postgresql-standby_rds_instance" {
   name                       = "${var.stackname}-transition-postgresql-standby"
   default_tags               = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "transition_postgresql_standby")}"
   instance_class             = "db.m4.large"
+  instance_name              = "${var.stackname}-transition-postgresql-standby"
   security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_transition-postgresql-standby_id}"]
   create_replicate_source_db = "1"
   replicate_source_db        = "${module.transition-postgresql-primary_rds_instance.rds_instance_id}"

--- a/terraform/projects/app-warehouse/main.tf
+++ b/terraform/projects/app-warehouse/main.tf
@@ -70,6 +70,7 @@ module "warehouse-postgresql-primary_rds_instance" {
   password            = "${var.password}"
   allocated_storage   = "64"
   instance_class      = "db.m4.large"
+  instance_name       = "${var.stackname}-warehouse-postgresql-primary"
   multi_az            = "${var.multi_az}"
   security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_warehouse-postgresql-primary_id}"]
   event_sns_topic_arn = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
@@ -90,6 +91,7 @@ module "warehouse-postgresql-standby_rds_instance" {
   name                       = "${var.stackname}-warehouse-postgresql-standby"
   default_tags               = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "postgresql_standby")}"
   instance_class             = "db.m4.large"
+  instance_name              = "${var.stackname}-warehouse-postgresql-standby"
   security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_warehouse-postgresql-primary_id}"]
   create_replicate_source_db = "1"
   replicate_source_db        = "${module.warehouse-postgresql-primary_rds_instance.rds_instance_id}"


### PR DESCRIPTION
- We don't specify an instance name when we create AWS RDS instances.
Hence, a default name is issued at creation. For example, it would look
like the following. 'terraform-20180410102142467900000002'

- This poses two issues.
  - It is difficult to view the AWS RDS console and determine the
instance visually, without selecting the instance and checking other
notations.
  - We identified that it is difficult to create Icninga checks with
dynamic names.

- To address the above mentioned issues, we are implementing the
`identifier` attribute of the `aws_db_instance` Terraform module.

https://trello.com/c/C7SY8edZ/1123-monitor-rds-and-elasticache-in-aws-and-alert-icinga

Solo: @suthagarht