### PR TITLE
Revert "Increasing the size of the root partition of backend from 30G to 60G"

### DIFF
--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -201,7 +201,7 @@ module "backend" {
   asg_min_size                  = "${var.asg_size}"
   asg_desired_capacity          = "${var.asg_size}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
-  root_block_device_volume_size = "60"
+  root_block_device_volume_size = "30"
 }
 
 module "alarms-elb-backend-internal" {


### PR DESCRIPTION
Reverts alphagov/govuk-aws#623

As per https://govuk.zendesk.com/agent/tickets/3107683.