### PR TITLE
Adding publishing-api RDS access to backup S3

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -34,6 +34,8 @@ database-backups: The bucket that will hold database backups
 | mongo_router_write_database_backups_bucket_policy_arn | ARN of the router_backend write database_backups-bucket policy |
 | mongodb_read_database_backups_bucket_policy_arn | ARN of the read mongodb database_backups-bucket policy |
 | mongodb_write_database_backups_bucket_policy_arn | ARN of the mongodb write database_backups-bucket policy |
+| publishing-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the read publishing-apiDBAdmin database_backups-bucket policy |
+| publishing-api_dbadmin_write_database_backups_bucket_policy_arn | ARN of the publishing-apiDBAdmin write database_backups-bucket policy |
 | transition_dbadmin_read_database_backups_bucket_policy_arn | ARN of the read TransitionDBAdmin database_backups-bucket policy |
 | transition_dbadmin_write_database_backups_bucket_policy_arn | ARN of the TransitionDBAdmin write database_backups-bucket policy |
 | warehouse_dbadmin_read_database_backups_bucket_policy_arn | ARN of the read WarehouseDBAdmin database_backups-bucket policy |

--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -170,6 +170,29 @@ data "aws_iam_policy_document" "warehouse_dbadmin_database_backups_reader" {
   }
 }
 
+resource "aws_iam_policy" "publishing-api_dbadmin_database_backups_reader" {
+  name        = "govuk-${var.aws_environment}-publishing-api_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.publishing-api_dbadmin_database_backups_reader.json}"
+  description = "Allows reading the publishing-api_dbadmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "publishing-api_dbadmin_database_backups_reader" {
+  statement {
+    sid = "publishingApiDBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*publishing-api-postgres*",
+    ]
+  }
+}
+
 resource "aws_iam_policy" "graphite_database_backups_reader" {
   name        = "govuk-${var.aws_environment}-graphite_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.graphite_database_backups_reader.json}"
@@ -221,6 +244,11 @@ output "dbadmin_read_database_backups_bucket_policy_arn" {
 output "transition_dbadmin_read_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.transition_dbadmin_database_backups_reader.arn}"
   description = "ARN of the read TransitionDBAdmin database_backups-bucket policy"
+}
+
+output "publishing-api_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.publishing-api_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the read publishing-apiDBAdmin database_backups-bucket policy"
 }
 
 output "warehouse_dbadmin_read_database_backups_bucket_policy_arn" {

--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -403,6 +403,63 @@ data "aws_iam_policy_document" "warehouse_dbadmin_database_backups_writer" {
   }
 }
 
+resource "aws_iam_policy" "publishing-api_dbadmin_database_backups_writer" {
+  name        = "govuk-${var.aws_environment}-publishing-api_dbadmin_database_backups-writer-policy"
+  policy      = "${data.aws_iam_policy_document.publishing-api_dbadmin_database_backups_writer.json}"
+  description = "Allows writing of the publishing-apiDBAdmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "publishing-api_dbadmin_database_backups_writer" {
+  statement {
+    sid = "ReadListOfBuckets"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "publishingApiDBAdminReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+
+    # The top level access is required.
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "mysql",
+        "postgres",
+      ]
+    }
+  }
+
+  statement {
+    sid = "publishingApiDBAdminWriteGovukDatabaseBackups"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*publishing-api-postgres*",
+    ]
+  }
+}
+
 resource "aws_iam_policy" "graphite_database_backups_writer" {
   name        = "govuk-${var.aws_environment}-graphite_database_backups-writer-policy"
   policy      = "${data.aws_iam_policy_document.graphite_database_backups_writer.json}"
@@ -492,6 +549,11 @@ output "transition_dbadmin_write_database_backups_bucket_policy_arn" {
 output "warehouse_dbadmin_write_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.warehouse_dbadmin_database_backups_writer.arn}"
   description = "ARN of the WarehouseDBAdmin write database_backups-bucket policy"
+}
+
+output "publishing-api_dbadmin_write_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.publishing-api_dbadmin_database_backups_writer.arn}"
+  description = "ARN of the publishing-apiDBAdmin write database_backups-bucket policy"
 }
 
 output "graphite_write_database_backups_bucket_policy_arn" {


### PR DESCRIPTION
- We want to separate out RDS instances for publishing-api and
email-alert-api due to load.

- For symmetry we have decided to instantiate one db_admin per RDS.

- The new publishing-api-db_admin need a policy to read/write to
sync/backup buckets

solo: @schmie