### PR TITLE
Change the S3 prefix router_backend to mongo-router

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -50,6 +50,7 @@ data "aws_iam_policy_document" "mongo_router_database_backups_reader" {
     resources = [
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*router_backend*",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mongo-router*",
     ]
   }
 }

--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -100,6 +100,7 @@ data "aws_iam_policy_document" "mongo_router_database_backups_writer" {
 
       values = [
         "router_backend",
+        "mongo-router",
       ]
     }
   }
@@ -115,6 +116,7 @@ data "aws_iam_policy_document" "mongo_router_database_backups_writer" {
 
     resources = [
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*router_backend*",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mongo-router*",
     ]
   }
 }


### PR DESCRIPTION
  We use the name mongo-router to stay coherent with the old
system