### PR TITLE
Attach IAM reader policies to rummager-elasticsearch, publishing-api-db-admin and email-alert-api-db-admin

### DIFF
--- a/terraform/projects/app-email-alert-api-db-admin/main.tf
+++ b/terraform/projects/app-email-alert-api-db-admin/main.tf
@@ -153,10 +153,16 @@ resource "aws_iam_role_policy_attachment" "write_email-alert-api-db-admin_databa
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.email-alert-api_dbadmin_write_database_backups_bucket_policy_arn}"
 }
 
-resource "aws_iam_role_policy_attachment" "read_email-alert-api-db-admin_database_backups_iam_role_policy_attachment" {
-  count      = 1
+resource "aws_iam_role_policy_attachment" "integration_read_email-alert-api-db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "integration" ? 1 : 0}"
   role       = "${module.email-alert-api-db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.email-alert-api_dbadmin_read_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.integration_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "staging_read_email-alert-api-db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "staging" ? 1 : 0}"
+  role       = "${module.email-alert-api-db-admin.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.staging_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn}"
 }
 
 # Outputs

--- a/terraform/projects/app-publishing-api-db-admin/main.tf
+++ b/terraform/projects/app-publishing-api-db-admin/main.tf
@@ -135,10 +135,16 @@ resource "aws_iam_role_policy_attachment" "write_publishing-api-db-admin_databas
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.publishing-api_dbadmin_write_database_backups_bucket_policy_arn}"
 }
 
-resource "aws_iam_role_policy_attachment" "read_publishing-api-db-admin_database_backups_iam_role_policy_attachment" {
-  count      = 1
+resource "aws_iam_role_policy_attachment" "integration_read_publishing-api-db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "integration" ? 1 : 0}"
   role       = "${module.publishing-api-db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.publishing-api_dbadmin_read_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.integration_publishing-api_dbadmin_read_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "staging_read_publishing-api-db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "staging" ? 1 : 0}"
+  role       = "${module.publishing-api-db-admin.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.staging_publishing-api_dbadmin_read_database_backups_bucket_policy_arn}"
 }
 
 # Outputs

--- a/terraform/projects/app-rummager-elasticsearch/main.tf
+++ b/terraform/projects/app-rummager-elasticsearch/main.tf
@@ -278,10 +278,16 @@ resource "aws_iam_role_policy_attachment" "write_rummager-elasticsearch-1_databa
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.elasticsearch_write_database_backups_bucket_policy_arn}"
 }
 
-resource "aws_iam_role_policy_attachment" "read_rummager-elasticsearch-1_database_backups_iam_role_policy_attachment" {
-  count      = 3
+resource "aws_iam_role_policy_attachment" "integration_read_rummager-elasticsearch-1_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "integration" ? 3 : 0}"
   role       = "${element(list(module.rummager-elasticsearch-1.instance_iam_role_name, module.rummager-elasticsearch-2.instance_iam_role_name, module.rummager-elasticsearch-3.instance_iam_role_name), count.index)}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.elasticsearch_read_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.integration_elasticsearch_read_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "staging_read_rummager-elasticsearch-1_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "staging" ? 3 : 0}"
+  role       = "${element(list(module.rummager-elasticsearch-1.instance_iam_role_name, module.rummager-elasticsearch-2.instance_iam_role_name, module.rummager-elasticsearch-3.instance_iam_role_name), count.index)}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.staging_elasticsearch_read_database_backups_bucket_policy_arn}"
 }
 
 # Outputs


### PR DESCRIPTION
- The new db-admins don't exist everywhere yet, but they will when we
  rebuild, and to avoid errors we should do this.