### PR TITLE
AWS Glue Crawlers for log files

### DIFF
--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -125,6 +125,187 @@ resource "aws_iam_role_policy" "fastly_logs_policy" {
 EOF
 }
 
+resource "aws_glue_crawler" "govuk_www" {
+  name          = "GOV.UK fastly logs"
+  description   = "Crawls the GOV.UK logs from fastly for allowing Athena querying"
+  database_name = "${aws_glue_catalog_database.fastly_logs.name}"
+  role          = "${aws_iam_role.glue.name}"
+  schedule      = "cron(30 */4 * * ? *)"
+
+  s3_target {
+    path = "s3://${aws_s3_bucket.fastly_logs.bucket}/govuk_www"
+  }
+
+  schema_change_policy {
+    delete_behavior = "DELETE_FROM_DATABASE"
+    update_behavior = "LOG"
+  }
+
+  configuration  = <<EOF
+{
+  "Version": 1.0,
+  "CrawlerOutput": {
+    "Partitions": {
+      "AddOrUpdateBehavior": "InheritFromTable"
+    }
+  }
+}
+EOF
+}
+
+resource "aws_glue_catalog_table" "govuk_www" {
+  name          = "govuk_www"
+  description   = "Maps the tab-seperated value log file to columns"
+  database_name = "${aws_glue_catalog_database.fastly_logs.name}"
+  table_type    = "EXTERNAL_TABLE"
+
+  storage_descriptor {
+    compressed    = true
+    location      = "s3://${aws_s3_bucket.fastly_logs.bucket}/govuk_www/"
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      name = "ser_de_name"
+      parameters {
+        field.delim = "\t"
+      }
+      serialization_library = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
+    }
+
+    // These columns corellate with the log format set up in Fastly which is:
+    // %h\t%u\t%{%Y-%m-%d %H:%M:%S.}t%{msec_frac}t\t%{%z}t\t%m\t%{req.url}V\t%>s\tv$%{time.elapsed.sec}V.%{time.elapsed.msec_frac}V\t%{time.to_first_byte}V\t%B\t%{Content-Type}o\t%{User-Agent}i\t%{Fastly-Backend-Name}o\t%{server.datacenter}V\t%{if(resp.http.X-Cache ~"HIT", "HIT", "MISS")}V\t%{tls.client.protocol}V\t%{tls.client.cipher}V
+    columns = [
+      // %h
+      {
+        name    = "remote_host"
+        type    = "string",
+        comment = "Host that made this request, most likely an IP address"
+      },
+      // %u
+      {
+        name    = "remote_user"
+        type    = "string",
+        comment = "Basic auth user for this request"
+      },
+      // %{%Y-%m-%d %H:%M:%S.}t%{msec_frac}t
+      {
+        name    = "request_received",
+        type    = "timestamp",
+        comment = "Time we received the request"
+      },
+      // This field is separate from the timestamp above as the Presto version
+      // on AWS Athena doesn't support timestamps - expectation is that this is
+      // always +0000 though
+      // %{%z}t
+      {
+        name    = "request_received_offset",
+        type    = "string",
+        comment = "Time offset of the request, expected to be +0000 always"
+      },
+      // %m
+      {
+        name    = "method",
+        type    = "string"
+        comment = "HTTP method for this request"
+      },
+      // %{req.url}V
+      {
+        name    = "url",
+        type    = "string",
+        comment = "URL requested with query string"
+      },
+      // %>s
+      {
+        name    = "status",
+        type    = "int",
+        comment = "HTTP status code returned"
+      },
+      // $%{time.elapsed.sec}V.%{time.elapsed.msec_frac}V
+      {
+        name    = "request_time",
+        type    = "float",
+        comment = "Time until user received full response in seconds"
+      },
+      // %{time.to_first_byte}V
+      {
+        name    = "time_to_generate_response",
+        type    = "float",
+        comment = "Time spent generating a response for varnish, in seconds"
+      },
+      // %B
+      {
+        name    = "bytes",
+        type    = "bigint",
+        comment = "Number of bytes returned"
+      },
+      // %{Content-Type}o
+      {
+        name    = "content_type",
+        type    = "string",
+        comment = "HTTP Content-Type header returned"
+      },
+      // %{User-Agent}i
+      {
+        name    = "user_agent",
+        type    = "string",
+        comment = "User agent that made the request"
+      },
+      // %{Fastly-Backend-Name}o
+      {
+        name    = "fastly_backend",
+        type    = "string",
+        comment = "Name of the backend that served this request"
+      },
+      // %{server.datacenter}V
+      {
+        name    = "fastly_data_centre",
+        type    = "string",
+        comment = "Name of the data centre that served this request"
+      },
+      // %{if(resp.http.X-Cache ~"HIT", "HIT", "MISS")}V
+      {
+        name    = "cache_hit",
+        type    = "string",
+        comment = "HIT or MISS as to whether this was served from Fastly cache"
+      },
+      // %{tls.client.protocol}V
+      {
+        name = "tls_client_protocol",
+        type = "string"
+      },
+      // %{tls.client.cipher}V
+      {
+        name = "tls_client_cipher",
+        type = "string"
+      }
+    ]
+  }
+
+  // these correspond to directory ordering of:
+  // /year=YYYY/month=MM/date=DD/file.log.gz
+  partition_keys = [
+    {
+      name = "year"
+      type = "int"
+    },
+    {
+      name = "month"
+      type = "int"
+    },
+    {
+      name = "date"
+      type = "int"
+    }
+  ]
+
+  parameters {
+    classification  = "csv"
+    compressionType = "gzip"
+    delimiter       = "\t"
+  }
+}
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -137,7 +137,7 @@ resource "aws_glue_crawler" "govuk_www" {
   }
 
   schema_change_policy {
-    delete_behavior = "DELETE_FROM_DATABASE"
+    delete_behavior = "DEPRECATE_IN_DATABASE"
     update_behavior = "LOG"
   }
 
@@ -318,7 +318,7 @@ resource "aws_glue_crawler" "govuk_assets" {
   }
 
   schema_change_policy {
-    delete_behavior = "DELETE_FROM_DATABASE"
+    delete_behavior = "DEPRECATE_IN_DATABASE"
     update_behavior = "LOG"
   }
 
@@ -499,7 +499,7 @@ resource "aws_glue_crawler" "bouncer" {
   }
 
   schema_change_policy {
-    delete_behavior = "DELETE_FROM_DATABASE"
+    delete_behavior = "DEPRECATE_IN_DATABASE"
     update_behavior = "LOG"
   }
 

--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -82,7 +82,8 @@ resource "aws_iam_role_policy_attachment" "aws-glue-service-role-service-attachm
 }
 
 resource "aws_iam_role" "glue" {
-  name               = "AWSGlueServiceRole-fastly-logs"
+  name = "AWSGlueServiceRole-fastly-logs"
+
   // I did want to set a path of /service-role/ here but that seems to break
   // creating the crawler
   assume_role_policy = <<EOF
@@ -141,7 +142,7 @@ resource "aws_glue_crawler" "govuk_www" {
     update_behavior = "LOG"
   }
 
-  configuration  = <<EOF
+  configuration = <<EOF
 {
   "Version": 1.0,
   "CrawlerOutput": {
@@ -167,118 +168,121 @@ resource "aws_glue_catalog_table" "govuk_www" {
 
     ser_de_info {
       name = "ser_de_name"
+
       parameters {
         field.delim = "\t"
       }
+
       serialization_library = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
     }
 
     // These columns corellate with the log format set up in Fastly which is:
     // %h\t%u\t%{%Y-%m-%d %H:%M:%S.}t%{msec_frac}t\t%{%z}t\t%m\t%{req.url}V\t%>s\tv$%{time.elapsed.sec}V.%{time.elapsed.msec_frac}V\t%{time.to_first_byte}V\t%B\t%{Content-Type}o\t%{User-Agent}i\t%{Fastly-Backend-Name}o\t%{server.datacenter}V\t%{if(resp.http.X-Cache ~"HIT", "HIT", "MISS")}V\t%{tls.client.protocol}V\t%{tls.client.cipher}V
     columns = [
-      // %h
       {
+        // %h
         name    = "remote_host"
-        type    = "string",
+        type    = "string"
         comment = "Host that made this request, most likely an IP address"
       },
-      // %u
       {
+        // %u
         name    = "remote_user"
-        type    = "string",
+        type    = "string"
         comment = "Basic auth user for this request"
       },
-      // %{%Y-%m-%d %H:%M:%S.}t%{msec_frac}t
       {
-        name    = "request_received",
-        type    = "timestamp",
+        // %{%Y-%m-%d %H:%M:%S.}t%{msec_frac}t
+        name    = "request_received"
+        type    = "timestamp"
         comment = "Time we received the request"
       },
-      // This field is separate from the timestamp above as the Presto version
-      // on AWS Athena doesn't support timestamps - expectation is that this is
-      // always +0000 though
-      // %{%z}t
       {
-        name    = "request_received_offset",
-        type    = "string",
+        // This field is separate from the timestamp above as the Presto version
+        // on AWS Athena doesn't support timestamps - expectation is that this is
+        // always +0000 though
+        // %{%z}t
+        name = "request_received_offset"
+
+        type    = "string"
         comment = "Time offset of the request, expected to be +0000 always"
       },
-      // %m
       {
-        name    = "method",
+        // %m
+        name    = "method"
         type    = "string"
         comment = "HTTP method for this request"
       },
-      // %{req.url}V
       {
-        name    = "url",
-        type    = "string",
+        // %{req.url}V
+        name    = "url"
+        type    = "string"
         comment = "URL requested with query string"
       },
-      // %>s
       {
-        name    = "status",
-        type    = "int",
+        // %>s
+        name    = "status"
+        type    = "int"
         comment = "HTTP status code returned"
       },
-      // $%{time.elapsed.sec}V.%{time.elapsed.msec_frac}V
       {
-        name    = "request_time",
-        type    = "float",
+        // $%{time.elapsed.sec}V.%{time.elapsed.msec_frac}V
+        name    = "request_time"
+        type    = "float"
         comment = "Time until user received full response in seconds"
       },
-      // %{time.to_first_byte}V
       {
-        name    = "time_to_generate_response",
-        type    = "float",
+        // %{time.to_first_byte}V
+        name    = "time_to_generate_response"
+        type    = "float"
         comment = "Time spent generating a response for varnish, in seconds"
       },
-      // %B
       {
-        name    = "bytes",
-        type    = "bigint",
+        // %B
+        name    = "bytes"
+        type    = "bigint"
         comment = "Number of bytes returned"
       },
-      // %{Content-Type}o
       {
-        name    = "content_type",
-        type    = "string",
+        // %{Content-Type}o
+        name    = "content_type"
+        type    = "string"
         comment = "HTTP Content-Type header returned"
       },
-      // %{User-Agent}i
       {
-        name    = "user_agent",
-        type    = "string",
+        // %{User-Agent}i
+        name    = "user_agent"
+        type    = "string"
         comment = "User agent that made the request"
       },
-      // %{Fastly-Backend-Name}o
       {
-        name    = "fastly_backend",
-        type    = "string",
+        // %{Fastly-Backend-Name}o
+        name    = "fastly_backend"
+        type    = "string"
         comment = "Name of the backend that served this request"
       },
-      // %{server.datacenter}V
       {
-        name    = "fastly_data_centre",
-        type    = "string",
+        // %{server.datacenter}V
+        name    = "fastly_data_centre"
+        type    = "string"
         comment = "Name of the data centre that served this request"
       },
-      // %{if(resp.http.X-Cache ~"HIT", "HIT", "MISS")}V
       {
-        name    = "cache_hit",
-        type    = "string",
+        // %{if(resp.http.X-Cache ~"HIT", "HIT", "MISS")}V
+        name    = "cache_hit"
+        type    = "string"
         comment = "HIT or MISS as to whether this was served from Fastly cache"
       },
-      // %{tls.client.protocol}V
       {
-        name = "tls_client_protocol",
+        // %{tls.client.protocol}V
+        name = "tls_client_protocol"
         type = "string"
       },
-      // %{tls.client.cipher}V
       {
-        name = "tls_client_cipher",
+        // %{tls.client.cipher}V
+        name = "tls_client_cipher"
         type = "string"
-      }
+      },
     ]
   }
 
@@ -296,7 +300,7 @@ resource "aws_glue_catalog_table" "govuk_www" {
     {
       name = "date"
       type = "int"
-    }
+    },
   ]
 
   parameters {
@@ -322,7 +326,7 @@ resource "aws_glue_crawler" "govuk_assets" {
     update_behavior = "LOG"
   }
 
-  configuration  = <<EOF
+  configuration = <<EOF
 {
   "Version": 1.0,
   "CrawlerOutput": {
@@ -348,118 +352,121 @@ resource "aws_glue_catalog_table" "govuk_assets" {
 
     ser_de_info {
       name = "ser_de_name"
+
       parameters {
         field.delim = "\t"
       }
+
       serialization_library = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
     }
 
     // These columns corellate with the log format set up in Fastly which is:
     // %h\t%u\t%{%Y-%m-%d %H:%M:%S.}t%{msec_frac}t\t%{%z}t\t%m\t%{req.url}V\t%>s\tv$%{time.elapsed.sec}V.%{time.elapsed.msec_frac}V\t%{time.to_first_byte}V\t%B\t%{Content-Type}o\t%{User-Agent}i\t%{Fastly-Backend-Name}o\t%{server.datacenter}V\t%{if(resp.http.X-Cache ~"HIT", "HIT", "MISS")}V\t%{tls.client.protocol}V\t%{tls.client.cipher}V
     columns = [
-      // %h
       {
+        // %h
         name    = "remote_host"
-        type    = "string",
+        type    = "string"
         comment = "Host that made this request, most likely an IP address"
       },
-      // %u
       {
+        // %u
         name    = "remote_user"
-        type    = "string",
+        type    = "string"
         comment = "Basic auth user for this request"
       },
-      // %{%Y-%m-%d %H:%M:%S.}t%{msec_frac}t
       {
-        name    = "request_received",
-        type    = "timestamp",
+        // %{%Y-%m-%d %H:%M:%S.}t%{msec_frac}t
+        name    = "request_received"
+        type    = "timestamp"
         comment = "Time we received the request"
       },
-      // This field is separate from the timestamp above as the Presto version
-      // on AWS Athena doesn't support timestamps - expectation is that this is
-      // always +0000 though
-      // %{%z}t
       {
-        name    = "request_received_offset",
-        type    = "string",
+        // This field is separate from the timestamp above as the Presto version
+        // on AWS Athena doesn't support timestamps - expectation is that this is
+        // always +0000 though
+        // %{%z}t
+        name = "request_received_offset"
+
+        type    = "string"
         comment = "Time offset of the request, expected to be +0000 always"
       },
-      // %m
       {
-        name    = "method",
+        // %m
+        name    = "method"
         type    = "string"
         comment = "HTTP method for this request"
       },
-      // %{req.url}V
       {
-        name    = "url",
-        type    = "string",
+        // %{req.url}V
+        name    = "url"
+        type    = "string"
         comment = "URL requested with query string"
       },
-      // %>s
       {
-        name    = "status",
-        type    = "int",
+        // %>s
+        name    = "status"
+        type    = "int"
         comment = "HTTP status code returned"
       },
-      // $%{time.elapsed.sec}V.%{time.elapsed.msec_frac}V
       {
-        name    = "request_time",
-        type    = "float",
+        // $%{time.elapsed.sec}V.%{time.elapsed.msec_frac}V
+        name    = "request_time"
+        type    = "float"
         comment = "Time until user received full response in seconds"
       },
-      // %{time.to_first_byte}V
       {
-        name    = "time_to_generate_response",
-        type    = "float",
+        // %{time.to_first_byte}V
+        name    = "time_to_generate_response"
+        type    = "float"
         comment = "Time spent generating a response for varnish, in seconds"
       },
-      // %B
       {
-        name    = "bytes",
-        type    = "bigint",
+        // %B
+        name    = "bytes"
+        type    = "bigint"
         comment = "Number of bytes returned"
       },
-      // %{Content-Type}o
       {
-        name    = "content_type",
-        type    = "string",
+        // %{Content-Type}o
+        name    = "content_type"
+        type    = "string"
         comment = "HTTP Content-Type header returned"
       },
-      // %{User-Agent}i
       {
-        name    = "user_agent",
-        type    = "string",
+        // %{User-Agent}i
+        name    = "user_agent"
+        type    = "string"
         comment = "User agent that made the request"
       },
-      // %{Fastly-Backend-Name}o
       {
-        name    = "fastly_backend",
-        type    = "string",
+        // %{Fastly-Backend-Name}o
+        name    = "fastly_backend"
+        type    = "string"
         comment = "Name of the backend that served this request"
       },
-      // %{server.datacenter}V
       {
-        name    = "fastly_data_centre",
-        type    = "string",
+        // %{server.datacenter}V
+        name    = "fastly_data_centre"
+        type    = "string"
         comment = "Name of the data centre that served this request"
       },
-      // %{if(resp.http.X-Cache ~"HIT", "HIT", "MISS")}V
       {
-        name    = "cache_hit",
-        type    = "string",
+        // %{if(resp.http.X-Cache ~"HIT", "HIT", "MISS")}V
+        name    = "cache_hit"
+        type    = "string"
         comment = "HIT or MISS as to whether this was served from Fastly cache"
       },
-      // %{tls.client.protocol}V
       {
-        name = "tls_client_protocol",
+        // %{tls.client.protocol}V
+        name = "tls_client_protocol"
         type = "string"
       },
-      // %{tls.client.cipher}V
       {
-        name = "tls_client_cipher",
+        // %{tls.client.cipher}V
+        name = "tls_client_cipher"
         type = "string"
-      }
+      },
     ]
   }
 
@@ -477,7 +484,7 @@ resource "aws_glue_catalog_table" "govuk_assets" {
     {
       name = "date"
       type = "int"
-    }
+    },
   ]
 
   parameters {
@@ -503,7 +510,7 @@ resource "aws_glue_crawler" "bouncer" {
     update_behavior = "LOG"
   }
 
-  configuration  = <<EOF
+  configuration = <<EOF
 {
   "Version": 1.0,
   "CrawlerOutput": {
@@ -529,106 +536,109 @@ resource "aws_glue_catalog_table" "bouncer" {
 
     ser_de_info {
       name = "ser_de_name"
+
       parameters {
         field.delim = "\t"
       }
+
       serialization_library = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
     }
 
     // These columns corellate with the log format set up in Fastly which is:
     // %{%Y-%m-%d %H:%M:%S.}t%{msec_frac}t\t%{%z}t\t%m\t%{Host}i\t%{req.url}V\t%>s\t%{time.elapsed.sec}V.%{time.elapsed.msec_frac}V\t%{time.to_first_byte}V\t%{Location}o\t%{User-Agent}i\t%{Fastly-Backend-Name}o\t%{server.datacenter}V\t%{if(resp.http.X-Cache ~"HIT", "HIT", "MISS")}V\t%{tls.client.protocol}V\t%{tls.client.cipher}V
     columns = [
-      // %{%Y-%m-%d %H:%M:%S.}t%{msec_frac}t
       {
-        name    = "request_received",
-        type    = "timestamp",
+        // %{%Y-%m-%d %H:%M:%S.}t%{msec_frac}t
+        name    = "request_received"
+        type    = "timestamp"
         comment = "Time we received the request"
       },
-      // This field is separate from the timestamp above as the Presto version
-      // on AWS Athena doesn't support timestamps - expectation is that this is
-      // always +0000 though
-      // %{%z}t
       {
-        name    = "request_received_offset",
-        type    = "string",
+        // This field is separate from the timestamp above as the Presto version
+        // on AWS Athena doesn't support timestamps - expectation is that this is
+        // always +0000 though
+        // %{%z}t
+        name = "request_received_offset"
+
+        type    = "string"
         comment = "Time offset of the request, expected to be +0000 always"
       },
-      // %m
       {
-        name    = "method",
+        // %m
+        name    = "method"
         type    = "string"
         comment = "HTTP method for this request"
       },
-      // %{Host}i
       {
+        // %{Host}i
         name    = "request_host"
-        type    = "string",
+        type    = "string"
         comment = "Host that was requested"
       },
-      // %{req.url}V
       {
-        name    = "url",
-        type    = "string",
+        // %{req.url}V
+        name    = "url"
+        type    = "string"
         comment = "URL requested with query string"
       },
-      // %>s
       {
-        name    = "status",
-        type    = "int",
+        // %>s
+        name    = "status"
+        type    = "int"
         comment = "HTTP status code returned"
       },
-      // $%{time.elapsed.sec}V.%{time.elapsed.msec_frac}V
       {
-        name    = "request_time",
-        type    = "float",
+        // $%{time.elapsed.sec}V.%{time.elapsed.msec_frac}V
+        name    = "request_time"
+        type    = "float"
         comment = "Time until user received full response in seconds"
       },
-      // %{time.to_first_byte}V
       {
-        name    = "time_to_generate_response",
-        type    = "float",
+        // %{time.to_first_byte}V
+        name    = "time_to_generate_response"
+        type    = "float"
         comment = "Time spent generating a response for varnish, in seconds"
       },
-      // %{Location}o
       {
-        name    = "redirect_location",
-        type    = "string",
+        // %{Location}o
+        name    = "redirect_location"
+        type    = "string"
         comment = "HTTP Location header returned, if any"
       },
-      // %{User-Agent}i
       {
-        name    = "user_agent",
-        type    = "string",
+        // %{User-Agent}i
+        name    = "user_agent"
+        type    = "string"
         comment = "User agent that made the request"
       },
-      // %{Fastly-Backend-Name}o
       {
-        name    = "fastly_backend",
-        type    = "string",
+        // %{Fastly-Backend-Name}o
+        name    = "fastly_backend"
+        type    = "string"
         comment = "Name of the backend that served this request"
       },
-      // %{server.datacenter}V
       {
-        name    = "fastly_data_centre",
-        type    = "string",
+        // %{server.datacenter}V
+        name    = "fastly_data_centre"
+        type    = "string"
         comment = "Name of the data centre that served this request"
       },
-      // %{if(resp.http.X-Cache ~"HIT", "HIT", "MISS")}V
       {
-        name    = "cache_hit",
-        type    = "string",
+        // %{if(resp.http.X-Cache ~"HIT", "HIT", "MISS")}V
+        name    = "cache_hit"
+        type    = "string"
         comment = "HIT or MISS as to whether this was served from Fastly cache"
       },
-      // %{tls.client.protocol}V
       {
-        name = "tls_client_protocol",
+        // %{tls.client.protocol}V
+        name = "tls_client_protocol"
         type = "string"
       },
-      // %{tls.client.cipher}V
       {
-        name = "tls_client_cipher",
+        // %{tls.client.cipher}V
+        name = "tls_client_cipher"
         type = "string"
-      }
+      },
     ]
   }
 
@@ -646,7 +656,7 @@ resource "aws_glue_catalog_table" "bouncer" {
     {
       name = "date"
       type = "int"
-    }
+    },
   ]
 
   parameters {
@@ -655,6 +665,7 @@ resource "aws_glue_catalog_table" "bouncer" {
     delimiter       = "\t"
   }
 }
+
 # Outputs
 # --------------------------------------------------------------
 

--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -43,6 +43,14 @@ resource "aws_s3_bucket" "fastly_logs" {
     target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
     target_prefix = "s3/govuk-${var.aws_environment}-fastly-logs/"
   }
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 90
+    }
+  }
 }
 
 # We require a user for Fastly to write to S3 buckets

--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -306,6 +306,187 @@ resource "aws_glue_catalog_table" "govuk_www" {
   }
 }
 
+resource "aws_glue_crawler" "govuk_assets" {
+  name          = "Assets fastly logs"
+  description   = "Crawls the assets logs from fastly for allowing Athena querying"
+  database_name = "${aws_glue_catalog_database.fastly_logs.name}"
+  role          = "${aws_iam_role.glue.name}"
+  schedule      = "cron(30 */4 * * ? *)"
+
+  s3_target {
+    path = "s3://${aws_s3_bucket.fastly_logs.bucket}/govuk_assets"
+  }
+
+  schema_change_policy {
+    delete_behavior = "DELETE_FROM_DATABASE"
+    update_behavior = "LOG"
+  }
+
+  configuration  = <<EOF
+{
+  "Version": 1.0,
+  "CrawlerOutput": {
+    "Partitions": {
+      "AddOrUpdateBehavior": "InheritFromTable"
+    }
+  }
+}
+EOF
+}
+
+resource "aws_glue_catalog_table" "govuk_assets" {
+  name          = "govuk_assets"
+  description   = "Maps the tab-seperated value log file to columns"
+  database_name = "${aws_glue_catalog_database.fastly_logs.name}"
+  table_type    = "EXTERNAL_TABLE"
+
+  storage_descriptor {
+    compressed    = true
+    location      = "s3://${aws_s3_bucket.fastly_logs.bucket}/govuk_assets/"
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      name = "ser_de_name"
+      parameters {
+        field.delim = "\t"
+      }
+      serialization_library = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
+    }
+
+    // These columns corellate with the log format set up in Fastly which is:
+    // %h\t%u\t%{%Y-%m-%d %H:%M:%S.}t%{msec_frac}t\t%{%z}t\t%m\t%{req.url}V\t%>s\tv$%{time.elapsed.sec}V.%{time.elapsed.msec_frac}V\t%{time.to_first_byte}V\t%B\t%{Content-Type}o\t%{User-Agent}i\t%{Fastly-Backend-Name}o\t%{server.datacenter}V\t%{if(resp.http.X-Cache ~"HIT", "HIT", "MISS")}V\t%{tls.client.protocol}V\t%{tls.client.cipher}V
+    columns = [
+      // %h
+      {
+        name    = "remote_host"
+        type    = "string",
+        comment = "Host that made this request, most likely an IP address"
+      },
+      // %u
+      {
+        name    = "remote_user"
+        type    = "string",
+        comment = "Basic auth user for this request"
+      },
+      // %{%Y-%m-%d %H:%M:%S.}t%{msec_frac}t
+      {
+        name    = "request_received",
+        type    = "timestamp",
+        comment = "Time we received the request"
+      },
+      // This field is separate from the timestamp above as the Presto version
+      // on AWS Athena doesn't support timestamps - expectation is that this is
+      // always +0000 though
+      // %{%z}t
+      {
+        name    = "request_received_offset",
+        type    = "string",
+        comment = "Time offset of the request, expected to be +0000 always"
+      },
+      // %m
+      {
+        name    = "method",
+        type    = "string"
+        comment = "HTTP method for this request"
+      },
+      // %{req.url}V
+      {
+        name    = "url",
+        type    = "string",
+        comment = "URL requested with query string"
+      },
+      // %>s
+      {
+        name    = "status",
+        type    = "int",
+        comment = "HTTP status code returned"
+      },
+      // $%{time.elapsed.sec}V.%{time.elapsed.msec_frac}V
+      {
+        name    = "request_time",
+        type    = "float",
+        comment = "Time until user received full response in seconds"
+      },
+      // %{time.to_first_byte}V
+      {
+        name    = "time_to_generate_response",
+        type    = "float",
+        comment = "Time spent generating a response for varnish, in seconds"
+      },
+      // %B
+      {
+        name    = "bytes",
+        type    = "bigint",
+        comment = "Number of bytes returned"
+      },
+      // %{Content-Type}o
+      {
+        name    = "content_type",
+        type    = "string",
+        comment = "HTTP Content-Type header returned"
+      },
+      // %{User-Agent}i
+      {
+        name    = "user_agent",
+        type    = "string",
+        comment = "User agent that made the request"
+      },
+      // %{Fastly-Backend-Name}o
+      {
+        name    = "fastly_backend",
+        type    = "string",
+        comment = "Name of the backend that served this request"
+      },
+      // %{server.datacenter}V
+      {
+        name    = "fastly_data_centre",
+        type    = "string",
+        comment = "Name of the data centre that served this request"
+      },
+      // %{if(resp.http.X-Cache ~"HIT", "HIT", "MISS")}V
+      {
+        name    = "cache_hit",
+        type    = "string",
+        comment = "HIT or MISS as to whether this was served from Fastly cache"
+      },
+      // %{tls.client.protocol}V
+      {
+        name = "tls_client_protocol",
+        type = "string"
+      },
+      // %{tls.client.cipher}V
+      {
+        name = "tls_client_cipher",
+        type = "string"
+      }
+    ]
+  }
+
+  // these correspond to directory ordering of:
+  // /year=YYYY/month=MM/date=DD/file.log.gz
+  partition_keys = [
+    {
+      name = "year"
+      type = "int"
+    },
+    {
+      name = "month"
+      type = "int"
+    },
+    {
+      name = "date"
+      type = "int"
+    }
+  ]
+
+  parameters {
+    classification  = "csv"
+    compressionType = "gzip"
+    delimiter       = "\t"
+  }
+}
+
 # Outputs
 # --------------------------------------------------------------
 


### PR DESCRIPTION
This sets up crawlers to run with the 3 strands of log files we have being sent from Fastly to S3: govuk-www, govuk-assets and bouncer.

It sets up a database for these 3 log files and a schema based on the format Fastly is configured to send (details of this is in the individual commits)

Finally this deletes logs from these buckets when they reach 90 days old.