### PR TITLE
Refactor puppetmaster bootstrap

### DIFF
--- a/tools/govuk-puppetmaster-bootstrap.sh
+++ b/tools/govuk-puppetmaster-bootstrap.sh
@@ -35,11 +35,11 @@ apt-get -y install git
 apt-get -y install python3-pip
 
 # Create required directories
-mkdir -p ${GPG_KEYSTORE}
-mkdir -p ${SSH_KEYSTORE}
-mkdir -p ${GOVUK_LOGDIR}
+mkdir -p "${GPG_KEYSTORE}"
+mkdir -p "${SSH_KEYSTORE}"
+mkdir -p "${GOVUK_LOGDIR}"
 
-cd ${GOVUK_WORKDIR}
+cd "${GOVUK_WORKDIR}" || exit
 
 # Function to access the AWS SSM parameter store and extract SecureString values from returned JSON
 function get_ssm_parameter ()
@@ -47,7 +47,7 @@ function get_ssm_parameter ()
 set +x
     SSM_PARAMETER_NAME=$2
     SSM_PARAMETER=$(aws --region=${AWS_REGION} ssm get-parameter --name "${SSM_PARAMETER_NAME}" --with-decryption | jq .Parameter.Value | sed -e "s/^\"//;s/\"$//")
-    echo ${SSM_PARAMETER}
+    echo "${SSM_PARAMETER}"
 set -x
 }
 
@@ -93,9 +93,9 @@ fi
 
 # Move puppet release to the expected location
 mkdir -p /usr/share/puppet/production/releases
-mv ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO} /usr/share/puppet/production/releases/${RELEASENAME}
-rm -f /usr/share/puppet/production/current
-ln -s /usr/share/puppet/production/releases/${RELEASENAME} /usr/share/puppet/production/current
+mv "${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}" "/usr/share/puppet/production/releases/${RELEASENAME}"
+rm -f "/usr/share/puppet/production/current"
+ln -s "/usr/share/puppet/production/releases/${RELEASENAME}" "/usr/share/puppet/production/current"
 # We only want the permissions applied to the deepest directory, so is correct
 # behaviour.
 # shellcheck disable=SC2174
@@ -106,14 +106,14 @@ chown -R puppet: /etc/puppet/gpg
 # Install Ruby dependencies for first puppet apply
 gem install --no-ri --no-rdoc hiera-eyaml-gpg gpgme
 
-cd /usr/share/puppet/production/current/
+cd "/usr/share/puppet/production/current/" || exit
 
 # Installing Puppet dependencies
 bundle install
 bundle exec rake librarian:install
 
-cd ${GOVUK_WORKDIR}
+cd "${GOVUK_WORKDIR}" || exit
 
 # Self-configure puppet
 puppet apply --verbose --trusted_node_data --hiera_config=/usr/share/puppet/production/current/hiera_aws.yml --modulepath=/usr/share/puppet/production/current/modules:/usr/share/puppet/production/current/vendor/modules/ --manifestdir=/usr/share/puppet/production/current/manifests /usr/share/puppet/production/current/manifests/site.pp >> ${GOVUK_LOGDIR}/govuk_puppet_apply.log 2>&1
-chown -R deploy:deploy /usr/share/puppet/production/releases/${RELEASENAME}
+chown -R deploy:deploy "/usr/share/puppet/production/releases/${RELEASENAME}"

--- a/tools/govuk-puppetmaster-bootstrap.sh
+++ b/tools/govuk-puppetmaster-bootstrap.sh
@@ -6,14 +6,6 @@
 set -x
 set -u
 
-GIT_BINARY='/usr/bin/git'
-AWS_BINARY='/usr/local/bin/aws'
-BUNDLE_BINARY='/usr/bin/bundle'
-RAKE_BINARY='/usr/local/bin/rake'
-GEM_BINARY='/usr/bin/gem'
-PUPPET_BINARY='/usr/local/bin/puppet'
-GPG_BINARY='/usr/bin/gpg'
-
 GOVUK_ENVIRONMENT='staging'
 GOVUK_STACKNAME='blue'
 
@@ -53,8 +45,8 @@ cd ${GOVUK_WORKDIR}
 function get_ssm_parameter ()
 {
 set +x
-    SSM_PARAMETER_NAME=$1
-    SSM_PARAMETER=$(${AWS_BINARY} --region=${AWS_REGION} ssm get-parameter --name "${SSM_PARAMETER_NAME}" --with-decryption | jq .Parameter.Value | sed -e "s/^\"//;s/\"$//")
+    SSM_PARAMETER_NAME=$2
+    SSM_PARAMETER=$(aws --region=${AWS_REGION} ssm get-parameter --name "${SSM_PARAMETER_NAME}" --with-decryption | jq .Parameter.Value | sed -e "s/^\"//;s/\"$//")
     echo ${SSM_PARAMETER}
 set -x
 }
@@ -77,10 +69,10 @@ chmod 600 ${GPG_KEYSTORE}/${GPG_KEYNAME}
 set -x
 
 # Clone Puppet repo
-${GIT_BINARY} clone ${GOVUK_GIT_URL}/${GOVUK_PUPPET_REPO}
+git clone ${GOVUK_GIT_URL}/${GOVUK_PUPPET_REPO}
 
 # Clone secrets repo
-${GIT_BINARY} clone ${GOVUK_GIT_URL}/${GOVUK_SECRETS_REPO}
+git clone ${GOVUK_GIT_URL}/${GOVUK_SECRETS_REPO}
 
 # Add secrets to puppet repository
 cp -r ${GOVUK_WORKDIR}/${GOVUK_SECRETS_REPO}/puppet_aws/hieradata/* ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/
@@ -108,20 +100,20 @@ ln -s /usr/share/puppet/production/releases/${RELEASENAME} /usr/share/puppet/pro
 # behaviour.
 # shellcheck disable=SC2174
 mkdir -p -m 0700 /etc/puppet/gpg
-${GPG_BINARY} --homedir /etc/puppet/gpg --allow-secret-key-import --import ${GPG_KEYSTORE}/${GPG_KEYNAME}
+gpg --homedir /etc/puppet/gpg --allow-secret-key-import --import ${GPG_KEYSTORE}/${GPG_KEYNAME}
 chown -R puppet: /etc/puppet/gpg
 
 # Install Ruby dependencies for first puppet apply
-${GEM_BINARY} install --no-ri --no-rdoc hiera-eyaml-gpg gpgme
+gem install --no-ri --no-rdoc hiera-eyaml-gpg gpgme
 
 cd /usr/share/puppet/production/current/
 
 # Installing Puppet dependencies
-${BUNDLE_BINARY} install
-${BUNDLE_BINARY} exec ${RAKE_BINARY} librarian:install
+bundle install
+bundle exec rake librarian:install
 
 cd ${GOVUK_WORKDIR}
 
 # Self-configure puppet
-${PUPPET_BINARY} apply --verbose --trusted_node_data --hiera_config=/usr/share/puppet/production/current/hiera_aws.yml --modulepath=/usr/share/puppet/production/current/modules:/usr/share/puppet/production/current/vendor/modules/ --manifestdir=/usr/share/puppet/production/current/manifests /usr/share/puppet/production/current/manifests/site.pp >> ${GOVUK_LOGDIR}/govuk_puppet_apply.log 2>&1
+puppet apply --verbose --trusted_node_data --hiera_config=/usr/share/puppet/production/current/hiera_aws.yml --modulepath=/usr/share/puppet/production/current/modules:/usr/share/puppet/production/current/vendor/modules/ --manifestdir=/usr/share/puppet/production/current/manifests /usr/share/puppet/production/current/manifests/site.pp >> ${GOVUK_LOGDIR}/govuk_puppet_apply.log 2>&1
 chown -R deploy:deploy /usr/share/puppet/production/releases/${RELEASENAME}


### PR DESCRIPTION
- These have cost us some grieve in the past in case installation
methods change (awscli via apt, rather than pip -> /usr/bin, rather than
/usr/loocal/bin)

- We should rely on the PATH variable to configure these correctly

solo: @schmie