### PR TITLE
Enable encryption on all EBS volumes, per environment

### DIFF
--- a/terraform/projects/app-apt/README.md
+++ b/terraform/projects/app-apt/README.md
@@ -10,6 +10,7 @@ Apt node
 | apt_1_subnet | Name of the subnet to place the apt instance 1 and EBS volume | string | - | yes |
 | aws_environment | AWS environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |

--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -14,6 +14,11 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
+variable "ebs_encrypted" {
+  type        = "string"
+  description = "Whether or not the EBS volume is encrypted"
+}
+
 variable "stackname" {
   type        = "string"
   description = "Stackname"
@@ -141,6 +146,7 @@ module "apt" {
 
 resource "aws_ebs_volume" "apt" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.apt_1_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   size              = 40
   type              = "gp2"
 

--- a/terraform/projects/app-ckan/README.md
+++ b/terraform/projects/app-ckan/README.md
@@ -11,6 +11,7 @@ CKAN node
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | ckan_subnet | Name of the subnet to place the ckan instance and the EBS volume | string | - | yes |
+| ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |

--- a/terraform/projects/app-ckan/main.tf
+++ b/terraform/projects/app-ckan/main.tf
@@ -14,6 +14,11 @@ variable "stackname" {
   description = "Stackname"
 }
 
+variable "ebs_encrypted" {
+  type        = "string"
+  description = "Whether or not the EBS volume is encrypted"
+}
+
 variable "aws_environment" {
   type        = "string"
   description = "AWS Environment"
@@ -201,6 +206,7 @@ module "ckan" {
 
 resource "aws_ebs_volume" "ckan" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ckan_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   type              = "gp2"
   size              = 20
 

--- a/terraform/projects/app-deploy/README.md
+++ b/terraform/projects/app-deploy/README.md
@@ -10,6 +10,7 @@ Deploy node
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | deploy_subnet | Name of the subnet to place the apt instance 1 and EBS volume | string | - | yes |
+| ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -19,6 +19,11 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "ebs_encrypted" {
+  type        = "string"
+  description = "Whether or not the EBS volume is encrypted"
+}
+
 variable "instance_ami_filter_name" {
   type        = "string"
   description = "Name to use to find AMI images"
@@ -197,6 +202,7 @@ module "deploy" {
 
 resource "aws_ebs_volume" "deploy" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.deploy_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   size              = 40
   type              = "gp2"
 

--- a/terraform/projects/app-graphite/README.md
+++ b/terraform/projects/app-graphite/README.md
@@ -9,6 +9,7 @@ Graphite node
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | graphite_1_subnet | Name of the subnet to place the Graphite instance 1 and EBS volume | string | - | yes |

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -19,6 +19,11 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "ebs_encrypted" {
+  type        = "string"
+  description = "Whether or not the EBS volume is encrypted"
+}
+
 variable "instance_ami_filter_name" {
   type        = "string"
   description = "Name to use to find AMI images"
@@ -211,6 +216,7 @@ module "graphite-1" {
 
 resource "aws_ebs_volume" "graphite-1" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.graphite_1_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   size              = 250
   type              = "io1"
   iops              = 1000

--- a/terraform/projects/app-logs-cdn/README.md
+++ b/terraform/projects/app-logs-cdn/README.md
@@ -9,6 +9,7 @@ logs-cdn node
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | logs_cdn_subnet | Name of the subnet to place the EBS volume | string | - | yes |

--- a/terraform/projects/app-logs-cdn/main.tf
+++ b/terraform/projects/app-logs-cdn/main.tf
@@ -19,6 +19,11 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "ebs_encrypted" {
+  type        = "string"
+  description = "Whether or not the EBS volume is encrypted"
+}
+
 variable "instance_ami_filter_name" {
   type        = "string"
   description = "Name to use to find AMI images"
@@ -136,6 +141,7 @@ module "logs-cdn" {
 
 resource "aws_ebs_volume" "logs-cdn" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.logs_cdn_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   size              = 500
   type              = "gp2"
 

--- a/terraform/projects/app-mapit/README.md
+++ b/terraform/projects/app-mapit/README.md
@@ -9,6 +9,7 @@ Mapit node
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | instance_type | The type of EC2 instance to use for both ASGs. | string | `t2.medium` | no |

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -19,6 +19,11 @@ variable "stackname" {
   description = "Stackname"
 }
 
+variable "ebs_encrypted" {
+  type        = "string"
+  description = "Whether or not the EBS volume is encrypted"
+}
+
 variable "instance_ami_filter_name" {
   type        = "string"
   description = "Name to use to find AMI images"
@@ -131,6 +136,7 @@ module "mapit-1" {
 
 resource "aws_ebs_volume" "mapit-1" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_1_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"
 
@@ -163,6 +169,7 @@ module "mapit-2" {
 
 resource "aws_ebs_volume" "mapit-2" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_2_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"
 

--- a/terraform/projects/app-mirrorer/README.md
+++ b/terraform/projects/app-mirrorer/README.md
@@ -9,6 +9,7 @@ Mirrorer node
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | mirrorer_instance_type | Instance type for the mirrorer instance | string | `m5.large` | no |
 | mirrorer_subnet | Subnet to contain mirrorer and its EBS volume | string | - | yes |

--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -19,6 +19,11 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "ebs_encrypted" {
+  type        = "string"
+  description = "Whether or not the EBS volume is encrypted"
+}
+
 variable "instance_ami_filter_name" {
   type        = "string"
   description = "Name to use to find AMI images"
@@ -69,6 +74,7 @@ module "mirrorer" {
 
 resource "aws_ebs_volume" "mirrorer" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mirrorer_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   size              = 100
   type              = "gp2"
 

--- a/terraform/projects/app-mongo/README.md
+++ b/terraform/projects/app-mongo/README.md
@@ -9,6 +9,7 @@ Mongo hosts
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | mongo_1_ip | IP address of the private IP to assign to the instance | string | - | yes |
 | mongo_1_reserved_ips_subnet | Name of the subnet to place the reserved IP of the instance | string | - | yes |

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -19,6 +19,11 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "ebs_encrypted" {
+  type        = "string"
+  description = "Whether or not the EBS volume is encrypted"
+}
+
 variable "instance_ami_filter_name" {
   type        = "string"
   description = "Name to use to find AMI images"
@@ -130,6 +135,7 @@ module "mongo-1" {
 
 resource "aws_ebs_volume" "mongo-1" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mongo_1_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   type              = "gp2"
   size              = 300
 
@@ -187,6 +193,7 @@ module "mongo-2" {
 
 resource "aws_ebs_volume" "mongo-2" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mongo_2_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   type              = "gp2"
   size              = 300
 
@@ -244,6 +251,7 @@ module "mongo-3" {
 
 resource "aws_ebs_volume" "mongo-3" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mongo_3_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   type              = "gp2"
   size              = 300
 

--- a/terraform/projects/app-monitoring/README.md
+++ b/terraform/projects/app-monitoring/README.md
@@ -9,6 +9,7 @@ Monitoring node
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |

--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -19,6 +19,11 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "ebs_encrypted" {
+  type        = "string"
+  description = "Whether or not the EBS volume is encrypted"
+}
+
 variable "instance_ami_filter_name" {
   type        = "string"
   description = "Name to use to find AMI images"
@@ -163,6 +168,7 @@ module "monitoring" {
 
 resource "aws_ebs_volume" "monitoring" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.monitoring_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   type              = "gp2"
   size              = 20
 

--- a/terraform/projects/app-rummager-elasticsearch/README.md
+++ b/terraform/projects/app-rummager-elasticsearch/README.md
@@ -10,6 +10,7 @@ Rummager Elasticsearch cluster
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cluster_name | Name of the Elasticsearch cluster to use for discovery | string | - | yes |
+| ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_database_backups_bucket_key_stack | Override stackname path to infra_database_backups_bucket remote state | string | `` | no |

--- a/terraform/projects/app-rummager-elasticsearch/main.tf
+++ b/terraform/projects/app-rummager-elasticsearch/main.tf
@@ -19,6 +19,11 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "ebs_encrypted" {
+  type        = "string"
+  description = "Whether or not the EBS volume is encrypted"
+}
+
 variable "instance_ami_filter_name" {
   type        = "string"
   description = "Name to use to find AMI images"
@@ -148,6 +153,7 @@ module "rummager-elasticsearch-1" {
 
 resource "aws_ebs_volume" "rummager-elasticsearch-1" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.rummager_elasticsearch_1_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   size              = 100
   type              = "gp2"
 
@@ -181,6 +187,7 @@ module "rummager-elasticsearch-2" {
 
 resource "aws_ebs_volume" "rummager-elasticsearch-2" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.rummager_elasticsearch_2_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   size              = 100
   type              = "gp2"
 
@@ -214,6 +221,7 @@ module "rummager-elasticsearch-3" {
 
 resource "aws_ebs_volume" "rummager-elasticsearch-3" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.rummager_elasticsearch_3_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
   size              = 100
   type              = "gp2"
 


### PR DESCRIPTION
- This variable is set in `govuk-aws-data` common.tfvars per
  environment. This is because we don't want to enable this just yet in
  integration, but we do want it in staging and production because we're
  starting afresh with those environments.
- This was a recommendation from the AWS well-architected review.

https://trello.com/c/GsT3KAMg/1479-enable-encryption-at-rest-on-several-ebs-volumes