### PR TITLE
Fix SSH access to alert from jumpbox

### DIFF
--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -107,6 +107,13 @@ resource "aws_elb" "monitoring_internal_elb" {
   internal        = "true"
 
   listener {
+    instance_port     = 22
+    instance_protocol = "tcp"
+    lb_port           = 22
+    lb_protocol       = "tcp"
+  }
+
+  listener {
     instance_port     = 5667
     instance_protocol = "tcp"
     lb_port           = 5667

--- a/terraform/projects/infra-security-groups/monitoring.tf
+++ b/terraform/projects/infra-security-groups/monitoring.tf
@@ -47,6 +47,19 @@ resource "aws_security_group_rule" "monitoring_ingress_monitoring-internal-elb_n
   source_security_group_id = "${aws_security_group.monitoring_internal_elb.id}"
 }
 
+resource "aws_security_group_rule" "monitoring_ingress_monitoring-internal-elb_ssh" {
+  type      = "ingress"
+  from_port = 22
+  to_port   = 22
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.monitoring.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.monitoring_internal_elb.id}"
+}
+
 resource "aws_security_group_rule" "monitoring_ingress_monitoring-internal-elb_http" {
   type      = "ingress"
   from_port = 80
@@ -117,6 +130,16 @@ resource "aws_security_group_rule" "monitoring-internal-elb_ingress_management_h
 
   security_group_id        = "${aws_security_group.monitoring_internal_elb.id}"
   source_security_group_id = "${aws_security_group.management.id}"
+}
+
+resource "aws_security_group_rule" "monitoring-internal-elb_ingress_jumpbox_ssh" {
+  type      = "ingress"
+  from_port = 22
+  to_port   = 22
+  protocol  = "tcp"
+
+  security_group_id        = "${aws_security_group.monitoring_internal_elb.id}"
+  source_security_group_id = "${aws_security_group.jumpbox.id}"
 }
 
 resource "aws_security_group_rule" "monitoring-internal-elb_egress_any_any" {


### PR DESCRIPTION
- This is used by a number of fabric scripts attempting to contact
  alert.cluster (and possibly others).

- This seems to be expected behaviour and is isolated/limited to the
  internal network.

@schmie