### PR TITLE
AWS S3 Database Backup Writer

### DIFF
--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -138,9 +138,16 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "db-admin_database_backups_iam_role_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "write_db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "production" ? 1 : 0}"
   role       = "${module.db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.write_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_write_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "read_db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment != "production" ? 1 : 0}"
+  role       = "${module.db-admin.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_read_database_backups_bucket_policy_arn}"
 }
 
 # Outputs

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -242,9 +242,16 @@ resource "aws_iam_role_policy_attachment" "graphite_1_iam_role_policy_cloudwatch
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
 }
 
-resource "aws_iam_role_policy_attachment" "graphite_database_backups_iam_role_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "write_graphite_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "production" ? 1 : 0}"
   role       = "${module.graphite-1.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.write_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.graphite_write_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "read_graphite_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment != "production" ? 1 : 0}"
+  role       = "${module.graphite-1.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.graphite_read_database_backups_bucket_policy_arn}"
 }
 
 data "terraform_remote_state" "infra_database_backups_bucket" {

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -341,14 +341,14 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "mongo_database_backups_iam_role_policy_attachment" {
-  count      = 3
+resource "aws_iam_role_policy_attachment" "write_mongo_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "production" ? 3 : 0}"
   role       = "${element(list(module.mongo-1.instance_iam_role_name, module.mongo-2.instance_iam_role_name, module.mongo-3.instance_iam_role_name), count.index)}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.write_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.mongo_api_write_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "read_mongo_database_backups_iam_role_policy_attachment" {
-  count      = 3
+  count      = "${var.aws_environment != "production" ? 3 : 0}"
   role       = "${element(list(module.mongo-1.instance_iam_role_name, module.mongo-2.instance_iam_role_name, module.mongo-3.instance_iam_role_name), count.index)}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.mongo_api_read_database_backups_bucket_policy_arn}"
 }

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -288,10 +288,16 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "router-backend_database_backups_iam_role_policy_attachment" {
-  count      = 3
+resource "aws_iam_role_policy_attachment" "write_router-backend_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "production" ? 3 : 0}"
   role       = "${element(list(module.router-backend-1.instance_iam_role_name, module.router-backend-2.instance_iam_role_name, module.router-backend-3.instance_iam_role_name), count.index)}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.write_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.mongo_api_write_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "read_router-backend_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment != "production" ? 3 : 0}"
+  role       = "${element(list(module.router-backend-1.instance_iam_role_name, module.router-backend-2.instance_iam_role_name, module.router-backend-3.instance_iam_role_name), count.index)}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.mongo_api_read_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_policy" "router-backend_iam_policy" {

--- a/terraform/projects/app-rummager-elasticsearch/main.tf
+++ b/terraform/projects/app-rummager-elasticsearch/main.tf
@@ -272,10 +272,16 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "rummager-elasticsearch-1_database_backups_iam_role_policy_attachment" {
-  count      = 3
+resource "aws_iam_role_policy_attachment" "write_rummager-elasticsearch-1_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "production" ? 3 : 0}"
   role       = "${element(list(module.rummager-elasticsearch-1.instance_iam_role_name, module.rummager-elasticsearch-2.instance_iam_role_name, module.rummager-elasticsearch-3.instance_iam_role_name), count.index)}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.write_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.elasticsearch_write_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "read_rummager-elasticsearch-1_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment != "production" ? 3 : 0}"
+  role       = "${element(list(module.rummager-elasticsearch-1.instance_iam_role_name, module.rummager-elasticsearch-2.instance_iam_role_name, module.rummager-elasticsearch-3.instance_iam_role_name), count.index)}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.elasticsearch_read_database_backups_bucket_policy_arn}"
 }
 
 # Outputs

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -129,9 +129,16 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "transition-db-admin_database_backups_iam_role_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "write_transition-db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "production" ? 1 : 0}"
   role       = "${module.transition-db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.write_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_write_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "read_transition-db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment != "production" ? 1 : 0}"
+  role       = "${module.transition-db-admin.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_read_database_backups_bucket_policy_arn}"
 }
 
 # Outputs

--- a/terraform/projects/app-warehouse-db-admin/main.tf
+++ b/terraform/projects/app-warehouse-db-admin/main.tf
@@ -129,9 +129,16 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "warehouse-db-admin_database_backups_iam_role_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "write_warehouse-db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "production" ? 1 : 0}"
   role       = "${module.warehouse-db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.write_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_write_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "read_warehouse-db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment != "production" ? 1 : 0}"
+  role       = "${module.warehouse-db-admin.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_read_database_backups_bucket_policy_arn}"
 }
 
 # Outputs

--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -22,6 +22,14 @@ database-backups: The bucket that will hold database backups
 
 | Name | Description |
 |------|-------------|
+| dbadmin_read_database_backups_bucket_policy_arn | ARN of the read DBAdmin database_backups-bucket policy |
+| dbadmin_write_database_backups_bucket_policy_arn | ARN of the DBAdmin write database_backups-bucket policy |
+| elasticsearch_read_database_backups_bucket_policy_arn | ARN of the read elasticsearch database_backups-bucket policy |
+| elasticsearch_write_database_backups_bucket_policy_arn | ARN of the elasticsearch write database_backups-bucket policy |
+| graphite_read_database_backups_bucket_policy_arn | ARN of the read Graphite database_backups-bucket policy |
+| graphite_write_database_backups_bucket_policy_arn | ARN of the Graphite write database_backups-bucket policy |
 | mongo_api_read_database_backups_bucket_policy_arn | ARN of the read mongo-api database_backups-bucket policy |
-| write_database_backups_bucket_policy_arn | ARN of the write database_backups-bucket policy |
+| mongo_api_write_database_backups_bucket_policy_arn | ARN of the mongo-api write database_backups-bucket policy |
+| mongodb_read_database_backups_bucket_policy_arn | ARN of the read mongodb database_backups-bucket policy |
+| mongodb_write_database_backups_bucket_policy_arn | ARN of the mongodb write database_backups-bucket policy |
 

--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -11,7 +11,7 @@
 resource "aws_iam_policy" "mongo_api_database_backups_reader" {
   name        = "govuk-${var.aws_environment}-mongo-api_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.mongo_api_database_backups_reader.json}"
-  description = "Allows reading the database_backups bucket"
+  description = "Allows reading the mongo-api database_backups bucket"
 }
 
 data "aws_iam_policy_document" "mongo_api_database_backups_reader" {
@@ -40,7 +40,156 @@ data "aws_iam_policy_document" "mongo_api_database_backups_reader" {
   }
 }
 
+resource "aws_iam_policy" "mongodb_database_backups_reader" {
+  name        = "govuk-${var.aws_environment}-mongodb_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.mongodb_database_backups_reader.json}"
+  description = "Allows reading the mongodb database_backups bucket"
+}
+
+data "aws_iam_policy_document" "mongodb_database_backups_reader" {
+  statement {
+    sid = "MongoDBReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::${var.backup_source_bucket}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "mongodb",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_policy" "elasticsearch_database_backups_reader" {
+  name        = "govuk-${var.aws_environment}-elasticsearch_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.elasticsearch_database_backups_reader.json}"
+  description = "Allows reading the elasticsearch database_backups bucket"
+}
+
+data "aws_iam_policy_document" "elasticsearch_database_backups_reader" {
+  statement {
+    sid = "ElasticsearchReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::${var.backup_source_bucket}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "elasticsearch",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_policy" "dbadmin_database_backups_reader" {
+  name        = "govuk-${var.aws_environment}-dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.dbadmin_database_backups_reader.json}"
+  description = "Allows reading the dbadmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "dbadmin_database_backups_reader" {
+  statement {
+    sid = "DBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::${var.backup_source_bucket}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "mysql",
+        "postgres",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_policy" "graphite_database_backups_reader" {
+  name        = "govuk-${var.aws_environment}-graphite_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.graphite_database_backups_reader.json}"
+  description = "Allows reading the graphite database_backups bucket"
+}
+
+data "aws_iam_policy_document" "graphite_database_backups_reader" {
+  statement {
+    sid = "GraphiteReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::${var.backup_source_bucket}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "whisper",
+      ]
+    }
+  }
+}
+
 output "mongo_api_read_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.mongo_api_database_backups_reader.arn}"
   description = "ARN of the read mongo-api database_backups-bucket policy"
+}
+
+output "mongodb_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.mongodb_database_backups_reader.arn}"
+  description = "ARN of the read mongodb database_backups-bucket policy"
+}
+
+output "elasticsearch_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.elasticsearch_database_backups_reader.arn}"
+  description = "ARN of the read elasticsearch database_backups-bucket policy"
+}
+
+output "dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.dbadmin_database_backups_reader.arn}"
+  description = "ARN of the read DBAdmin database_backups-bucket policy"
+}
+
+output "graphite_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.graphite_database_backups_reader.arn}"
+  description = "ARN of the read Graphite database_backups-bucket policy"
 }

--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -7,15 +7,15 @@
 *
 */
 
-resource "aws_iam_policy" "database_backups_writer" {
-  name        = "govuk-${var.aws_environment}-database_backups-writer-policy"
-  policy      = "${data.aws_iam_policy_document.database_backups_writer.json}"
-  description = "Allows writing of the database_backups bucket"
+resource "aws_iam_policy" "mongo_api_database_backups_writer" {
+  name        = "govuk-${var.aws_environment}-mongo-api_database_backups-writer-policy"
+  policy      = "${data.aws_iam_policy_document.mongo_api_database_backups_writer.json}"
+  description = "Allows writing of the mongo-api database_backups bucket"
 }
 
-data "aws_iam_policy_document" "database_backups_writer" {
+data "aws_iam_policy_document" "mongo_api_database_backups_writer" {
   statement {
-    sid = "ReadBucketLists"
+    sid = "MongoAPIReadBucketLists"
 
     actions = [
       "s3:ListBucket",
@@ -23,14 +23,24 @@ data "aws_iam_policy_document" "database_backups_writer" {
       "s3:GetBucketLocation",
     ]
 
-    # In theory  should work but it doesn't so use * instead
+    # The top level access is required.
     resources = [
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
     ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "mongo-api",
+      ]
+    }
   }
 
   statement {
-    sid = "WriteGovukDatabaseBackups"
+    sid = "MongoAPIWriteGovukDatabaseBackups"
 
     actions = [
       "s3:PutObject",
@@ -39,12 +49,272 @@ data "aws_iam_policy_document" "database_backups_writer" {
     ]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
     ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "mongo-api",
+      ]
+    }
   }
 }
 
-output "write_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.database_backups_writer.arn}"
-  description = "ARN of the write database_backups-bucket policy"
+resource "aws_iam_policy" "mongodb_database_backups_writer" {
+  name        = "govuk-${var.aws_environment}-mongodb_database_backups-writer-policy"
+  policy      = "${data.aws_iam_policy_document.mongodb_database_backups_writer.json}"
+  description = "Allows writing of the mongodb database_backups bucket"
+}
+
+data "aws_iam_policy_document" "mongodb_database_backups_writer" {
+  statement {
+    sid = "MongoDBReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    # The top level access is required.
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "mongodb",
+      ]
+    }
+  }
+
+  statement {
+    sid = "MongoDBWriteGovukDatabaseBackups"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "mongodb",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_policy" "elasticsearch_database_backups_writer" {
+  name        = "govuk-${var.aws_environment}-elasticsearch_database_backups-writer-policy"
+  policy      = "${data.aws_iam_policy_document.elasticsearch_database_backups_writer.json}"
+  description = "Allows writing of the elasticsearch database_backups bucket"
+}
+
+data "aws_iam_policy_document" "elasticsearch_database_backups_writer" {
+  statement {
+    sid = "ElasticsearchReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    # The top level access is required.
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "elasticsearch",
+      ]
+    }
+  }
+
+  statement {
+    sid = "ElasticsearchWriteGovukDatabaseBackups"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "elasticsearch",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_policy" "dbadmin_database_backups_writer" {
+  name        = "govuk-${var.aws_environment}-dbadmin_database_backups-writer-policy"
+  policy      = "${data.aws_iam_policy_document.dbadmin_database_backups_writer.json}"
+  description = "Allows writing of the DBAdmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "dbadmin_database_backups_writer" {
+  statement {
+    sid = "DBAdminReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    # The top level access is required.
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "mysql",
+        "postgres",
+      ]
+    }
+  }
+
+  statement {
+    sid = "DBAdminWriteGovukDatabaseBackups"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "mysql",
+        "postgres",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_policy" "graphite_database_backups_writer" {
+  name        = "govuk-${var.aws_environment}-graphite_database_backups-writer-policy"
+  policy      = "${data.aws_iam_policy_document.graphite_database_backups_writer.json}"
+  description = "Allows writing of the Graphite database_backups bucket"
+}
+
+data "aws_iam_policy_document" "graphite_database_backups_writer" {
+  statement {
+    sid = "GraphiteReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    # The top level access is required.
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "whisper",
+      ]
+    }
+  }
+
+  statement {
+    sid = "GraphiteWriteGovukDatabaseBackups"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "whisper",
+      ]
+    }
+  }
+}
+
+output "mongo_api_write_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.mongo_api_database_backups_writer.arn}"
+  description = "ARN of the mongo-api write database_backups-bucket policy"
+}
+
+output "mongodb_write_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.mongodb_database_backups_writer.arn}"
+  description = "ARN of the mongodb write database_backups-bucket policy"
+}
+
+output "elasticsearch_write_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.elasticsearch_database_backups_writer.arn}"
+  description = "ARN of the elasticsearch write database_backups-bucket policy"
+}
+
+output "dbadmin_write_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.dbadmin_database_backups_writer.arn}"
+  description = "ARN of the DBAdmin write database_backups-bucket policy"
+}
+
+output "graphite_write_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.graphite_database_backups_writer.arn}"
+  description = "ARN of the Graphite write database_backups-bucket policy"
 }


### PR DESCRIPTION
- We had an AWS IAM policy called "database_backups_writer". This policy
provided write access to the "govuk-production-database-backups" bucket.
This policy was attached to the instances created by the "app-mongo"
project.

- The requirement has changed. We want the AWS Production environment
mongo instances to be able to write to the object called "govuk-production-database-backups/mongo-api".
We also need to provide read access to this location for the AWS  staging and integration environments.

- To accomplish this, we have modified the "writer" policy. The modified
policy will define a single resource per project. This enables us to
limit which objects within the bucket can be accessed (prefix). We are
using the prefix value in the backup script. https://github.com/alphagov/govuk-env-sync/blob/mongo-to-s3-bash/mongo-to-s3.sh#L45

- We have also introduced a condition inside the app-mongo project. This
condition means that the writer policy will only be attached to AWS
production environment instances. The other environments will get a
reader policy attached.

https://trello.com/c/H3CJpNje/1257-data-sync-aws-s3-backup-bucket-access

Solo: @suthagarht