### PR TITLE
Allow db-admin to delete snapshots

### DIFF
--- a/terraform/projects/app-db-admin/additional_policy.json
+++ b/terraform/projects/app-db-admin/additional_policy.json
@@ -36,6 +36,7 @@
                 "rds:ModifyDBClusterSnapshotAttribute",
                 "rds:ModifyDBSnapshot",
                 "rds:ModifyDBSnapshotAttribute",
+                "rds:DeleteDBSnapshot",
                 "rds:DescribeDBClusters",
                 "rds:DescribeDBClusterParameterGroups",
                 "rds:DescribeDBClusterSnapshots",


### PR DESCRIPTION
Required for the scrubber to clean up after itself and delete old snapshots.