### PR TITLE
Email alert api glue crawler

### DIFF
--- a/terraform/projects/infra-email-alert-api-archive/main.tf
+++ b/terraform/projects/infra-email-alert-api-archive/main.tf
@@ -30,7 +30,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.25.0"
 }
 
 resource "aws_s3_bucket" "email_alert_api_archive" {
@@ -70,6 +70,59 @@ data "template_file" "s3_writer_policy_template" {
     aws_environment = "${var.aws_environment}"
     bucket          = "${aws_s3_bucket.email_alert_api_archive.id}"
   }
+}
+
+resource "aws_glue_catalog_database" "email_archive" {
+  name        = "email_alert_api_archive"
+  description = "Stores email sent data from the email-alert-api application"
+}
+
+resource "aws_iam_role_policy_attachment" "aws-glue-service-role-service-attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+  role       = "${aws_iam_role.glue.name}"
+}
+
+resource "aws_iam_role" "glue" {
+  name = "AWSGlueServiceRole-email-alert-api-archive"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "glue.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "glue_policy" {
+  name = "govuk-${var.aws_environment}-email-alert-api-archive-glue-policy"
+  role = "${aws_iam_role.glue.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${aws_s3_bucket.email_alert_api_archive.id}",
+        "arn:aws:s3:::${aws_s3_bucket.email_alert_api_archive.id}/*"
+      ]
+    }
+  ]
+}
+EOF
 }
 
 # Outputs


### PR DESCRIPTION
This sets up a few resources to run a glue crawler that populates a partitioned database for querying the Email Alert API archives.

This:
- bumps the AWS terraform provider so we can use the glue methods
- creates a database for Email Alert API data
- creates a role that glue crawler can run as
- a policy so the glue crawler can access the data
- the crawler itself running on a 4 hour interval
- the schema for the database table defining the appropriate types for the JSON data and partitioning