### PR TITLE
New VPC resources for VPN to Carrenza.

### DIFF
--- a/terraform/projects/infra-vpc/README.md
+++ b/terraform/projects/infra-vpc/README.md
@@ -9,6 +9,8 @@ and resources to export these logs to S3
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | aws_region | AWS region | string | `eu-west-1` | no |
+| carrenza_internal_net_cidr | Internal network range of the environment in Carrenza | string | - | yes |
+| carrenza_vpn_endpoint_ip | Public IP address of the VPN gateway in Carrenza | string | - | yes |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
@@ -21,6 +23,7 @@ and resources to export these logs to S3
 
 | Name | Description |
 |------|-------------|
+| aws_vpn_connection_id | The ID of the AWS to Carrenza VPN |
 | internet_gateway_id | The ID of the Internet Gateway |
 | route_table_public_id | The ID of the public routing table |
 | vpc_cidr | The CIDR block of the VPC |

--- a/terraform/projects/infra-vpc/main.tf
+++ b/terraform/projects/infra-vpc/main.tf
@@ -49,6 +49,16 @@ variable "remote_state_infra_monitoring_key_stack" {
   default     = ""
 }
 
+variable "carrenza_vpn_endpoint_ip" {
+  type        = "string"
+  description = "Public IP address of the VPN gateway in Carrenza"
+}
+
+variable "carrenza_internal_net_cidr" {
+  type        = "string"
+  description = "Internal network range of the environment in Carrenza"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -123,6 +133,40 @@ module "vpc_flow_log_exporter" {
   lambda_log_retention_in_days = "${var.cloudwatch_log_retention}"
 }
 
+resource "aws_customer_gateway" "carrenza_vpn_gateway" {
+  bgp_asn    = 65000
+  ip_address = "${var.carrenza_vpn_endpoint_ip}"
+  type       = "ipsec.1"
+
+  tags {
+    Name = "Carrenza - ${var.stackname}"
+  }
+}
+
+resource "aws_vpn_gateway" "aws_vpn_gateway" {
+  vpc_id = "${module.vpc.vpc_id}"
+
+  tags {
+    Name = "${var.stackname} VPN Gateway"
+  }
+}
+
+resource "aws_vpn_connection" "aws_carrenza_vpn" {
+  vpn_gateway_id      = "${aws_vpn_gateway.aws_vpn_gateway.id}"
+  customer_gateway_id = "${aws_customer_gateway.carrenza_vpn_gateway.id}"
+  type                = "ipsec.1"
+  static_routes_only  = true
+
+  tags {
+    Name = "${var.stackname} AWS to Carrenza"
+  }
+}
+
+resource "aws_vpn_connection_route" "Carrenza" {
+  destination_cidr_block = "${var.carrenza_internal_net_cidr}"
+  vpn_connection_id      = "${aws_vpn_connection.aws_carrenza_vpn.id}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 
@@ -144,4 +188,9 @@ output "internet_gateway_id" {
 output "route_table_public_id" {
   value       = "${module.vpc.route_table_public_id}"
   description = "The ID of the public routing table"
+}
+
+output "aws_vpn_connection_id" {
+  value       = "${aws_vpn_connection.aws_carrenza_vpn.id}"
+  description = "The ID of the AWS to Carrenza VPN"
 }


### PR DESCRIPTION
This creates the two gateways and a VPN for connecting the VPC to Carrenza. There are 2 new variables to add in govuk-aws-data also. This should create the VPN and then we can get the created configuration to use to update the VCloud configuration in govuk-provisioning to deploy the Carrenza side of things.