### PR TITLE
RDS: Default to keeping final snapshots

### DIFF
--- a/terraform/modules/aws/rds_instance/README.md
+++ b/terraform/modules/aws/rds_instance/README.md
@@ -27,7 +27,7 @@ Create an RDS instance
 | password | Password for accessing the database. | string | `` | no |
 | replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate | string | `false` | no |
 | security_group_ids | Security group IDs to apply to this cluster | list | - | yes |
-| skip_final_snapshot | Set to false to create a final snapshot when the cluster is deleted. | string | `true` | no |
+| skip_final_snapshot | Set to true to NOT create a final snapshot when the cluster is deleted. | string | `false` | no |
 | snapshot_identifier | Specifies whether or not to create this database from a snapshot. | string | `` | no |
 | storage_type | One of standard (magnetic), gp2 (general purpose SSD), or io1 (provisioned IOPS SSD). The default is gp2 | string | `gp2` | no |
 | subnet_ids | Subnet IDs to assign to the aws_elasticache_subnet_group | list | `<list>` | no |

--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -99,8 +99,8 @@ variable "parameter_group_name" {
 
 variable "skip_final_snapshot" {
   type        = "string"
-  description = "Set to false to create a final snapshot when the cluster is deleted."
-  default     = "true"
+  description = "Set to true to NOT create a final snapshot when the cluster is deleted."
+  default     = "false"
 }
 
 variable "maintenance_window" {
@@ -204,7 +204,6 @@ resource "aws_db_instance" "db_instance_replica" {
     update = "${var.terraform_update_rds_timeout}"
   }
 
-  # TODO this should be enabled in a Production environment:
   final_snapshot_identifier = "${var.name}-final-snapshot"
   skip_final_snapshot       = "${var.skip_final_snapshot}"
 
@@ -240,7 +239,6 @@ resource "aws_db_instance" "db_instance" {
     update = "${var.terraform_update_rds_timeout}"
   }
 
-  # TODO this should be enabled in a Production environment:
   final_snapshot_identifier = "${var.name}-final-snapshot"
   skip_final_snapshot       = "${var.skip_final_snapshot}"
 

--- a/terraform/projects/app-mysql/README.md
+++ b/terraform/projects/app-mysql/README.md
@@ -19,6 +19,7 @@ RDS Mysql Primary instance
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| skip_final_snapshot_policy | A map of environments to boolean values determining whether final snapshots are enabled in each environment | map | `<map>` | no |
 | snapshot_identifier | Specifies whether or not to create the database from this snapshot | string | `` | no |
 | stackname | Stackname | string | - | yes |
 | storage_size | Defines the AWS RDS storage capacity, in gigabytes. | string | `30` | no |

--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -52,6 +52,17 @@ variable "storage_size" {
   default     = "30"
 }
 
+variable "skip_final_snapshot_policy" {
+  type        = "map"
+  description = "A map of environments to boolean values determining whether final snapshots are enabled in each environment"
+
+  default = {
+    "integration" = "true"
+    "staging"     = "false"
+    "production"  = "false"
+  }
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -81,6 +92,7 @@ module "mysql_primary_rds_instance" {
   parameter_group_name = "${aws_db_parameter_group.mysql-primary.name}"
   event_sns_topic_arn  = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
   snapshot_identifier  = "${var.snapshot_identifier}"
+  skip_final_snapshot  = "${lookup(var.skip_final_snapshot_policy, var.aws_environment)}"
 }
 
 resource "aws_db_parameter_group" "mysql-primary" {


### PR DESCRIPTION
Change the default in the rds_instance module to be production-safe.