### PR TITLE
Refactor database-backups-bucket access policies

### DIFF
--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -151,10 +151,16 @@ resource "aws_iam_role_policy_attachment" "write_db-admin_database_backups_iam_r
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_write_database_backups_bucket_policy_arn}"
 }
 
-resource "aws_iam_role_policy_attachment" "read_db-admin_database_backups_iam_role_policy_attachment" {
-  count      = 1
+resource "aws_iam_role_policy_attachment" "read_integration_db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "integration" ? 1 : 0}"
   role       = "${module.db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_read_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.integration_dbadmin_read_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "read_staging_db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "staging" ? 1 : 0}"
+  role       = "${module.db-admin.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.staging_dbadmin_read_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_policy" "db-admin_iam_policy" {

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -248,10 +248,16 @@ resource "aws_iam_role_policy_attachment" "write_graphite_database_backups_iam_r
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.graphite_write_database_backups_bucket_policy_arn}"
 }
 
-resource "aws_iam_role_policy_attachment" "read_graphite_database_backups_iam_role_policy_attachment" {
-  count      = 1
+resource "aws_iam_role_policy_attachment" "read_integration_graphite_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "integration" ? 1 : 0}"
   role       = "${module.graphite-1.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.graphite_read_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.integration_graphite_read_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "read_staging_graphite_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "staging" ? 1 : 0}"
+  role       = "${module.graphite-1.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.staging_graphite_read_database_backups_bucket_policy_arn}"
 }
 
 data "terraform_remote_state" "infra_database_backups_bucket" {

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -294,10 +294,16 @@ resource "aws_iam_role_policy_attachment" "write_router-backend_database_backups
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.mongo_router_write_database_backups_bucket_policy_arn}"
 }
 
-resource "aws_iam_role_policy_attachment" "read_router-backend_database_backups_iam_role_policy_attachment" {
-  count      = 3
+resource "aws_iam_role_policy_attachment" "read_integration_router-backend_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "integration" ? 3 : 0}"
   role       = "${element(list(module.router-backend-1.instance_iam_role_name, module.router-backend-2.instance_iam_role_name, module.router-backend-3.instance_iam_role_name), count.index)}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.mongo_router_read_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.integration_mongo_router_read_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "read_staging_router-backend_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "staging" ? 3 : 0}"
+  role       = "${element(list(module.router-backend-1.instance_iam_role_name, module.router-backend-2.instance_iam_role_name, module.router-backend-3.instance_iam_role_name), count.index)}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.staging_mongo_router_read_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_policy" "router-backend_iam_policy" {

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -135,10 +135,16 @@ resource "aws_iam_role_policy_attachment" "write_transition-db-admin_database_ba
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.transition_dbadmin_write_database_backups_bucket_policy_arn}"
 }
 
-resource "aws_iam_role_policy_attachment" "read_transition-db-admin_database_backups_iam_role_policy_attachment" {
-  count      = 1
+resource "aws_iam_role_policy_attachment" "read_integration_transition-db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "integration" ? 1 : 0}"
   role       = "${module.transition-db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.transition_dbadmin_read_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.integration_transition_dbadmin_read_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "read_staging_transition-db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "staging" ? 1 : 0}"
+  role       = "${module.transition-db-admin.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.staging_transition_dbadmin_read_database_backups_bucket_policy_arn}"
 }
 
 # Outputs

--- a/terraform/projects/app-warehouse-db-admin/main.tf
+++ b/terraform/projects/app-warehouse-db-admin/main.tf
@@ -135,10 +135,16 @@ resource "aws_iam_role_policy_attachment" "write_warehouse-db-admin_database_bac
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.warehouse_dbadmin_write_database_backups_bucket_policy_arn}"
 }
 
-resource "aws_iam_role_policy_attachment" "read_warehouse-db-admin_database_backups_iam_role_policy_attachment" {
-  count      = 1
+resource "aws_iam_role_policy_attachment" "read_integration_warehouse-db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "integration" ? 1 : 0}"
   role       = "${module.warehouse-db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.warehouse_dbadmin_read_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.integration_warehouse_dbadmin_read_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "read_staging_warehouse-db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "staging" ? 1 : 0}"
+  role       = "${module.warehouse-db-admin.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.staging_warehouse_dbadmin_read_database_backups_bucket_policy_arn}"
 }
 
 # Outputs

--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -22,24 +22,44 @@ database-backups: The bucket that will hold database backups
 
 | Name | Description |
 |------|-------------|
-| dbadmin_read_database_backups_bucket_policy_arn | ARN of the read DBAdmin database_backups-bucket policy |
 | dbadmin_write_database_backups_bucket_policy_arn | ARN of the DBAdmin write database_backups-bucket policy |
-| elasticsearch_read_database_backups_bucket_policy_arn | ARN of the read elasticsearch database_backups-bucket policy |
 | elasticsearch_write_database_backups_bucket_policy_arn | ARN of the elasticsearch write database_backups-bucket policy |
-| email-alert-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the read EmailAlertAPUDBAdmin database_backups-bucket policy |
 | email-alert-api_dbadmin_write_database_backups_bucket_policy_arn | ARN of the EmailAlertAPIDBAdmin write database_backups-bucket policy |
-| graphite_read_database_backups_bucket_policy_arn | ARN of the read Graphite database_backups-bucket policy |
 | graphite_write_database_backups_bucket_policy_arn | ARN of the Graphite write database_backups-bucket policy |
-| mongo_api_read_database_backups_bucket_policy_arn | ARN of the read mongo-api database_backups-bucket policy |
+| integration_dbadmin_read_database_backups_bucket_policy_arn | ARN of the integration read DBAdmin database_backups-bucket policy |
+| integration_elasticsearch_read_database_backups_bucket_policy_arn | ARN of the integration read elasticsearch database_backups-bucket policy |
+| integration_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the integration read EmailAlertAPUDBAdmin database_backups-bucket policy |
+| integration_graphite_read_database_backups_bucket_policy_arn | ARN of the integration read Graphite database_backups-bucket policy |
+| integration_mongo_api_read_database_backups_bucket_policy_arn | ARN of the integration read mongo-api database_backups-bucket policy |
+| integration_mongo_router_read_database_backups_bucket_policy_arn | ARN of the integration read router_backend database_backups-bucket policy |
+| integration_mongodb_read_database_backups_bucket_policy_arn | ARN of the integration read mongodb database_backups-bucket policy |
+| integration_publishing-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the integration read publishing-apiDBAdmin database_backups-bucket policy |
+| integration_transition_dbadmin_read_database_backups_bucket_policy_arn | ARN of the integration read TransitionDBAdmin database_backups-bucket policy |
+| integration_warehouse_dbadmin_read_database_backups_bucket_policy_arn | ARN of the integration read WarehouseDBAdmin database_backups-bucket policy |
 | mongo_api_write_database_backups_bucket_policy_arn | ARN of the mongo-api write database_backups-bucket policy |
-| mongo_router_read_database_backups_bucket_policy_arn | ARN of the read router_backend database_backups-bucket policy |
 | mongo_router_write_database_backups_bucket_policy_arn | ARN of the router_backend write database_backups-bucket policy |
-| mongodb_read_database_backups_bucket_policy_arn | ARN of the read mongodb database_backups-bucket policy |
 | mongodb_write_database_backups_bucket_policy_arn | ARN of the mongodb write database_backups-bucket policy |
-| publishing-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the read publishing-apiDBAdmin database_backups-bucket policy |
+| production_dbadmin_read_database_backups_bucket_policy_arn | ARN of the production read DBAdmin database_backups-bucket policy |
+| production_elasticsearch_read_database_backups_bucket_policy_arn | ARN of the production read elasticsearch database_backups-bucket policy |
+| production_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the production read EmailAlertAPUDBAdmin database_backups-bucket policy |
+| production_graphite_read_database_backups_bucket_policy_arn | ARN of the production read Graphite database_backups-bucket policy |
+| production_mongo_api_read_database_backups_bucket_policy_arn | ARN of the production read mongo-api database_backups-bucket policy |
+| production_mongo_router_read_database_backups_bucket_policy_arn | ARN of the production read router_backend database_backups-bucket policy |
+| production_mongodb_read_database_backups_bucket_policy_arn | ARN of the production read mongodb database_backups-bucket policy |
+| production_publishing-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the production read publishing-apiDBAdmin database_backups-bucket policy |
+| production_transition_dbadmin_read_database_backups_bucket_policy_arn | ARN of the production read TransitionDBAdmin database_backups-bucket policy |
+| production_warehouse_dbadmin_read_database_backups_bucket_policy_arn | ARN of the production read WarehouseDBAdmin database_backups-bucket policy |
 | publishing-api_dbadmin_write_database_backups_bucket_policy_arn | ARN of the publishing-apiDBAdmin write database_backups-bucket policy |
-| transition_dbadmin_read_database_backups_bucket_policy_arn | ARN of the read TransitionDBAdmin database_backups-bucket policy |
+| staging_dbadmin_read_database_backups_bucket_policy_arn | ARN of the staging read DBAdmin database_backups-bucket policy |
+| staging_elasticsearch_read_database_backups_bucket_policy_arn | ARN of the staging read elasticsearch database_backups-bucket policy |
+| staging_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the staging read EmailAlertAPUDBAdmin database_backups-bucket policy |
+| staging_graphite_read_database_backups_bucket_policy_arn | ARN of the staging read Graphite database_backups-bucket policy |
+| staging_mongo_api_read_database_backups_bucket_policy_arn | ARN of the staging read mongo-api database_backups-bucket policy |
+| staging_mongo_router_read_database_backups_bucket_policy_arn | ARN of the staging read router_backend database_backups-bucket policy |
+| staging_mongodb_read_database_backups_bucket_policy_arn | ARN of the staging read mongodb database_backups-bucket policy |
+| staging_publishing-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the staging read publishing-apiDBAdmin database_backups-bucket policy |
+| staging_transition_dbadmin_read_database_backups_bucket_policy_arn | ARN of the staging read TransitionDBAdmin database_backups-bucket policy |
+| staging_warehouse_dbadmin_read_database_backups_bucket_policy_arn | ARN of the staging read WarehouseDBAdmin database_backups-bucket policy |
 | transition_dbadmin_write_database_backups_bucket_policy_arn | ARN of the TransitionDBAdmin write database_backups-bucket policy |
-| warehouse_dbadmin_read_database_backups_bucket_policy_arn | ARN of the read WarehouseDBAdmin database_backups-bucket policy |
 | warehouse_dbadmin_write_database_backups_bucket_policy_arn | ARN of the WarehouseDBAdmin write database_backups-bucket policy |
 

--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -8,13 +8,13 @@
 *
 */
 
-resource "aws_iam_policy" "mongo_api_database_backups_reader" {
-  name        = "govuk-${var.aws_environment}-mongo-api_database_backups-reader-policy"
-  policy      = "${data.aws_iam_policy_document.mongo_api_database_backups_reader.json}"
+resource "aws_iam_policy" "integration_mongo_api_database_backups_reader" {
+  name        = "govuk-integration-mongo-api_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.integration_mongo_api_database_backups_reader.json}"
   description = "Allows reading the mongo-api database_backups bucket"
 }
 
-data "aws_iam_policy_document" "mongo_api_database_backups_reader" {
+data "aws_iam_policy_document" "integration_mongo_api_database_backups_reader" {
   statement {
     sid = "MongoAPIReadBucket"
 
@@ -25,19 +25,19 @@ data "aws_iam_policy_document" "mongo_api_database_backups_reader" {
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mongo-api*",
+      "arn:aws:s3:::govuk-integration-database-backups",
+      "arn:aws:s3:::govuk-integration-database-backups/*mongo-api*",
     ]
   }
 }
 
-resource "aws_iam_policy" "mongo_router_database_backups_reader" {
-  name        = "govuk-${var.aws_environment}-mongo-router_database_backups-reader-policy"
-  policy      = "${data.aws_iam_policy_document.mongo_router_database_backups_reader.json}"
+resource "aws_iam_policy" "integration_mongo_router_database_backups_reader" {
+  name        = "govuk-integration-mongo-router_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.integration_mongo_router_database_backups_reader.json}"
   description = "Allows reading the mongo-router database_backups bucket"
 }
 
-data "aws_iam_policy_document" "mongo_router_database_backups_reader" {
+data "aws_iam_policy_document" "integration_mongo_router_database_backups_reader" {
   statement {
     sid = "MongoRouterReadBucket"
 
@@ -48,20 +48,20 @@ data "aws_iam_policy_document" "mongo_router_database_backups_reader" {
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*router_backend*",
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mongo-router*",
+      "arn:aws:s3:::govuk-integration-database-backups",
+      "arn:aws:s3:::govuk-integration-database-backups/*router_backend*",
+      "arn:aws:s3:::govuk-integration-database-backups/*mongo-router*",
     ]
   }
 }
 
-resource "aws_iam_policy" "mongodb_database_backups_reader" {
-  name        = "govuk-${var.aws_environment}-mongodb_database_backups-reader-policy"
-  policy      = "${data.aws_iam_policy_document.mongodb_database_backups_reader.json}"
+resource "aws_iam_policy" "integration_mongodb_database_backups_reader" {
+  name        = "govuk-integration-mongodb_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.integration_mongodb_database_backups_reader.json}"
   description = "Allows reading the mongodb database_backups bucket"
 }
 
-data "aws_iam_policy_document" "mongodb_database_backups_reader" {
+data "aws_iam_policy_document" "integration_mongodb_database_backups_reader" {
   statement {
     sid = "MongoDBReadBucket"
 
@@ -72,19 +72,19 @@ data "aws_iam_policy_document" "mongodb_database_backups_reader" {
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mongo*",
+      "arn:aws:s3:::govuk-integration-database-backups",
+      "arn:aws:s3:::govuk-integration-database-backups/*mongo*",
     ]
   }
 }
 
-resource "aws_iam_policy" "elasticsearch_database_backups_reader" {
-  name        = "govuk-${var.aws_environment}-elasticsearch_database_backups-reader-policy"
-  policy      = "${data.aws_iam_policy_document.elasticsearch_database_backups_reader.json}"
+resource "aws_iam_policy" "integration_elasticsearch_database_backups_reader" {
+  name        = "govuk-integration-elasticsearch_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.integration_elasticsearch_database_backups_reader.json}"
   description = "Allows reading the elasticsearch database_backups bucket"
 }
 
-data "aws_iam_policy_document" "elasticsearch_database_backups_reader" {
+data "aws_iam_policy_document" "integration_elasticsearch_database_backups_reader" {
   statement {
     sid = "ElasticsearchReadBucket"
 
@@ -95,19 +95,19 @@ data "aws_iam_policy_document" "elasticsearch_database_backups_reader" {
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*elasticsearch*",
+      "arn:aws:s3:::govuk-integration-database-backups",
+      "arn:aws:s3:::govuk-integration-database-backups/*elasticsearch*",
     ]
   }
 }
 
-resource "aws_iam_policy" "dbadmin_database_backups_reader" {
-  name        = "govuk-${var.aws_environment}-dbadmin_database_backups-reader-policy"
-  policy      = "${data.aws_iam_policy_document.dbadmin_database_backups_reader.json}"
+resource "aws_iam_policy" "integration_dbadmin_database_backups_reader" {
+  name        = "govuk-integration-dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.integration_dbadmin_database_backups_reader.json}"
   description = "Allows reading the dbadmin database_backups bucket"
 }
 
-data "aws_iam_policy_document" "dbadmin_database_backups_reader" {
+data "aws_iam_policy_document" "integration_dbadmin_database_backups_reader" {
   statement {
     sid = "DBAdminReadBucket"
 
@@ -118,20 +118,20 @@ data "aws_iam_policy_document" "dbadmin_database_backups_reader" {
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mysql*",
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*postgres*",
+      "arn:aws:s3:::govuk-integration-database-backups",
+      "arn:aws:s3:::govuk-integration-database-backups/*mysql*",
+      "arn:aws:s3:::govuk-integration-database-backups/*postgres*",
     ]
   }
 }
 
-resource "aws_iam_policy" "transition_dbadmin_database_backups_reader" {
-  name        = "govuk-${var.aws_environment}-transition_dbadmin_database_backups-reader-policy"
-  policy      = "${data.aws_iam_policy_document.transition_dbadmin_database_backups_reader.json}"
+resource "aws_iam_policy" "integration_transition_dbadmin_database_backups_reader" {
+  name        = "govuk-integration-transition_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.integration_transition_dbadmin_database_backups_reader.json}"
   description = "Allows reading the transition_dbadmin database_backups bucket"
 }
 
-data "aws_iam_policy_document" "transition_dbadmin_database_backups_reader" {
+data "aws_iam_policy_document" "integration_transition_dbadmin_database_backups_reader" {
   statement {
     sid = "TransitionDBAdminReadBucket"
 
@@ -142,19 +142,19 @@ data "aws_iam_policy_document" "transition_dbadmin_database_backups_reader" {
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*transition-postgres*",
+      "arn:aws:s3:::govuk-integration-database-backups",
+      "arn:aws:s3:::govuk-integration-database-backups/*transition-postgres*",
     ]
   }
 }
 
-resource "aws_iam_policy" "warehouse_dbadmin_database_backups_reader" {
-  name        = "govuk-${var.aws_environment}-warehouse_dbadmin_database_backups-reader-policy"
-  policy      = "${data.aws_iam_policy_document.warehouse_dbadmin_database_backups_reader.json}"
+resource "aws_iam_policy" "integration_warehouse_dbadmin_database_backups_reader" {
+  name        = "govuk-integration-warehouse_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.integration_warehouse_dbadmin_database_backups_reader.json}"
   description = "Allows reading the warehouse_dbadmin database_backups bucket"
 }
 
-data "aws_iam_policy_document" "warehouse_dbadmin_database_backups_reader" {
+data "aws_iam_policy_document" "integration_warehouse_dbadmin_database_backups_reader" {
   statement {
     sid = "WarehouseDBAdminReadBucket"
 
@@ -165,19 +165,19 @@ data "aws_iam_policy_document" "warehouse_dbadmin_database_backups_reader" {
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*warehouse-postgres*",
+      "arn:aws:s3:::govuk-integration-database-backups",
+      "arn:aws:s3:::govuk-integration-database-backups/*warehouse-postgres*",
     ]
   }
 }
 
-resource "aws_iam_policy" "publishing-api_dbadmin_database_backups_reader" {
-  name        = "govuk-${var.aws_environment}-publishing-api_dbadmin_database_backups-reader-policy"
-  policy      = "${data.aws_iam_policy_document.publishing-api_dbadmin_database_backups_reader.json}"
+resource "aws_iam_policy" "integration_publishing-api_dbadmin_database_backups_reader" {
+  name        = "govuk-integration-publishing-api_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.integration_publishing-api_dbadmin_database_backups_reader.json}"
   description = "Allows reading the publishing-api_dbadmin database_backups bucket"
 }
 
-data "aws_iam_policy_document" "publishing-api_dbadmin_database_backups_reader" {
+data "aws_iam_policy_document" "integration_publishing-api_dbadmin_database_backups_reader" {
   statement {
     sid = "publishingApiDBAdminReadBucket"
 
@@ -188,19 +188,19 @@ data "aws_iam_policy_document" "publishing-api_dbadmin_database_backups_reader" 
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*publishing-api-postgres*",
+      "arn:aws:s3:::govuk-integration-database-backups",
+      "arn:aws:s3:::govuk-integration-database-backups/*publishing-api-postgres*",
     ]
   }
 }
 
-resource "aws_iam_policy" "email-alert-api_dbadmin_database_backups_reader" {
-  name        = "govuk-${var.aws_environment}-email-alert-api_dbadmin_database_backups-reader-policy"
-  policy      = "${data.aws_iam_policy_document.email-alert-api_dbadmin_database_backups_reader.json}"
+resource "aws_iam_policy" "integration_email-alert-api_dbadmin_database_backups_reader" {
+  name        = "govuk-integration-email-alert-api_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.integration_email-alert-api_dbadmin_database_backups_reader.json}"
   description = "Allows reading the email-alert-api_dbadmin database_backups bucket"
 }
 
-data "aws_iam_policy_document" "email-alert-api_dbadmin_database_backups_reader" {
+data "aws_iam_policy_document" "integration_email-alert-api_dbadmin_database_backups_reader" {
   statement {
     sid = "EmailAlertAPIDBAdminReadBucket"
 
@@ -211,19 +211,19 @@ data "aws_iam_policy_document" "email-alert-api_dbadmin_database_backups_reader"
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*email-alert-api-postgres*",
+      "arn:aws:s3:::govuk-integration-database-backups",
+      "arn:aws:s3:::govuk-integration-database-backups/*email-alert-api-postgres*",
     ]
   }
 }
 
-resource "aws_iam_policy" "graphite_database_backups_reader" {
-  name        = "govuk-${var.aws_environment}-graphite_database_backups-reader-policy"
-  policy      = "${data.aws_iam_policy_document.graphite_database_backups_reader.json}"
+resource "aws_iam_policy" "integration_graphite_database_backups_reader" {
+  name        = "govuk-integration-graphite_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.integration_graphite_database_backups_reader.json}"
   description = "Allows reading the graphite database_backups bucket"
 }
 
-data "aws_iam_policy_document" "graphite_database_backups_reader" {
+data "aws_iam_policy_document" "integration_graphite_database_backups_reader" {
   statement {
     sid = "GraphiteReadBucket"
 
@@ -234,58 +234,622 @@ data "aws_iam_policy_document" "graphite_database_backups_reader" {
 
     # Need access to the top level of the tree.
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*whisper*",
+      "arn:aws:s3:::govuk-integration-database-backups",
+      "arn:aws:s3:::govuk-integration-database-backups/*whisper*",
     ]
   }
 }
 
-output "mongo_api_read_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.mongo_api_database_backups_reader.arn}"
-  description = "ARN of the read mongo-api database_backups-bucket policy"
+resource "aws_iam_policy" "staging_mongo_api_database_backups_reader" {
+  name        = "govuk-staging-mongo-api_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.staging_mongo_api_database_backups_reader.json}"
+  description = "Allows reading the mongo-api database_backups bucket"
 }
 
-output "mongo_router_read_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.mongo_router_database_backups_reader.arn}"
-  description = "ARN of the read router_backend database_backups-bucket policy"
+data "aws_iam_policy_document" "staging_mongo_api_database_backups_reader" {
+  statement {
+    sid = "MongoAPIReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-staging-database-backups",
+      "arn:aws:s3:::govuk-staging-database-backups/*mongo-api*",
+    ]
+  }
 }
 
-output "mongodb_read_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.mongodb_database_backups_reader.arn}"
-  description = "ARN of the read mongodb database_backups-bucket policy"
+resource "aws_iam_policy" "staging_mongo_router_database_backups_reader" {
+  name        = "govuk-staging-mongo-router_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.staging_mongo_router_database_backups_reader.json}"
+  description = "Allows reading the mongo-router database_backups bucket"
 }
 
-output "elasticsearch_read_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.elasticsearch_database_backups_reader.arn}"
-  description = "ARN of the read elasticsearch database_backups-bucket policy"
+data "aws_iam_policy_document" "staging_mongo_router_database_backups_reader" {
+  statement {
+    sid = "MongoRouterReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-staging-database-backups",
+      "arn:aws:s3:::govuk-staging-database-backups/*router_backend*",
+      "arn:aws:s3:::govuk-staging-database-backups/*mongo-router*",
+    ]
+  }
 }
 
-output "dbadmin_read_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.dbadmin_database_backups_reader.arn}"
-  description = "ARN of the read DBAdmin database_backups-bucket policy"
+resource "aws_iam_policy" "staging_mongodb_database_backups_reader" {
+  name        = "govuk-staging-mongodb_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.staging_mongodb_database_backups_reader.json}"
+  description = "Allows reading the mongodb database_backups bucket"
 }
 
-output "transition_dbadmin_read_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.transition_dbadmin_database_backups_reader.arn}"
-  description = "ARN of the read TransitionDBAdmin database_backups-bucket policy"
+data "aws_iam_policy_document" "staging_mongodb_database_backups_reader" {
+  statement {
+    sid = "MongoDBReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-staging-database-backups",
+      "arn:aws:s3:::govuk-staging-database-backups/*mongo*",
+    ]
+  }
 }
 
-output "publishing-api_dbadmin_read_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.publishing-api_dbadmin_database_backups_reader.arn}"
-  description = "ARN of the read publishing-apiDBAdmin database_backups-bucket policy"
+resource "aws_iam_policy" "staging_elasticsearch_database_backups_reader" {
+  name        = "govuk-staging-elasticsearch_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.staging_elasticsearch_database_backups_reader.json}"
+  description = "Allows reading the elasticsearch database_backups bucket"
 }
 
-output "warehouse_dbadmin_read_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.warehouse_dbadmin_database_backups_reader.arn}"
-  description = "ARN of the read WarehouseDBAdmin database_backups-bucket policy"
+data "aws_iam_policy_document" "staging_elasticsearch_database_backups_reader" {
+  statement {
+    sid = "ElasticsearchReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-staging-database-backups",
+      "arn:aws:s3:::govuk-staging-database-backups/*elasticsearch*",
+    ]
+  }
 }
 
-output "email-alert-api_dbadmin_read_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.email-alert-api_dbadmin_database_backups_reader.arn}"
-  description = "ARN of the read EmailAlertAPUDBAdmin database_backups-bucket policy"
+resource "aws_iam_policy" "staging_dbadmin_database_backups_reader" {
+  name        = "govuk-staging-dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.staging_dbadmin_database_backups_reader.json}"
+  description = "Allows reading the dbadmin database_backups bucket"
 }
 
-output "graphite_read_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.graphite_database_backups_reader.arn}"
-  description = "ARN of the read Graphite database_backups-bucket policy"
+data "aws_iam_policy_document" "staging_dbadmin_database_backups_reader" {
+  statement {
+    sid = "DBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-staging-database-backups",
+      "arn:aws:s3:::govuk-staging-database-backups/*mysql*",
+      "arn:aws:s3:::govuk-staging-database-backups/*postgres*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "staging_transition_dbadmin_database_backups_reader" {
+  name        = "govuk-staging-transition_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.staging_transition_dbadmin_database_backups_reader.json}"
+  description = "Allows reading the transition_dbadmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "staging_transition_dbadmin_database_backups_reader" {
+  statement {
+    sid = "TransitionDBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-staging-database-backups",
+      "arn:aws:s3:::govuk-staging-database-backups/*transition-postgres*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "staging_warehouse_dbadmin_database_backups_reader" {
+  name        = "govuk-staging-warehouse_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.staging_warehouse_dbadmin_database_backups_reader.json}"
+  description = "Allows reading the warehouse_dbadmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "staging_warehouse_dbadmin_database_backups_reader" {
+  statement {
+    sid = "WarehouseDBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-staging-database-backups",
+      "arn:aws:s3:::govuk-staging-database-backups/*warehouse-postgres*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "staging_publishing-api_dbadmin_database_backups_reader" {
+  name        = "govuk-staging-publishing-api_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.staging_publishing-api_dbadmin_database_backups_reader.json}"
+  description = "Allows reading the publishing-api_dbadmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "staging_publishing-api_dbadmin_database_backups_reader" {
+  statement {
+    sid = "publishingApiDBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-staging-database-backups",
+      "arn:aws:s3:::govuk-staging-database-backups/*publishing-api-postgres*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "staging_email-alert-api_dbadmin_database_backups_reader" {
+  name        = "govuk-staging-email-alert-api_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.staging_email-alert-api_dbadmin_database_backups_reader.json}"
+  description = "Allows reading the email-alert-api_dbadmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "staging_email-alert-api_dbadmin_database_backups_reader" {
+  statement {
+    sid = "EmailAlertAPIDBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-staging-database-backups",
+      "arn:aws:s3:::govuk-staging-database-backups/*email-alert-api-postgres*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "staging_graphite_database_backups_reader" {
+  name        = "govuk-staging-graphite_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.staging_graphite_database_backups_reader.json}"
+  description = "Allows reading the graphite database_backups bucket"
+}
+
+data "aws_iam_policy_document" "staging_graphite_database_backups_reader" {
+  statement {
+    sid = "GraphiteReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-staging-database-backups",
+      "arn:aws:s3:::govuk-staging-database-backups/*whisper*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "production_mongo_api_database_backups_reader" {
+  name        = "govuk-production-mongo-api_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.production_mongo_api_database_backups_reader.json}"
+  description = "Allows reading the mongo-api database_backups bucket"
+}
+
+data "aws_iam_policy_document" "production_mongo_api_database_backups_reader" {
+  statement {
+    sid = "MongoAPIReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-production-database-backups",
+      "arn:aws:s3:::govuk-production-database-backups/*mongo-api*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "production_mongo_router_database_backups_reader" {
+  name        = "govuk-production-mongo-router_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.production_mongo_router_database_backups_reader.json}"
+  description = "Allows reading the mongo-router database_backups bucket"
+}
+
+data "aws_iam_policy_document" "production_mongo_router_database_backups_reader" {
+  statement {
+    sid = "MongoRouterReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-production-database-backups",
+      "arn:aws:s3:::govuk-production-database-backups/*router_backend*",
+      "arn:aws:s3:::govuk-production-database-backups/*mongo-router*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "production_mongodb_database_backups_reader" {
+  name        = "govuk-production-mongodb_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.production_mongodb_database_backups_reader.json}"
+  description = "Allows reading the mongodb database_backups bucket"
+}
+
+data "aws_iam_policy_document" "production_mongodb_database_backups_reader" {
+  statement {
+    sid = "MongoDBReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-production-database-backups",
+      "arn:aws:s3:::govuk-production-database-backups/*mongo*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "production_elasticsearch_database_backups_reader" {
+  name        = "govuk-production-elasticsearch_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.production_elasticsearch_database_backups_reader.json}"
+  description = "Allows reading the elasticsearch database_backups bucket"
+}
+
+data "aws_iam_policy_document" "production_elasticsearch_database_backups_reader" {
+  statement {
+    sid = "ElasticsearchReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-production-database-backups",
+      "arn:aws:s3:::govuk-production-database-backups/*elasticsearch*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "production_dbadmin_database_backups_reader" {
+  name        = "govuk-production-dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.production_dbadmin_database_backups_reader.json}"
+  description = "Allows reading the dbadmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "production_dbadmin_database_backups_reader" {
+  statement {
+    sid = "DBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-production-database-backups",
+      "arn:aws:s3:::govuk-production-database-backups/*mysql*",
+      "arn:aws:s3:::govuk-production-database-backups/*postgres*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "production_transition_dbadmin_database_backups_reader" {
+  name        = "govuk-production-transition_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.production_transition_dbadmin_database_backups_reader.json}"
+  description = "Allows reading the transition_dbadmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "production_transition_dbadmin_database_backups_reader" {
+  statement {
+    sid = "TransitionDBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-production-database-backups",
+      "arn:aws:s3:::govuk-production-database-backups/*transition-postgres*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "production_warehouse_dbadmin_database_backups_reader" {
+  name        = "govuk-production-warehouse_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.production_warehouse_dbadmin_database_backups_reader.json}"
+  description = "Allows reading the warehouse_dbadmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "production_warehouse_dbadmin_database_backups_reader" {
+  statement {
+    sid = "WarehouseDBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-production-database-backups",
+      "arn:aws:s3:::govuk-production-database-backups/*warehouse-postgres*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "production_publishing-api_dbadmin_database_backups_reader" {
+  name        = "govuk-production-publishing-api_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.production_publishing-api_dbadmin_database_backups_reader.json}"
+  description = "Allows reading the publishing-api_dbadmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "production_publishing-api_dbadmin_database_backups_reader" {
+  statement {
+    sid = "publishingApiDBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-production-database-backups",
+      "arn:aws:s3:::govuk-production-database-backups/*publishing-api-postgres*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "production_email-alert-api_dbadmin_database_backups_reader" {
+  name        = "govuk-production-email-alert-api_dbadmin_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.production_email-alert-api_dbadmin_database_backups_reader.json}"
+  description = "Allows reading the email-alert-api_dbadmin database_backups bucket"
+}
+
+data "aws_iam_policy_document" "production_email-alert-api_dbadmin_database_backups_reader" {
+  statement {
+    sid = "EmailAlertAPIDBAdminReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-production-database-backups",
+      "arn:aws:s3:::govuk-production-database-backups/*email-alert-api-postgres*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "production_graphite_database_backups_reader" {
+  name        = "govuk-production-graphite_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.production_graphite_database_backups_reader.json}"
+  description = "Allows reading the graphite database_backups bucket"
+}
+
+data "aws_iam_policy_document" "production_graphite_database_backups_reader" {
+  statement {
+    sid = "GraphiteReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-production-database-backups",
+      "arn:aws:s3:::govuk-production-database-backups/*whisper*",
+    ]
+  }
+}
+
+output "integration_mongo_api_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.integration_mongo_api_database_backups_reader.arn}"
+  description = "ARN of the integration read mongo-api database_backups-bucket policy"
+}
+
+output "integration_mongo_router_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.integration_mongo_router_database_backups_reader.arn}"
+  description = "ARN of the integration read router_backend database_backups-bucket policy"
+}
+
+output "integration_mongodb_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.integration_mongodb_database_backups_reader.arn}"
+  description = "ARN of the integration read mongodb database_backups-bucket policy"
+}
+
+output "integration_elasticsearch_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.integration_elasticsearch_database_backups_reader.arn}"
+  description = "ARN of the integration read elasticsearch database_backups-bucket policy"
+}
+
+output "integration_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.integration_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the integration read DBAdmin database_backups-bucket policy"
+}
+
+output "integration_transition_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.integration_transition_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the integration read TransitionDBAdmin database_backups-bucket policy"
+}
+
+output "integration_publishing-api_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.integration_publishing-api_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the integration read publishing-apiDBAdmin database_backups-bucket policy"
+}
+
+output "integration_warehouse_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.integration_warehouse_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the integration read WarehouseDBAdmin database_backups-bucket policy"
+}
+
+output "integration_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.integration_email-alert-api_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the integration read EmailAlertAPUDBAdmin database_backups-bucket policy"
+}
+
+output "integration_graphite_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.integration_graphite_database_backups_reader.arn}"
+  description = "ARN of the integration read Graphite database_backups-bucket policy"
+}
+
+output "staging_mongo_api_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.staging_mongo_api_database_backups_reader.arn}"
+  description = "ARN of the staging read mongo-api database_backups-bucket policy"
+}
+
+output "staging_mongo_router_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.staging_mongo_router_database_backups_reader.arn}"
+  description = "ARN of the staging read router_backend database_backups-bucket policy"
+}
+
+output "staging_mongodb_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.staging_mongodb_database_backups_reader.arn}"
+  description = "ARN of the staging read mongodb database_backups-bucket policy"
+}
+
+output "staging_elasticsearch_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.staging_elasticsearch_database_backups_reader.arn}"
+  description = "ARN of the staging read elasticsearch database_backups-bucket policy"
+}
+
+output "staging_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.staging_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the staging read DBAdmin database_backups-bucket policy"
+}
+
+output "staging_transition_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.staging_transition_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the staging read TransitionDBAdmin database_backups-bucket policy"
+}
+
+output "staging_publishing-api_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.staging_publishing-api_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the staging read publishing-apiDBAdmin database_backups-bucket policy"
+}
+
+output "staging_warehouse_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.staging_warehouse_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the staging read WarehouseDBAdmin database_backups-bucket policy"
+}
+
+output "staging_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.staging_email-alert-api_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the staging read EmailAlertAPUDBAdmin database_backups-bucket policy"
+}
+
+output "staging_graphite_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.staging_graphite_database_backups_reader.arn}"
+  description = "ARN of the staging read Graphite database_backups-bucket policy"
+}
+
+output "production_mongo_api_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.production_mongo_api_database_backups_reader.arn}"
+  description = "ARN of the production read mongo-api database_backups-bucket policy"
+}
+
+output "production_mongo_router_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.production_mongo_router_database_backups_reader.arn}"
+  description = "ARN of the production read router_backend database_backups-bucket policy"
+}
+
+output "production_mongodb_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.production_mongodb_database_backups_reader.arn}"
+  description = "ARN of the production read mongodb database_backups-bucket policy"
+}
+
+output "production_elasticsearch_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.production_elasticsearch_database_backups_reader.arn}"
+  description = "ARN of the production read elasticsearch database_backups-bucket policy"
+}
+
+output "production_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.production_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the production read DBAdmin database_backups-bucket policy"
+}
+
+output "production_transition_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.production_transition_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the production read TransitionDBAdmin database_backups-bucket policy"
+}
+
+output "production_publishing-api_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.production_publishing-api_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the production read publishing-apiDBAdmin database_backups-bucket policy"
+}
+
+output "production_warehouse_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.production_warehouse_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the production read WarehouseDBAdmin database_backups-bucket policy"
+}
+
+output "production_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.production_email-alert-api_dbadmin_database_backups_reader.arn}"
+  description = "ARN of the production read EmailAlertAPUDBAdmin database_backups-bucket policy"
+}
+
+output "production_graphite_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.production_graphite_database_backups_reader.arn}"
+  description = "ARN of the production read Graphite database_backups-bucket policy"
 }


### PR DESCRIPTION
- In order to grant cross-account access to buckets in multiple
environments (e.g. integration AND staging S3 access from integration) we
need to be able to manipulate policies in individual ways.

- We thus have removed the parametrised creation of these policies in
favour of explicit definition per environment.

pair: @issyl0 @schmie