### PR TITLE
Add Multi-AZ support for RDS databases in Staging.

### DIFF
--- a/terraform/modules/aws/rds_instance/README.md
+++ b/terraform/modules/aws/rds_instance/README.md
@@ -21,7 +21,7 @@ Create an RDS instance
 | instance_class | The instance type of the RDS instance. | string | `db.t1.micro` | no |
 | instance_name | The RDS Instance Name. | string | `` | no |
 | maintenance_window | The window to perform maintenance in. | string | `Mon:04:00-Mon:06:00` | no |
-| multi_az | Specifies if the RDS instance is multi-AZ | string | `false` | no |
+| multi_az | Specifies if the RDS instance is multi-AZ | string | `true` | no |
 | name | The common name for all the resources created by this module | string | - | yes |
 | parameter_group_name | Name of the parameter group to make the instance a member of. | string | `` | no |
 | password | Password for accessing the database. | string | `` | no |

--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -76,7 +76,7 @@ variable "security_group_ids" {
 variable "multi_az" {
   type        = "string"
   description = "Specifies if the RDS instance is multi-AZ"
-  default     = false
+  default     = true
 }
 
 variable "create_replicate_source_db" {

--- a/terraform/projects/app-email-alert-api-postgresql/README.md
+++ b/terraform/projects/app-email-alert-api-postgresql/README.md
@@ -11,7 +11,7 @@ RDS email-alert-api PostgreSQL Primary instance
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
 | instance_name | The RDS Instance Name. | string | `` | no |
-| multi_az | Enable multi-az. | string | `false` | no |
+| multi_az | Enable multi-az. | string | `true` | no |
 | password | DB password | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-email-alert-api-postgresql/main.tf
+++ b/terraform/projects/app-email-alert-api-postgresql/main.tf
@@ -43,7 +43,7 @@ variable "password" {
 variable "multi_az" {
   type        = "string"
   description = "Enable multi-az."
-  default     = false
+  default     = true
 }
 
 variable "skip_final_snapshot" {

--- a/terraform/projects/app-email-alert-api-postgresql/staging.blue.backend
+++ b/terraform/projects/app-email-alert-api-postgresql/staging.blue.backend
@@ -1,4 +1,4 @@
-bucket  = "govuk-terraform-steppingstone-staging"
-key     = "blue/app-email-alert-api-postgresql.tfstate"
-encrypt = true
-region  = "eu-west-1"
+bucket   = "govuk-terraform-steppingstone-staging"
+key      = "blue/app-email-alert-api-postgresql.tfstate"
+encrypt  = true
+region   = "eu-west-1"

--- a/terraform/projects/app-mysql/staging.blue.backend
+++ b/terraform/projects/app-mysql/staging.blue.backend
@@ -1,4 +1,4 @@
-bucket  = "govuk-terraform-steppingstone-staging"
-key     = "blue/app-mysql.tfstate"
-encrypt = true
-region  = "eu-west-1"
+bucket   = "govuk-terraform-steppingstone-staging"
+key      = "blue/app-mysql.tfstate"
+encrypt  = true
+region   = "eu-west-1"

--- a/terraform/projects/app-postgresql/README.md
+++ b/terraform/projects/app-postgresql/README.md
@@ -11,7 +11,7 @@ RDS PostgreSQL instances
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
 | instance_name | The RDS Instance Name. | string | `` | no |
-| multi_az | Enable multi-az. | string | `false` | no |
+| multi_az | Enable multi-az. | string | `true` | no |
 | password | DB password | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -43,7 +43,7 @@ variable "password" {
 variable "multi_az" {
   type        = "string"
   description = "Enable multi-az."
-  default     = false
+  default     = true
 }
 
 variable "skip_final_snapshot" {

--- a/terraform/projects/app-postgresql/staging.blue.backend
+++ b/terraform/projects/app-postgresql/staging.blue.backend
@@ -1,4 +1,4 @@
-bucket  = "govuk-terraform-steppingstone-staging"
-key     = "blue/app-postgresql.tfstate"
-encrypt = true
-region  = "eu-west-1"
+bucket   = "govuk-terraform-steppingstone-staging"
+key      = "blue/app-postgresql.tfstate"
+encrypt  = true
+region   = "eu-west-1"

--- a/terraform/projects/app-publishing-api-postgresql/README.md
+++ b/terraform/projects/app-publishing-api-postgresql/README.md
@@ -10,7 +10,7 @@ RDS PostgreSQL instance for the GOV.UK data publishing-api-postgresql
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
-| multi_az | Enable multi-az. | string | `false` | no |
+| multi_az | Enable multi-az. | string | `true` | no |
 | password | DB password | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-publishing-api-postgresql/main.tf
+++ b/terraform/projects/app-publishing-api-postgresql/main.tf
@@ -37,7 +37,7 @@ variable "password" {
 variable "multi_az" {
   type        = "string"
   description = "Enable multi-az."
-  default     = false
+  default     = true
 }
 
 variable "skip_final_snapshot" {

--- a/terraform/projects/app-publishing-api-postgresql/staging.blue.backend
+++ b/terraform/projects/app-publishing-api-postgresql/staging.blue.backend
@@ -1,4 +1,4 @@
-bucket  = "govuk-terraform-steppingstone-staging"
-key     = "blue/app-publishing-api-postgresql.tfstate"
-encrypt = true
-region  = "eu-west-1"
+bucket   = "govuk-terraform-steppingstone-staging"
+key      = "blue/app-publishing-api-postgresql.tfstate"
+encrypt  = true
+region   = "eu-west-1"

--- a/terraform/projects/app-transition-postgresql/README.md
+++ b/terraform/projects/app-transition-postgresql/README.md
@@ -11,7 +11,7 @@ RDS Transition PostgreSQL Primary instance
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
 | instance_name | The RDS Instance Name. | string | `` | no |
-| multi_az | Enable multi-az. | string | `false` | no |
+| multi_az | Enable multi-az. | string | `true` | no |
 | password | DB password | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -43,7 +43,7 @@ variable "password" {
 variable "multi_az" {
   type        = "string"
   description = "Enable multi-az."
-  default     = false
+  default     = true
 }
 
 variable "skip_final_snapshot" {

--- a/terraform/projects/app-transition-postgresql/staging.blue.backend
+++ b/terraform/projects/app-transition-postgresql/staging.blue.backend
@@ -1,4 +1,4 @@
-bucket  = "govuk-terraform-steppingstone-staging"
-key     = "blue/app-transition-postgresql.tfstate"
-encrypt = true
-region  = "eu-west-1"
+bucket   = "govuk-terraform-steppingstone-staging"
+key      = "blue/app-transition-postgresql.tfstate"
+encrypt  = true
+region   = "eu-west-1"

--- a/terraform/projects/app-warehouse/README.md
+++ b/terraform/projects/app-warehouse/README.md
@@ -10,7 +10,7 @@ RDS PostgreSQL instance for the GOV.UK data warehouse
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
-| multi_az | Enable multi-az. | string | `false` | no |
+| multi_az | Enable multi-az. | string | `true` | no |
 | password | DB password | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-warehouse/main.tf
+++ b/terraform/projects/app-warehouse/main.tf
@@ -37,7 +37,7 @@ variable "password" {
 variable "multi_az" {
   type        = "string"
   description = "Enable multi-az."
-  default     = false
+  default     = true
 }
 
 variable "skip_final_snapshot" {

--- a/terraform/projects/app-warehouse/staging.blue.backend
+++ b/terraform/projects/app-warehouse/staging.blue.backend
@@ -1,4 +1,4 @@
-bucket  = "govuk-terraform-steppingstone-staging"
-key     = "blue/app-warehouse.tfstate"
-encrypt = true
-region  = "eu-west-1"
+bucket   = "govuk-terraform-steppingstone-staging"
+key      = "blue/app-warehouse.tfstate"
+encrypt  = true
+region   = "eu-west-1"


### PR DESCRIPTION
This makes AWS create internal HA replicas in a different AZ from the primary DB of each RDS instance. These are not available for us to use as read-replicas but rather for use in a failover situation where the primary DB AZ fails. This failover and recovery is managed automatically by RDS. At the moment our RDS instances are not HA.