### PR TITLE
Icinga Monitoring - AWS RDS

### DIFF
--- a/terraform/projects/app-mysql/README.md
+++ b/terraform/projects/app-mysql/README.md
@@ -33,3 +33,10 @@ RDS Mysql Primary instance
 | mysql_replica_address | Mysql instance address |
 | mysql_replica_endpoint | Mysql instance endpoint |
 
+## Monitoring
+We can monitor AWS RDS Instances via Icinga. This can be done by adding the instance name inside the 'hieradata_aws/common.yaml' file in the GOV.UK Pupet repository, under the 'monitoring::checks::rds::servers:'.
+
+If you do need additional matics to be checked, you will have to add some additional files to the GOV.UK Puppet repository.
+1) Create a plugin [ inside modules/monitoring/files/usr/lib/nagios/plugins/].
+2) We have to specify the command format. [ inside modules/monitoring/files/etc/nagios3/conf.d/]
+3) We have to create a puppet class that will map the plugin to the command. Also, here you will be able to create a "config" file that will provide the alert values to the command. [inside modules/monitoring/manifests/checks/]

--- a/terraform/projects/app-postgresql/README.md
+++ b/terraform/projects/app-postgresql/README.md
@@ -34,3 +34,11 @@ RDS PostgreSQL instances
 | postgresql-standby_address | postgresql replica instance address |
 | postgresql-standby_endpoint | postgresql replica instance endpoint |
 
+
+## Monitoring
+We can monitor AWS RDS Instances via Icinga. This can be done by adding the instance name inside the 'hieradata_aws/common.yaml' file in the GOV.UK Pupet repository, under the 'monitoring::checks::rds::servers:'.
+
+If you do need additional matics to be checked, you will have to add some additional files to the GOV.UK Puppet repository.
+1) Create a plugin [ inside modules/monitoring/files/usr/lib/nagios/plugins/].
+2) We have to specify the command format. [ inside modules/monitoring/files/etc/nagios3/conf.d/]
+3) We have to create a puppet class that will map the plugin to the command. Also, here you will be able to create a "config" file that will provide the alert values to the command. [inside modules/monitoring/manifests/checks/]

--- a/terraform/projects/app-transition-postgresql/README.md
+++ b/terraform/projects/app-transition-postgresql/README.md
@@ -34,3 +34,10 @@ RDS Transition PostgreSQL Primary instance
 | transition-postgresql-standby-address | transition-postgresql replica instance address |
 | transition-postgresql-standby-endpoint | transition-postgresql replica instance endpoint |
 
+## Monitoring
+We can monitor AWS RDS Instances via Icinga. This can be done by adding the instance name inside the 'hieradata_aws/common.yaml' file in the GOV.UK Pupet repository, under the 'monitoring::checks::rds::servers:'.
+
+If you do need additional matics to be checked, you will have to add some additional files to the GOV.UK Puppet repository.
+1) Create a plugin [ inside modules/monitoring/files/usr/lib/nagios/plugins/].
+2) We have to specify the command format. [ inside modules/monitoring/files/etc/nagios3/conf.d/]
+3) We have to create a puppet class that will map the plugin to the command. Also, here you will be able to create a "config" file that will provide the alert values to the command. [inside modules/monitoring/manifests/checks/]

--- a/terraform/projects/app-warehouse/README.md
+++ b/terraform/projects/app-warehouse/README.md
@@ -34,3 +34,10 @@ RDS PostgreSQL instance for the GOV.UK data warehouse
 | warehouse-postgresql-primary_id | postgresql instance ID |
 | warehouse-postgresql-primary_resource_id | postgresql instance resource ID |
 
+## Monitoring
+We can monitor AWS RDS Instances via Icinga. This can be done by adding the instance name inside the 'hieradata_aws/common.yaml' file in the GOV.UK Pupet repository, under the 'monitoring::checks::rds::servers:'.
+
+If you do need additional matics to be checked, you will have to add some additional files to the GOV.UK Puppet repository.
+1) Create a plugin [ inside modules/monitoring/files/usr/lib/nagios/plugins/].
+2) We have to specify the command format. [ inside modules/monitoring/files/etc/nagios3/conf.d/]
+3) We have to create a puppet class that will map the plugin to the command. Also, here you will be able to create a "config" file that will provide the alert values to the command. [inside modules/monitoring/manifests/checks/]


### PR DESCRIPTION
- We have made few changes to enable AWS RDS instances to be monitored by
Icinga. This change incorporates some instructions/guidance on how to
add an instance to be monitored or to add a new matric to be monitored.

https://trello.com/c/C7SY8edZ/1123-monitor-rds-and-elasticache-in-aws-and-alert-icinga

Pair: @suthagarht @szd55gds