### PR TITLE
Add RDS policy to db-admin instance

### DIFF
--- a/terraform/projects/app-db-admin/additional_policy.json
+++ b/terraform/projects/app-db-admin/additional_policy.json
@@ -1,0 +1,52 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:CreateDBInstance",
+                "rds:DeleteDBInstance",
+                "rds:RestoreDBInstanceFromDBSnapshot"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "rds:db-tag": "scrubber"
+                }
+           }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:DescribeDBClusterSnapshotAttributes",
+                "rds:DescribeDBClusterParameters",
+                "rds:DescribeDBEngineVersions",
+                "rds:DescribeDBSnapshots",
+                "rds:CopyDBSnapshot",
+                "rds:CopyDBClusterSnapshot",
+                "rds:DescribePendingMaintenanceActions",
+                "rds:DescribeDBLogFiles",
+                "rds:DescribeDBParameterGroups",
+                "rds:DescribeDBSnapshotAttributes",
+                "rds:DescribeReservedDBInstancesOfferings",
+                "rds:ListTagsForResource",
+                "rds:CreateDBSnapshot",
+                "rds:CreateDBClusterSnapshot",
+                "rds:DescribeDBParameters",
+                "rds:ModifyDBClusterSnapshotAttribute",
+                "rds:ModifyDBSnapshotAttribute",
+                "rds:DescribeDBClusters",
+                "rds:DescribeDBClusterParameterGroups",
+                "rds:DescribeDBClusterSnapshots",
+                "rds:DescribeDBInstances",
+                "rds:DescribeEngineDefaultClusterParameters",
+                "rds:DescribeOrderableDBInstanceOptions",
+                "rds:DescribeEngineDefaultParameters",
+                "rds:DescribeCertificates",
+                "rds:DescribeEventCategories",
+                "rds:DescribeAccountAttributes"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -157,6 +157,17 @@ resource "aws_iam_role_policy_attachment" "read_db-admin_database_backups_iam_ro
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_read_database_backups_bucket_policy_arn}"
 }
 
+resource "aws_iam_policy" "db-admin_iam_policy" {
+  name   = "${var.stackname}-db-admin-additional"
+  path   = "/"
+  policy = "${file("${path.module}/additional_policy.json")}"
+}
+
+resource "aws_iam_role_policy_attachment" "db-admin_iam_role_policy_attachment" {
+  role       = "${module.db-admin.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.db-admin_iam_policy.arn}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 


### PR DESCRIPTION
  We give the right to db-admin instance to create an RDS to do
database scrubbing before importing them in integration.