### PR TITLE
Changes to the artefact-s3-bucket policy

### DIFF
--- a/terraform/projects/infra-artefact-bucket/main.tf
+++ b/terraform/projects/infra-artefact-bucket/main.tf
@@ -195,7 +195,6 @@ resource "aws_s3_bucket_policy" "govuk-artefact-bucket-policy" {
             "Principal": {
                 "AWS": [
                          "arn:aws:iam::${var.aws_account_id}:root",
-                         "arn:aws:iam::${var.aws_account_id}:role/${var.deployer_role}",
                          "arn:aws:iam::${var.aws_s3_access_account}:root"
 ]
             },


### PR DESCRIPTION
- We noticed that the artefact S3 bucket policy was failing when applied
via terraform. The same policy can be copied and pasted via the
console.

- The error that we noticed was referring to the format of the policy.

'* aws_s3_bucket_policy.govuk-artefact-bucket-policy: Error putting S3 policy: MalformedPolicy: Invalid principal in policy
    status code: 400, request id: 1CCFE75F22EA31F3, host id:
g3IOHI35MTShg41/2AGEYOajDwUQMkPz1ttHfzrisC4EeGOZST5xY2HOiJEhqKNOIUNevK3NnKg='

- This seems to be caused by the line that has been removed.

- We have tested that the functionality is still available.

https://trello.com/c/366S8eBR/1309-start-building-production

Pair: @szd55gds @suthagarht