### PR TITLE
Update app-db-admin IAM policy to support datascrubber

### DIFF
--- a/terraform/projects/app-db-admin/additional_policy.json
+++ b/terraform/projects/app-db-admin/additional_policy.json
@@ -4,20 +4,20 @@
         {
             "Effect": "Allow",
             "Action": [
-                "rds:CreateDBInstance",
-                "rds:DeleteDBInstance",
-                "rds:RestoreDBInstanceFromDBSnapshot"
+                "rds:ModifyDBInstance",
+                "rds:DeleteDBInstance"
             ],
             "Resource": "*",
             "Condition": {
                 "StringEquals": {
-                    "rds:db-tag": "scrubber"
+                    "rds:db-tag/scrubber": ["scrubber"]
                 }
            }
         },
         {
             "Effect": "Allow",
             "Action": [
+                "rds:RestoreDBInstanceFromDBSnapshot",
                 "rds:DescribeDBClusterSnapshotAttributes",
                 "rds:DescribeDBClusterParameters",
                 "rds:DescribeDBEngineVersions",
@@ -34,6 +34,7 @@
                 "rds:CreateDBClusterSnapshot",
                 "rds:DescribeDBParameters",
                 "rds:ModifyDBClusterSnapshotAttribute",
+                "rds:ModifyDBSnapshot",
                 "rds:ModifyDBSnapshotAttribute",
                 "rds:DescribeDBClusters",
                 "rds:DescribeDBClusterParameterGroups",


### PR DESCRIPTION
* Fix the conditional to correctly match against the resource tags.
  * Tag matching on `RestoreDBInstanceFromDBSnapshot` doesn't work because the resource doesn't exist when the API call is invoked.
* `CreateDBInstance` isn't required - remove
* `ModifyDBSnapshot` is required - add