### PR TITLE
Add separate access policy for transition

### DIFF
--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -132,13 +132,13 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 resource "aws_iam_role_policy_attachment" "write_transition-db-admin_database_backups_iam_role_policy_attachment" {
   count      = 1
   role       = "${module.transition-db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_write_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.transition_dbadmin_write_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "read_transition-db-admin_database_backups_iam_role_policy_attachment" {
   count      = 1
   role       = "${module.transition-db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_read_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.transition_dbadmin_read_database_backups_bucket_policy_arn}"
 }
 
 # Outputs

--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -34,4 +34,6 @@ database-backups: The bucket that will hold database backups
 | mongo_router_write_database_backups_bucket_policy_arn | ARN of the router_backend write database_backups-bucket policy |
 | mongodb_read_database_backups_bucket_policy_arn | ARN of the read mongodb database_backups-bucket policy |
 | mongodb_write_database_backups_bucket_policy_arn | ARN of the mongodb write database_backups-bucket policy |
+| transition_dbadmin_read_database_backups_bucket_policy_arn | ARN of the read TransitionDBAdmin database_backups-bucket policy |
+| transition_dbadmin_write_database_backups_bucket_policy_arn | ARN of the TransitionDBAdmin write database_backups-bucket policy |
 

--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -124,6 +124,29 @@ data "aws_iam_policy_document" "dbadmin_database_backups_reader" {
   }
 }
 
+resource "aws_iam_policy" "transition_dbadmin_database_backups_reader" {
+  name        = "govuk-${var.aws_environment}-transition_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.transition_dbadmin_database_backups_reader.json}"
+  description = "Allows reading the transition_dbadmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "transition_dbadmin_database_backups_reader" {
+  statement {
+    sid = "TransitionDBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*transition-postgres*",
+    ]
+  }
+}
+
 resource "aws_iam_policy" "graphite_database_backups_reader" {
   name        = "govuk-${var.aws_environment}-graphite_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.graphite_database_backups_reader.json}"
@@ -170,6 +193,11 @@ output "elasticsearch_read_database_backups_bucket_policy_arn" {
 output "dbadmin_read_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.dbadmin_database_backups_reader.arn}"
   description = "ARN of the read DBAdmin database_backups-bucket policy"
+}
+
+output "transition_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.transition_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the read TransitionDBAdmin database_backups-bucket policy"
 }
 
 output "graphite_read_database_backups_bucket_policy_arn" {

--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -289,6 +289,63 @@ data "aws_iam_policy_document" "dbadmin_database_backups_writer" {
   }
 }
 
+resource "aws_iam_policy" "transition_dbadmin_database_backups_writer" {
+  name        = "govuk-${var.aws_environment}-transition_dbadmin_database_backups-writer-policy"
+  policy      = "${data.aws_iam_policy_document.transition_dbadmin_database_backups_writer.json}"
+  description = "Allows writing of the TransitionDBAdmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "transition_dbadmin_database_backups_writer" {
+  statement {
+    sid = "ReadListOfBuckets"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "TransitionDBAdminReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+
+    # The top level access is required.
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "mysql",
+        "postgres",
+      ]
+    }
+  }
+
+  statement {
+    sid = "TransitionDBAdminWriteGovukDatabaseBackups"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*transition-postgres*",
+    ]
+  }
+}
+
 resource "aws_iam_policy" "graphite_database_backups_writer" {
   name        = "govuk-${var.aws_environment}-graphite_database_backups-writer-policy"
   policy      = "${data.aws_iam_policy_document.graphite_database_backups_writer.json}"
@@ -368,6 +425,11 @@ output "elasticsearch_write_database_backups_bucket_policy_arn" {
 output "dbadmin_write_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.dbadmin_database_backups_writer.arn}"
   description = "ARN of the DBAdmin write database_backups-bucket policy"
+}
+
+output "transition_dbadmin_write_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.transition_dbadmin_database_backups_writer.arn}"
+  description = "ARN of the TransitionDBAdmin write database_backups-bucket policy"
 }
 
 output "graphite_write_database_backups_bucket_policy_arn" {


### PR DESCRIPTION
- The new access policy filters for the S3 bucket in
  infra-database-backups-bucket are based on prefixes.

- New policies added in infra-database-backups-bucket need a
corresponding change in the app terraform to attach properly.

- Re-apply of both projects is required

pair @schmie @szd55gds