### PR TITLE
Grant more S3 permissions on Athena output bucket

### DIFF
--- a/terraform/policies/transition_executor_policy.tpl
+++ b/terraform/policies/transition_executor_policy.tpl
@@ -43,6 +43,12 @@
     {
        "Effect":"Allow",
        "Action":[
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads",
+          "s3:ListMultipartUploadParts",
+          "s3:AbortMultipartUpload",
           "s3:PutObject"
        ],
        "Resource":[


### PR DESCRIPTION
The query is failing in production with:

> Unable to verify/create output bucket
> govuk-production-transition-fastly-logs

So this commit grants the same S3 permissions on the output bucket as
the AmazonAthenaFullAccess example policy, other than s3:CreateBucket.
There's no need to grant s3:CreateBucket as the bucket already exists.

https://docs.aws.amazon.com/athena/latest/ug/access.html

---

[Trello card](https://trello.com/c/dNtEfmJM/395-move-transition-hit-stats-processing-to-s3-and-athena-%F0%9F%8D%90-portunity)