### PR TITLE
Install the AWS CLI from the Apt repo instead of from Pip

### DIFF
--- a/terraform/userdata/00-base
+++ b/terraform/userdata/00-base
@@ -26,6 +26,13 @@ wget -qO $TMPFILE http://apt.puppetlabs.com/puppetlabs-release-$DISTRIB_CODENAME
 dpkg -i $TMPFILE
 rm $TMPFILE
 
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: install Gov.UK package signing key and repositories ..."
+curl --silent --show-error --fail \
+  https://apt.publishing.service.gov.uk/EC5FE1A937E3ACBB.asc | apt-key add -
+
+echo "deb [arch=amd64] http://apt.production.alphagov.co.uk/awscli $DISTRIB_CODENAME main" \
+  >> /etc/apt/sources.list.d/awscli.list
+
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: ensure the packages are up to date ..."
 apt-get update -qq
 apt-get -y upgrade

--- a/tools/govuk-puppetmaster-bootstrap.sh
+++ b/tools/govuk-puppetmaster-bootstrap.sh
@@ -41,7 +41,6 @@ apt-get -y install postgresql-9.3
 apt-get -y install bundler
 apt-get -y install git
 apt-get -y install python3-pip
-pip3 install awscli
 
 # Create required directories
 mkdir -p ${GPG_KEYSTORE}


### PR DESCRIPTION
Add GOV.UK Apt repos in 00-base cloud-init snippet.

Install the signing key and configure (one of) the GOV.UK Apt repos (awscli).

Install awscli in 00-base with apt, and don't install it in `tools/govuk-puppetmaster-bootstrap.sh` with pip.