### PR TITLE
Change field type for Email Alert API DB definition

### DIFF
--- a/terraform/projects/infra-email-alert-api-archive/main.tf
+++ b/terraform/projects/infra-email-alert-api-archive/main.tf
@@ -193,8 +193,8 @@ resource "aws_glue_catalog_table" "email_archive" {
       },
       {
         name    = "subscriber_id"
-        type    = "string"
-        comment = "UUID of the subscriber assoicated with this Email if any"
+        type    = "bigint"
+        comment = "ID which corresponds with the entry in the subscribers table in Email Alert API"
       },
       {
         name    = "subject"


### PR DESCRIPTION
Trello: https://trello.com/c/FM3MCuAl/255-investigate-email-alert-api-database-size-and-push-email-archives-to-s3

The field, subscriber_id, was incorrectly set up as a string with the expectation that this field would be a UUID. In fact it is actually an integer in Email Alert API so this updates this to match.