### PR TITLE
Pluralize the `govuk_poweruser` role name to match the other roles

### DIFF
--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -89,7 +89,7 @@ module "role_admin" {
 
 module "role_poweruser" {
   source           = "../../modules/aws/iam/role_user"
-  role_name        = "govuk-poweruser"
+  role_name        = "govuk-powerusers"
   role_user_arns   = ["${var.role_poweruser_user_arns}"]
   role_policy_arns = ["${var.role_poweruser_policy_arns}"]
 }


### PR DESCRIPTION
- This inconsistency is annoying for everyone new to assume-role, and
  our docs are even inconsistent. Instead of changing the docs, change the
  pluralization of the role name to match `govuk-administratorS` and
  `govuk-userS`, as now it's just a snowflake and always takes some time
  to debug problems with people's config because of what is essentially
  a typo.