### PR TITLE
Enable pgbouncer traffic 

### DIFF
--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -64,6 +64,13 @@ resource "aws_elb" "db-admin_elb" {
     lb_protocol       = "tcp"
   }
 
+  listener {
+    instance_port     = 6432
+    instance_protocol = "tcp"
+    lb_port           = 6432
+    lb_protocol       = "tcp"
+  }
+
   health_check {
     healthy_threshold   = 2
     unhealthy_threshold = 2

--- a/terraform/projects/infra-security-groups/db-admin.tf
+++ b/terraform/projects/infra-security-groups/db-admin.tf
@@ -34,6 +34,19 @@ resource "aws_security_group_rule" "db-admin_ingress_db-admin-elb_ssh" {
   source_security_group_id = "${aws_security_group.db-admin_elb.id}"
 }
 
+resource "aws_security_group_rule" "db-admin_ingress_db-admin-elb_pgbouncer" {
+  type      = "ingress"
+  from_port = 6432
+  to_port   = 6432
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.db-admin.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.db-admin_elb.id}"
+}
+
 resource "aws_security_group" "db-admin_elb" {
   name        = "${var.stackname}_db-admin_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"

--- a/terraform/projects/infra-security-groups/pgbouncer.tf
+++ b/terraform/projects/infra-security-groups/pgbouncer.tf
@@ -15,7 +15,7 @@ resource "aws_security_group_rule" "db-admin_ingress_backend_pgbouncer" {
   protocol  = "tcp"
 
   # Which security group is the rule assigned to
-  security_group_id = "${aws_security_group.db-admin.id}"
+  security_group_id = "${aws_security_group.db-admin_elb.id}"
 
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.backend.id}"
@@ -28,7 +28,7 @@ resource "aws_security_group_rule" "db-admin_ingress_ckan_pgbouncer" {
   protocol  = "tcp"
 
   # Which security group is the rule assigned to
-  security_group_id = "${aws_security_group.db-admin.id}"
+  security_group_id = "${aws_security_group.db-admin_elb.id}"
 
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.ckan.id}"
@@ -41,7 +41,7 @@ resource "aws_security_group_rule" "db-admin_ingress_email-alert-api_pgbouncer" 
   protocol  = "tcp"
 
   # Which security group is the rule assigned to
-  security_group_id = "${aws_security_group.db-admin.id}"
+  security_group_id = "${aws_security_group.db-admin_elb.id}"
 
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.email-alert-api.id}"
@@ -54,7 +54,7 @@ resource "aws_security_group_rule" "db-admin_ingress_publishing-api_pgbouncer" {
   protocol  = "tcp"
 
   # Which security group is the rule assigned to
-  security_group_id = "${aws_security_group.db-admin.id}"
+  security_group_id = "${aws_security_group.db-admin_elb.id}"
 
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.publishing-api.id}"
@@ -67,7 +67,7 @@ resource "aws_security_group_rule" "db-admin_ingress_pentest_pgbouncer" {
   protocol  = "tcp"
 
   # Which security group is the rule assigned to
-  security_group_id = "${aws_security_group.db-admin.id}"
+  security_group_id = "${aws_security_group.db-admin_elb.id}"
 
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.pentest.id}"


### PR DESCRIPTION
[Trello card](https://trello.com/c/BosbZ9n9/336-investigate-postgres-connection-pooling)

- Add pgbouncer listener to the db_admin ELB:
  - Allows backend etc machines to connect to pgbouncer running on db_admin boxes.

- Allow pgbouncer traffic to and from ELB 
  - Allow applications to talk to db_admin ELB on 6432, but not db_admin directly.
  - Allow ELB to talk to pgbouncer on db_admin