### PR TITLE
AWS blue-monitoring IAM policy.

### DIFF
--- a/terraform/projects/app-monitoring/additional_policy.json
+++ b/terraform/projects/app-monitoring/additional_policy.json
@@ -10,7 +10,21 @@
                 "ec2:AttachVolume",
                 "ec2:DetachVolume",
                 "ec2:DescribeVolumeStatus",
-                "ec2:DescribeVolumes"
+                "ec2:DescribeVolumes",
+                "ec2:DescribeAvailabilityZones",
+                "rds:Describe*",
+                "rds:ListTagsForResource",
+                "elasticache:Describe*",
+                "cloudwatch:DescribeAlarmHistory",
+                "cloudwatch:GetDashboard",
+                "cloudwatch:GetMetricData",
+                "cloudwatch:DescribeAlarmsForMetric",
+                "cloudwatch:ListDashboards",
+                "cloudwatch:DescribeAlarms",
+                "cloudwatch:GetMetricStatistics",
+                "cloudwatch:ListMetrics",
+                "logs:DescribeLogStreams",
+                "logs:GetLogEvents"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
- We have made some changes to enable Icinga to report on AWS RDS
instances and Elastic Cache instances. We had to provide some additional
access privileges to the blue-monitoring instance to fulfil this need.

- We have added the following exceptions.
  - Allow blue-monitoring to list and read 'CloudWatch' and 'CloudWatch
Logs'
  - Allow to list 'ElasticCache'
  - Allow to list and read on RDS.

https://trello.com/c/C7SY8edZ/1123-monitor-rds-and-elasticache-in-aws-and-alert-icinga

Solos: @suthagarht