### PR TITLE
AWS S3 Cross Account Access

### DIFF
--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -347,6 +347,12 @@ resource "aws_iam_role_policy_attachment" "mongo_database_backups_iam_role_polic
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.write_database_backups_bucket_policy_arn}"
 }
 
+resource "aws_iam_role_policy_attachment" "read_mongo_database_backups_iam_role_policy_attachment" {
+  count      = 3
+  role       = "${element(list(module.mongo-1.instance_iam_role_name, module.mongo-2.instance_iam_role_name, module.mongo-3.instance_iam_role_name), count.index)}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.mongo_api_read_database_backups_bucket_policy_arn}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -13,6 +13,7 @@ database-backups: The bucket that will hold database backups
 | aws_backup_region | AWS region | string | `eu-west-2` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| backup_source_bucket | This variable is used to pass the backup bucket that is used to get the data (from production). | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | stackname | Stackname | string | - | yes |
@@ -21,5 +22,6 @@ database-backups: The bucket that will hold database backups
 
 | Name | Description |
 |------|-------------|
+| mongo_api_read_database_backups_bucket_policy_arn | ARN of the read mongo-api database_backups-bucket policy |
 | write_database_backups_bucket_policy_arn | ARN of the write database_backups-bucket policy |
 

--- a/terraform/projects/infra-database-backups-bucket/bucket_policy.tf
+++ b/terraform/projects/infra-database-backups-bucket/bucket_policy.tf
@@ -1,0 +1,33 @@
+/**
+* ## Project: database-backups-bucket
+*
+* Create a policy that allows listing and reading of the database-backups bucket.
+*
+*/
+
+resource "aws_s3_bucket_policy" "database_backups_cross_account_access" {
+  bucket = "${aws_s3_bucket.database_backups.id}"
+  policy = "${data.aws_iam_policy_document.database_backups_cross_account_access.json}"
+}
+
+data "aws_iam_policy_document" "database_backups_cross_account_access" {
+  statement {
+    sid     = "CrossAccountPermissions"
+    effect  = "Allow"
+    actions = ["s3:Get*", "s3:List*"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+    ]
+
+    principals = {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::210287912431:root",
+        "arn:aws:iam::696911096973:root",
+        "arn:aws:iam::172025368201:root",
+      ]
+    }
+  }
+}

--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -40,6 +40,12 @@ variable "remote_state_infra_monitoring_key_stack" {
   default     = ""
 }
 
+variable "backup_source_bucket" {
+  type        = "string"
+  description = "This variable is used to pass the backup bucket that is used to get the data (from production)."
+  default     = ""
+}
+
 # Set up the backend & provider for each region
 terraform {
   backend          "s3"             {}

--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -1,0 +1,46 @@
+/**
+* ## Project: database-backups-bucket
+*
+* This is used to provide and control access to the database backup bucket located in the Production environment.
+* a) We have created individual resources that can be applied to individual projects.
+* b) We have also restricted wich sub object can be accessed.
+* c) The bucket gives read access to accounts from all three environments, but we believe that restricting at this level is sufficient.
+*
+*/
+
+resource "aws_iam_policy" "mongo_api_database_backups_reader" {
+  name        = "govuk-${var.aws_environment}-mongo-api_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.mongo_api_database_backups_reader.json}"
+  description = "Allows reading the database_backups bucket"
+}
+
+data "aws_iam_policy_document" "mongo_api_database_backups_reader" {
+  statement {
+    sid = "MongoAPIReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::${var.backup_source_bucket}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "mongo-api",
+      ]
+    }
+  }
+}
+
+output "mongo_api_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.mongo_api_database_backups_reader.arn}"
+  description = "ARN of the read mongo-api database_backups-bucket policy"
+}

--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -25,16 +25,20 @@ data "aws_iam_policy_document" "database_backups_writer" {
 
     # In theory  should work but it doesn't so use * instead
     resources = [
-      "arn:aws:s3:::*",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
     ]
   }
 
   statement {
-    sid     = "WriteGovukDatabaseBackups"
-    actions = ["s3:*"]
+    sid = "WriteGovukDatabaseBackups"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*",
     ]
   }


### PR DESCRIPTION
- We have a requirement to make the production database backup S3 bucket
, readble by the staging and integration environments.

- This was necessary to reduce the backup duplication.

https://trello.com/c/9B3bGNK3/1200-write-or-modify-s3-bucket-policies-to-allow-staging-and-integration-to-read-backups-from-production

Pair: @schmie  @suthagarht