### PR TITLE
Change Fastly logs Glue Crawler configuration

### DIFF
--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -146,7 +146,7 @@ resource "aws_glue_crawler" "govuk_www" {
   }
 
   schema_change_policy {
-    delete_behavior = "DEPRECATE_IN_DATABASE"
+    delete_behavior = "DELETE_FROM_DATABASE"
     update_behavior = "LOG"
   }
 
@@ -330,7 +330,7 @@ resource "aws_glue_crawler" "govuk_assets" {
   }
 
   schema_change_policy {
-    delete_behavior = "DEPRECATE_IN_DATABASE"
+    delete_behavior = "DELETE_FROM_DATABASE"
     update_behavior = "LOG"
   }
 
@@ -514,7 +514,7 @@ resource "aws_glue_crawler" "bouncer" {
   }
 
   schema_change_policy {
-    delete_behavior = "DEPRECATE_IN_DATABASE"
+    delete_behavior = "DELETE_FROM_DATABASE"
     update_behavior = "LOG"
   }
 


### PR DESCRIPTION
This changes the configuration of the Glue Crawlers that work with the data from Fastly logs. After a lot of fighting with Fastly logging formats I've found we can get it to output JSON and that seems to offer best options of reliable athena parsing and future extensibility.  The logs are now output in this so this updates the crawler to deal with them.

This also changes the delete behaviour to remove tables and partitions when they are gone. This is because we have a 90 day retention on objects and want the database to deal with them being removed. 