### PR TITLE
Add user for AWS X-Ray daemon

### DIFF
--- a/terraform/projects/infra-monitoring/main.tf
+++ b/terraform/projects/infra-monitoring/main.tf
@@ -228,20 +228,33 @@ resource "aws_sqs_queue_policy" "notifications_sqs_queue_policy" {
 }
 
 #
-# Create an IAM role which allows the AWS X-Ray daemon to upload trace data to
-# AWS X-Ray (only required while trace data is sent from Carrenza)
+# Create an IAM user and role which allows the AWS X-Ray daemon to upload trace
+# data to AWS X-Ray (only required while trace data is sent from Carrenza)
 #
-
-resource "aws_iam_role" "xray_daemon_role" {
-  name               = "${var.stackname}-xray-daemon-traces"
-  path               = "/"
-  assume_role_policy = "${file("${path.module}/../../policies/xray_traces_assume_policy.json")}"
-}
 
 resource "aws_iam_policy" "xray_daemon_policy" {
   name   = "${var.stackname}-xray-daemon-traces-policy"
   path   = "/"
   policy = "${file("${path.module}/../../policies/xray_traces_policy.json")}"
+}
+
+resource "aws_iam_role" "xray_daemon_role" {
+  name               = "${var.stackname}-xray-daemon-traces"
+  assume_role_policy = "${file("${path.module}/../../policies/xray_traces_assume_policy.json")}"
+}
+
+resource "aws_iam_role_policy_attachment" "xray_daemon_role_policy_attachment" {
+  role       = "${aws_iam_role.xray_daemon_role.name}"
+  policy_arn = "${aws_iam_policy.xray_daemon_policy.arn}"
+}
+
+resource "aws_iam_user" "xray_daemon_user" {
+  name = "govuk-xray-daemon"
+}
+
+resource "aws_iam_policy_attachment" "xray_daemon_user_policy_attachment" {
+  users      = ["${aws_iam_user.xray_daemon_user.name}"]
+  policy_arn = "${aws_iam_policy.xray_daemon_policy.arn}"
 }
 
 # Outputs


### PR DESCRIPTION
This commit adds a user that will be used to generate an access key and secret key for the AWS X-Ray daemon. It also correctly attaches the policy to the existing role.

Trello: https://trello.com/c/YMZBPMGF/450-provision-x-ray-and-set-up-permissions-%F0%9F%8D%90-portunity