### PR TITLE
Add warehouse db admin policy to access s3 backup buckets

### DIFF
--- a/terraform/projects/app-warehouse-db-admin/main.tf
+++ b/terraform/projects/app-warehouse-db-admin/main.tf
@@ -132,13 +132,13 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
 resource "aws_iam_role_policy_attachment" "write_warehouse-db-admin_database_backups_iam_role_policy_attachment" {
   count      = 1
   role       = "${module.warehouse-db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_write_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.warehouse_dbadmin_write_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "read_warehouse-db-admin_database_backups_iam_role_policy_attachment" {
   count      = 1
   role       = "${module.warehouse-db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_read_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.warehouse_dbadmin_read_database_backups_bucket_policy_arn}"
 }
 
 # Outputs

--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -36,4 +36,6 @@ database-backups: The bucket that will hold database backups
 | mongodb_write_database_backups_bucket_policy_arn | ARN of the mongodb write database_backups-bucket policy |
 | transition_dbadmin_read_database_backups_bucket_policy_arn | ARN of the read TransitionDBAdmin database_backups-bucket policy |
 | transition_dbadmin_write_database_backups_bucket_policy_arn | ARN of the TransitionDBAdmin write database_backups-bucket policy |
+| warehouse_dbadmin_read_database_backups_bucket_policy_arn | ARN of the read WarehouseDBAdmin database_backups-bucket policy |
+| warehouse_dbadmin_write_database_backups_bucket_policy_arn | ARN of the WarehouseDBAdmin write database_backups-bucket policy |
 

--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -147,6 +147,29 @@ data "aws_iam_policy_document" "transition_dbadmin_database_backups_reader" {
   }
 }
 
+resource "aws_iam_policy" "warehouse_dbadmin_database_backups_reader" {
+  name        = "govuk-${var.aws_environment}-warehouse_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.warehouse_dbadmin_database_backups_reader.json}"
+  description = "Allows reading the warehouse_dbadmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "warehouse_dbadmin_database_backups_reader" {
+  statement {
+    sid = "WarehouseDBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*warehouse-postgres*",
+    ]
+  }
+}
+
 resource "aws_iam_policy" "graphite_database_backups_reader" {
   name        = "govuk-${var.aws_environment}-graphite_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.graphite_database_backups_reader.json}"
@@ -198,6 +221,11 @@ output "dbadmin_read_database_backups_bucket_policy_arn" {
 output "transition_dbadmin_read_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.transition_dbadmin_database_backups_reader.arn}"
   description = "ARN of the read TransitionDBAdmin database_backups-bucket policy"
+}
+
+output "warehouse_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.warehouse_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the read WarehouseDBAdmin database_backups-bucket policy"
 }
 
 output "graphite_read_database_backups_bucket_policy_arn" {


### PR DESCRIPTION
s3 read/write policies required to permit adding warehouse-db_admin in AWS to the env_backup app.