### PR TITLE
Allow Production Carrenza to talk to Integration

### DIFF
--- a/terraform/projects/infra-security-groups/deploy.tf
+++ b/terraform/projects/infra-security-groups/deploy.tf
@@ -67,7 +67,7 @@ resource "aws_security_group_rule" "deploy-elb_ingress_office_https" {
   cidr_blocks       = ["${var.office_ips}"]
 }
 
-# Allow Carrenza Integration access to trigger automated deployments
+# Allow Carrenza Integration and Production access to trigger automated deployments
 resource "aws_security_group_rule" "deploy-elb_ingress_carrenza_https" {
   type      = "ingress"
   from_port = 443
@@ -75,7 +75,7 @@ resource "aws_security_group_rule" "deploy-elb_ingress_carrenza_https" {
   protocol  = "tcp"
 
   security_group_id = "${aws_security_group.deploy_elb.id}"
-  cidr_blocks       = ["${var.carrenza_integration_ips}"]
+  cidr_blocks       = ["${var.carrenza_integration_ips}", "${var.carrenza_production_ips}"]
 }
 
 resource "aws_security_group_rule" "deploy-elb_egress_any_any" {


### PR DESCRIPTION
- We have a Jenkins job that runs after the data sync jobs, called
  "trigger data sync complete". This has been failing while trying to
  trigger the integration one, because access to
  `https://deploy.integration.publishing.service.gov.uk` has been
  failing. The IPs in each of the `carrenza_{environment}_ips` variables
  in govuk-aws-data look good, they're just not referenced anywhere in
  the security groups for the deploy ELB.