### PR TITLE
Control RDS final snapshots

### DIFF
--- a/terraform/modules/aws/rds_instance/README.md
+++ b/terraform/modules/aws/rds_instance/README.md
@@ -27,7 +27,7 @@ Create an RDS instance
 | password | Password for accessing the database. | string | `` | no |
 | replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate | string | `false` | no |
 | security_group_ids | Security group IDs to apply to this cluster | list | - | yes |
-| skip_final_snapshot | Set to false to create a final snapshot when the cluster is deleted. | string | `true` | no |
+| skip_final_snapshot | Set to true to NOT create a final snapshot when the cluster is deleted. | string | `false` | no |
 | snapshot_identifier | Specifies whether or not to create this database from a snapshot. | string | `` | no |
 | storage_type | One of standard (magnetic), gp2 (general purpose SSD), or io1 (provisioned IOPS SSD). The default is gp2 | string | `gp2` | no |
 | subnet_ids | Subnet IDs to assign to the aws_elasticache_subnet_group | list | `<list>` | no |

--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -99,8 +99,8 @@ variable "parameter_group_name" {
 
 variable "skip_final_snapshot" {
   type        = "string"
-  description = "Set to false to create a final snapshot when the cluster is deleted."
-  default     = "true"
+  description = "Set to true to NOT create a final snapshot when the cluster is deleted."
+  default     = "false"
 }
 
 variable "maintenance_window" {
@@ -204,7 +204,6 @@ resource "aws_db_instance" "db_instance_replica" {
     update = "${var.terraform_update_rds_timeout}"
   }
 
-  # TODO this should be enabled in a Production environment:
   final_snapshot_identifier = "${var.name}-final-snapshot"
   skip_final_snapshot       = "${var.skip_final_snapshot}"
 
@@ -240,7 +239,6 @@ resource "aws_db_instance" "db_instance" {
     update = "${var.terraform_update_rds_timeout}"
   }
 
-  # TODO this should be enabled in a Production environment:
   final_snapshot_identifier = "${var.name}-final-snapshot"
   skip_final_snapshot       = "${var.skip_final_snapshot}"
 

--- a/terraform/projects/app-email-alert-api-postgresql/README.md
+++ b/terraform/projects/app-email-alert-api-postgresql/README.md
@@ -20,6 +20,7 @@ RDS email-alert-api PostgreSQL Primary instance
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| skip_final_snapshot | Set to true to NOT create a final snapshot when the cluster is deleted. | string | - | yes |
 | snapshot_identifier | Specifies whether or not to create the database from this snapshot | string | `` | no |
 | stackname | Stackname | string | - | yes |
 | username | PostgreSQL username | string | - | yes |

--- a/terraform/projects/app-email-alert-api-postgresql/main.tf
+++ b/terraform/projects/app-email-alert-api-postgresql/main.tf
@@ -46,6 +46,11 @@ variable "multi_az" {
   default     = false
 }
 
+variable "skip_final_snapshot" {
+  type        = "string"
+  description = "Set to true to NOT create a final snapshot when the cluster is deleted."
+}
+
 variable "snapshot_identifier" {
   type        = "string"
   description = "Specifies whether or not to create the database from this snapshot"
@@ -80,6 +85,7 @@ module "email-alert-api-postgresql-primary_rds_instance" {
   multi_az            = "${var.multi_az}"
   security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_email-alert-api-postgresql-primary_id}"]
   event_sns_topic_arn = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot = "${var.skip_final_snapshot}"
   snapshot_identifier = "${var.snapshot_identifier}"
 }
 
@@ -102,6 +108,7 @@ module "email-alert-api-postgresql-standby_rds_instance" {
   create_replicate_source_db = "1"
   replicate_source_db        = "${module.email-alert-api-postgresql-primary_rds_instance.rds_instance_id}"
   event_sns_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot        = "${var.skip_final_snapshot}"
 }
 
 resource "aws_route53_record" "replica_service_record" {

--- a/terraform/projects/app-mysql/README.md
+++ b/terraform/projects/app-mysql/README.md
@@ -19,6 +19,7 @@ RDS Mysql Primary instance
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| skip_final_snapshot | Set to true to NOT create a final snapshot when the cluster is deleted. | string | - | yes |
 | snapshot_identifier | Specifies whether or not to create the database from this snapshot | string | `` | no |
 | stackname | Stackname | string | - | yes |
 | storage_size | Defines the AWS RDS storage capacity, in gigabytes. | string | `30` | no |

--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -40,6 +40,11 @@ variable "password" {
   description = "DB password"
 }
 
+variable "skip_final_snapshot" {
+  type        = "string"
+  description = "Set to true to NOT create a final snapshot when the cluster is deleted."
+}
+
 variable "snapshot_identifier" {
   type        = "string"
   description = "Specifies whether or not to create the database from this snapshot"
@@ -80,6 +85,7 @@ module "mysql_primary_rds_instance" {
   security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mysql-primary_id}"]
   parameter_group_name = "${aws_db_parameter_group.mysql-primary.name}"
   event_sns_topic_arn  = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot  = "${var.skip_final_snapshot}"
   snapshot_identifier  = "${var.snapshot_identifier}"
 }
 
@@ -139,6 +145,7 @@ module "mysql_replica_rds_instance" {
   create_replicate_source_db = "1"
   replicate_source_db        = "${module.mysql_primary_rds_instance.rds_instance_id}"
   event_sns_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot        = "${var.skip_final_snapshot}"
 }
 
 resource "aws_route53_record" "replica_service_record" {

--- a/terraform/projects/app-postgresql/README.md
+++ b/terraform/projects/app-postgresql/README.md
@@ -20,6 +20,7 @@ RDS PostgreSQL instances
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| skip_final_snapshot | Set to true to NOT create a final snapshot when the cluster is deleted. | string | - | yes |
 | snapshot_identifier | Specifies whether or not to create the database from this snapshot | string | `` | no |
 | stackname | Stackname | string | - | yes |
 | username | PostgreSQL username | string | - | yes |

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -46,6 +46,11 @@ variable "multi_az" {
   default     = false
 }
 
+variable "skip_final_snapshot" {
+  type        = "string"
+  description = "Set to true to NOT create a final snapshot when the cluster is deleted."
+}
+
 variable "snapshot_identifier" {
   type        = "string"
   description = "Specifies whether or not to create the database from this snapshot"
@@ -80,6 +85,7 @@ module "postgresql-primary_rds_instance" {
   multi_az            = "${var.multi_az}"
   security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]
   event_sns_topic_arn = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot = "${var.skip_final_snapshot}"
   snapshot_identifier = "${var.snapshot_identifier}"
 }
 
@@ -102,6 +108,7 @@ module "postgresql-standby_rds_instance" {
   create_replicate_source_db = "1"
   replicate_source_db        = "${module.postgresql-primary_rds_instance.rds_instance_id}"
   event_sns_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot        = "${var.skip_final_snapshot}"
 }
 
 resource "aws_route53_record" "replica_service_record" {

--- a/terraform/projects/app-publishing-api-postgresql/README.md
+++ b/terraform/projects/app-publishing-api-postgresql/README.md
@@ -19,6 +19,7 @@ RDS PostgreSQL instance for the GOV.UK data publishing-api-postgresql
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| skip_final_snapshot | Set to true to NOT create a final snapshot when the cluster is deleted. | string | - | yes |
 | snapshot_identifier | Specifies whether or not to create the database from this snapshot | string | `` | no |
 | stackname | Stackname | string | - | yes |
 | username | PostgreSQL username | string | - | yes |

--- a/terraform/projects/app-publishing-api-postgresql/main.tf
+++ b/terraform/projects/app-publishing-api-postgresql/main.tf
@@ -40,6 +40,11 @@ variable "multi_az" {
   default     = false
 }
 
+variable "skip_final_snapshot" {
+  type        = "string"
+  description = "Set to true to NOT create a final snapshot when the cluster is deleted."
+}
+
 variable "snapshot_identifier" {
   type        = "string"
   description = "Specifies whether or not to create the database from this snapshot"
@@ -74,6 +79,7 @@ module "publishing-api-postgresql-primary_rds_instance" {
   multi_az            = "${var.multi_az}"
   security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_publishing-api-postgresql-primary_id}"]
   event_sns_topic_arn = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot = "${var.skip_final_snapshot}"
   snapshot_identifier = "${var.snapshot_identifier}"
 }
 
@@ -96,6 +102,7 @@ module "publishing-api-postgresql-standby_rds_instance" {
   create_replicate_source_db = "1"
   replicate_source_db        = "${module.publishing-api-postgresql-primary_rds_instance.rds_instance_id}"
   event_sns_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot        = "${var.skip_final_snapshot}"
 }
 
 resource "aws_route53_record" "replica_service_record" {

--- a/terraform/projects/app-transition-postgresql/README.md
+++ b/terraform/projects/app-transition-postgresql/README.md
@@ -20,6 +20,7 @@ RDS Transition PostgreSQL Primary instance
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| skip_final_snapshot | Set to true to NOT create a final snapshot when the cluster is deleted. | string | - | yes |
 | snapshot_identifier | Specifies whether or not to create the database from this snapshot | string | `` | no |
 | stackname | Stackname | string | - | yes |
 | username | PostgreSQL username | string | - | yes |

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -46,6 +46,11 @@ variable "multi_az" {
   default     = false
 }
 
+variable "skip_final_snapshot" {
+  type        = "string"
+  description = "Set to true to NOT create a final snapshot when the cluster is deleted."
+}
+
 variable "snapshot_identifier" {
   type        = "string"
   description = "Specifies whether or not to create the database from this snapshot"
@@ -80,6 +85,7 @@ module "transition-postgresql-primary_rds_instance" {
   multi_az            = "${var.multi_az}"
   security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_transition-postgresql-primary_id}"]
   event_sns_topic_arn = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot = "${var.skip_final_snapshot}"
   snapshot_identifier = "${var.snapshot_identifier}"
 }
 
@@ -102,6 +108,7 @@ module "transition-postgresql-standby_rds_instance" {
   create_replicate_source_db = "1"
   replicate_source_db        = "${module.transition-postgresql-primary_rds_instance.rds_instance_id}"
   event_sns_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot        = "${var.skip_final_snapshot}"
 }
 
 resource "aws_route53_record" "replica_service_record" {

--- a/terraform/projects/app-warehouse/README.md
+++ b/terraform/projects/app-warehouse/README.md
@@ -19,6 +19,7 @@ RDS PostgreSQL instance for the GOV.UK data warehouse
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| skip_final_snapshot | Set to true to NOT create a final snapshot when the cluster is deleted. | string | - | yes |
 | snapshot_identifier | Specifies whether or not to create the database from this snapshot | string | `` | no |
 | stackname | Stackname | string | - | yes |
 | username | PostgreSQL username | string | - | yes |

--- a/terraform/projects/app-warehouse/main.tf
+++ b/terraform/projects/app-warehouse/main.tf
@@ -40,6 +40,11 @@ variable "multi_az" {
   default     = false
 }
 
+variable "skip_final_snapshot" {
+  type        = "string"
+  description = "Set to true to NOT create a final snapshot when the cluster is deleted."
+}
+
 variable "snapshot_identifier" {
   type        = "string"
   description = "Specifies whether or not to create the database from this snapshot"
@@ -74,6 +79,7 @@ module "warehouse-postgresql-primary_rds_instance" {
   multi_az            = "${var.multi_az}"
   security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_warehouse-postgresql-primary_id}"]
   event_sns_topic_arn = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot = "${var.skip_final_snapshot}"
   snapshot_identifier = "${var.snapshot_identifier}"
 }
 
@@ -96,6 +102,7 @@ module "warehouse-postgresql-standby_rds_instance" {
   create_replicate_source_db = "1"
   replicate_source_db        = "${module.warehouse-postgresql-primary_rds_instance.rds_instance_id}"
   event_sns_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot        = "${var.skip_final_snapshot}"
 }
 
 resource "aws_route53_record" "replica_service_record" {


### PR DESCRIPTION
The setting of [final snapshot](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_DeleteInstance.html) on an RDS instance was controlled by the `rds_instance` module which defaulted it to `true`. This wasn't being overridden by any of the database projects that used the module.

Change the default to `false` to match the Terraform and AWS default and make it production safe.

Add the same variable to each of the database projects.

There is a corresponding data PR to set the values per environment - https://github.com/alphagov/govuk-aws-data/pull/211