### PR TITLE
Remove the app-performance-(backend,frontend,mongo) projects

### DIFF
--- a/terraform/projects/app-performance-backend/production.blue.backend
+++ b/terraform/projects/app-performance-backend/production.blue.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-production"
-key     = "blue/app-performance-backend.tfstate"
-encrypt = true
-region  = "eu-west-1"

--- a/terraform/projects/app-performance-backend/staging.blue.backend
+++ b/terraform/projects/app-performance-backend/staging.blue.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-staging"
-key     = "blue/app-performance-backend.tfstate"
-encrypt = true
-region  = "eu-west-1"

--- a/terraform/projects/app-performance-frontend/production.blue.backend
+++ b/terraform/projects/app-performance-frontend/production.blue.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-production"
-key     = "blue/app-performance-frontend.tfstate"
-encrypt = true
-region  = "eu-west-1"

--- a/terraform/projects/app-performance-frontend/staging.blue.backend
+++ b/terraform/projects/app-performance-frontend/staging.blue.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-staging"
-key     = "blue/app-performance-frontend.tfstate"
-encrypt = true
-region  = "eu-west-1"

--- a/terraform/projects/app-performance-mongo/production.blue.backend
+++ b/terraform/projects/app-performance-mongo/production.blue.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-production"
-key     = "blue/app-performance-mongo.tfstate"
-encrypt = true
-region  = "eu-west-1"

--- a/terraform/projects/app-performance-mongo/staging.blue.backend
+++ b/terraform/projects/app-performance-mongo/staging.blue.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-staging"
-key     = "blue/app-performance-mongo.tfstate"
-encrypt = true
-region  = "eu-west-1"


### PR DESCRIPTION
- We don't have them in integration and shouldn't have them in staging
  or production. They're moving to the PaaS.