### PR TITLE
Fix Terraform for S3 access to database backups

### DIFF
--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -146,13 +146,13 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 }
 
 resource "aws_iam_role_policy_attachment" "write_db-admin_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment == "production" ? 1 : 0}"
+  count      = 1
   role       = "${module.db-admin.instance_iam_role_name}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_write_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "read_db-admin_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment != "production" ? 1 : 0}"
+  count      = 1
   role       = "${module.db-admin.instance_iam_role_name}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_read_database_backups_bucket_policy_arn}"
 }

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -243,13 +243,13 @@ resource "aws_iam_role_policy_attachment" "graphite_1_iam_role_policy_cloudwatch
 }
 
 resource "aws_iam_role_policy_attachment" "write_graphite_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment == "production" ? 1 : 0}"
+  count      = 1
   role       = "${module.graphite-1.instance_iam_role_name}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.graphite_write_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "read_graphite_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment != "production" ? 1 : 0}"
+  count      = 1
   role       = "${module.graphite-1.instance_iam_role_name}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.graphite_read_database_backups_bucket_policy_arn}"
 }

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -339,13 +339,13 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 }
 
 resource "aws_iam_role_policy_attachment" "write_mongo_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment == "production" ? 3 : 0}"
+  count      = 3
   role       = "${element(list(module.mongo-1.instance_iam_role_name, module.mongo-2.instance_iam_role_name, module.mongo-3.instance_iam_role_name), count.index)}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.mongo_api_write_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "read_mongo_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment != "production" ? 3 : 0}"
+  count      = 3
   role       = "${element(list(module.mongo-1.instance_iam_role_name, module.mongo-2.instance_iam_role_name, module.mongo-3.instance_iam_role_name), count.index)}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.mongo_api_read_database_backups_bucket_policy_arn}"
 }

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -289,15 +289,15 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 }
 
 resource "aws_iam_role_policy_attachment" "write_router-backend_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment == "production" ? 3 : 0}"
+  count      = 3
   role       = "${element(list(module.router-backend-1.instance_iam_role_name, module.router-backend-2.instance_iam_role_name, module.router-backend-3.instance_iam_role_name), count.index)}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.mongo_api_write_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.mongo_router_write_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "read_router-backend_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment != "production" ? 3 : 0}"
+  count      = 3
   role       = "${element(list(module.router-backend-1.instance_iam_role_name, module.router-backend-2.instance_iam_role_name, module.router-backend-3.instance_iam_role_name), count.index)}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.mongo_api_read_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.mongo_router_read_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_policy" "router-backend_iam_policy" {

--- a/terraform/projects/app-rummager-elasticsearch/main.tf
+++ b/terraform/projects/app-rummager-elasticsearch/main.tf
@@ -273,13 +273,13 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 }
 
 resource "aws_iam_role_policy_attachment" "write_rummager-elasticsearch-1_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment == "production" ? 3 : 0}"
+  count      = 3
   role       = "${element(list(module.rummager-elasticsearch-1.instance_iam_role_name, module.rummager-elasticsearch-2.instance_iam_role_name, module.rummager-elasticsearch-3.instance_iam_role_name), count.index)}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.elasticsearch_write_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "read_rummager-elasticsearch-1_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment != "production" ? 3 : 0}"
+  count      = 3
   role       = "${element(list(module.rummager-elasticsearch-1.instance_iam_role_name, module.rummager-elasticsearch-2.instance_iam_role_name, module.rummager-elasticsearch-3.instance_iam_role_name), count.index)}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.elasticsearch_read_database_backups_bucket_policy_arn}"
 }

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -130,13 +130,13 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 }
 
 resource "aws_iam_role_policy_attachment" "write_transition-db-admin_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment == "production" ? 1 : 0}"
+  count      = 1
   role       = "${module.transition-db-admin.instance_iam_role_name}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_write_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "read_transition-db-admin_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment != "production" ? 1 : 0}"
+  count      = 1
   role       = "${module.transition-db-admin.instance_iam_role_name}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_read_database_backups_bucket_policy_arn}"
 }

--- a/terraform/projects/app-warehouse-db-admin/main.tf
+++ b/terraform/projects/app-warehouse-db-admin/main.tf
@@ -130,13 +130,13 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 }
 
 resource "aws_iam_role_policy_attachment" "write_warehouse-db-admin_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment == "production" ? 1 : 0}"
+  count      = 1
   role       = "${module.warehouse-db-admin.instance_iam_role_name}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_write_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "read_warehouse-db-admin_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment != "production" ? 1 : 0}"
+  count      = 1
   role       = "${module.warehouse-db-admin.instance_iam_role_name}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_read_database_backups_bucket_policy_arn}"
 }

--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -30,6 +30,8 @@ database-backups: The bucket that will hold database backups
 | graphite_write_database_backups_bucket_policy_arn | ARN of the Graphite write database_backups-bucket policy |
 | mongo_api_read_database_backups_bucket_policy_arn | ARN of the read mongo-api database_backups-bucket policy |
 | mongo_api_write_database_backups_bucket_policy_arn | ARN of the mongo-api write database_backups-bucket policy |
+| mongo_router_read_database_backups_bucket_policy_arn | ARN of the read router_backend database_backups-bucket policy |
+| mongo_router_write_database_backups_bucket_policy_arn | ARN of the router_backend write database_backups-bucket policy |
 | mongodb_read_database_backups_bucket_policy_arn | ARN of the read mongodb database_backups-bucket policy |
 | mongodb_write_database_backups_bucket_policy_arn | ARN of the mongodb write database_backups-bucket policy |
 

--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -25,18 +25,32 @@ data "aws_iam_policy_document" "mongo_api_database_backups_reader" {
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${var.backup_source_bucket}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mongo-api*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "mongo_router_database_backups_reader" {
+  name        = "govuk-${var.aws_environment}-mongo-router_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.mongo_router_database_backups_reader.json}"
+  description = "Allows reading the mongo-router database_backups bucket"
+}
+
+data "aws_iam_policy_document" "mongo_router_database_backups_reader" {
+  statement {
+    sid = "MongoRouterReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
     ]
 
-    # We can now apply restictions on what can be accessed.
-    condition {
-      test     = "StringLike"
-      variable = "s3:prefix"
-
-      values = [
-        "mongo-api",
-      ]
-    }
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*router_backend*",
+    ]
   }
 }
 
@@ -57,18 +71,9 @@ data "aws_iam_policy_document" "mongodb_database_backups_reader" {
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${var.backup_source_bucket}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mongodb*",
     ]
-
-    # We can now apply restictions on what can be accessed.
-    condition {
-      test     = "StringLike"
-      variable = "s3:prefix"
-
-      values = [
-        "mongodb",
-      ]
-    }
   }
 }
 
@@ -89,18 +94,9 @@ data "aws_iam_policy_document" "elasticsearch_database_backups_reader" {
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${var.backup_source_bucket}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*elasticsearch*",
     ]
-
-    # We can now apply restictions on what can be accessed.
-    condition {
-      test     = "StringLike"
-      variable = "s3:prefix"
-
-      values = [
-        "elasticsearch",
-      ]
-    }
   }
 }
 
@@ -121,19 +117,10 @@ data "aws_iam_policy_document" "dbadmin_database_backups_reader" {
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${var.backup_source_bucket}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mysql*",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*postgres*",
     ]
-
-    # We can now apply restictions on what can be accessed.
-    condition {
-      test     = "StringLike"
-      variable = "s3:prefix"
-
-      values = [
-        "mysql",
-        "postgres",
-      ]
-    }
   }
 }
 
@@ -154,24 +141,20 @@ data "aws_iam_policy_document" "graphite_database_backups_reader" {
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${var.backup_source_bucket}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*whisper*",
     ]
-
-    # We can now apply restictions on what can be accessed.
-    condition {
-      test     = "StringLike"
-      variable = "s3:prefix"
-
-      values = [
-        "whisper",
-      ]
-    }
   }
 }
 
 output "mongo_api_read_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.mongo_api_database_backups_reader.arn}"
   description = "ARN of the read mongo-api database_backups-bucket policy"
+}
+
+output "mongo_router_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.mongo_router_database_backups_reader.arn}"
+  description = "ARN of the read router_backend database_backups-bucket policy"
 }
 
 output "mongodb_read_database_backups_bucket_policy_arn" {

--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -15,11 +15,20 @@ resource "aws_iam_policy" "mongo_api_database_backups_writer" {
 
 data "aws_iam_policy_document" "mongo_api_database_backups_writer" {
   statement {
+    sid = "ReadListOfBuckets"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
     sid = "MongoAPIReadBucketLists"
 
     actions = [
       "s3:ListBucket",
-      "s3:ListAllMyBuckets",
       "s3:GetBucketLocation",
     ]
 
@@ -49,6 +58,38 @@ data "aws_iam_policy_document" "mongo_api_database_backups_writer" {
     ]
 
     resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mongo-api*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "mongo_router_database_backups_writer" {
+  name        = "govuk-${var.aws_environment}-mongo-router_database_backups-writer-policy"
+  policy      = "${data.aws_iam_policy_document.mongo_router_database_backups_writer.json}"
+  description = "Allows writing of the router_backend database_backups bucket"
+}
+
+data "aws_iam_policy_document" "mongo_router_database_backups_writer" {
+  statement {
+    sid = "ReadListOfBuckets"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "MongoRouterReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+
+    # The top level access is required.
+    resources = [
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
     ]
 
@@ -58,9 +99,23 @@ data "aws_iam_policy_document" "mongo_api_database_backups_writer" {
       variable = "s3:prefix"
 
       values = [
-        "mongo-api",
+        "router_backend",
       ]
     }
+  }
+
+  statement {
+    sid = "MongoRouterWriteGovukDatabaseBackups"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*router_backend*",
+    ]
   }
 }
 
@@ -72,11 +127,20 @@ resource "aws_iam_policy" "mongodb_database_backups_writer" {
 
 data "aws_iam_policy_document" "mongodb_database_backups_writer" {
   statement {
+    sid = "ReadListOfBuckets"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
     sid = "MongoDBReadBucketLists"
 
     actions = [
       "s3:ListBucket",
-      "s3:ListAllMyBuckets",
       "s3:GetBucketLocation",
     ]
 
@@ -106,18 +170,8 @@ data "aws_iam_policy_document" "mongodb_database_backups_writer" {
     ]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mongodb*",
     ]
-
-    # We can now apply restictions on what can be accessed.
-    condition {
-      test     = "StringLike"
-      variable = "s3:prefix"
-
-      values = [
-        "mongodb",
-      ]
-    }
   }
 }
 
@@ -129,11 +183,20 @@ resource "aws_iam_policy" "elasticsearch_database_backups_writer" {
 
 data "aws_iam_policy_document" "elasticsearch_database_backups_writer" {
   statement {
+    sid = "ReadListOfBuckets"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
     sid = "ElasticsearchReadBucketLists"
 
     actions = [
       "s3:ListBucket",
-      "s3:ListAllMyBuckets",
       "s3:GetBucketLocation",
     ]
 
@@ -163,18 +226,8 @@ data "aws_iam_policy_document" "elasticsearch_database_backups_writer" {
     ]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*elasticsearch*",
     ]
-
-    # We can now apply restictions on what can be accessed.
-    condition {
-      test     = "StringLike"
-      variable = "s3:prefix"
-
-      values = [
-        "elasticsearch",
-      ]
-    }
   }
 }
 
@@ -186,11 +239,20 @@ resource "aws_iam_policy" "dbadmin_database_backups_writer" {
 
 data "aws_iam_policy_document" "dbadmin_database_backups_writer" {
   statement {
+    sid = "ReadListOfBuckets"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
     sid = "DBAdminReadBucketLists"
 
     actions = [
       "s3:ListBucket",
-      "s3:ListAllMyBuckets",
       "s3:GetBucketLocation",
     ]
 
@@ -221,19 +283,9 @@ data "aws_iam_policy_document" "dbadmin_database_backups_writer" {
     ]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mysql*",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*postgres*",
     ]
-
-    # We can now apply restictions on what can be accessed.
-    condition {
-      test     = "StringLike"
-      variable = "s3:prefix"
-
-      values = [
-        "mysql",
-        "postgres",
-      ]
-    }
   }
 }
 
@@ -245,11 +297,20 @@ resource "aws_iam_policy" "graphite_database_backups_writer" {
 
 data "aws_iam_policy_document" "graphite_database_backups_writer" {
   statement {
+    sid = "ReadListOfBuckets"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
     sid = "GraphiteReadBucketLists"
 
     actions = [
       "s3:ListBucket",
-      "s3:ListAllMyBuckets",
       "s3:GetBucketLocation",
     ]
 
@@ -279,24 +340,19 @@ data "aws_iam_policy_document" "graphite_database_backups_writer" {
     ]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*whisper*",
     ]
-
-    # We can now apply restictions on what can be accessed.
-    condition {
-      test     = "StringLike"
-      variable = "s3:prefix"
-
-      values = [
-        "whisper",
-      ]
-    }
   }
 }
 
 output "mongo_api_write_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.mongo_api_database_backups_writer.arn}"
   description = "ARN of the mongo-api write database_backups-bucket policy"
+}
+
+output "mongo_router_write_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.mongo_router_database_backups_writer.arn}"
+  description = "ARN of the router_backend write database_backups-bucket policy"
 }
 
 output "mongodb_write_database_backups_bucket_policy_arn" {


### PR DESCRIPTION
- While executing cleanly, the current terraform created policies
  including warnings.

- Access of machines to the database backups bucket was only 
   partially working

- Non-prod machines need to be able to write to their own 
   backup buckets

solo @schmie