### PR TITLE
Add IAM users for Terraboard

### DIFF
--- a/terraform/policies/terraboard_policy.tpl
+++ b/terraform/policies/terraboard_policy.tpl
@@ -1,0 +1,23 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+             ],
+            "Resource": [
+                "arn:aws:s3:::govuk-terraform-state-${aws_environment}"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject"
+             ],
+            "Resource": [
+                "arn:aws:s3:::govuk-terraform-state-${aws_environment}/*"
+            ]
+        }
+    ]
+ }

--- a/terraform/projects/infra-monitoring/README.md
+++ b/terraform/projects/infra-monitoring/README.md
@@ -6,8 +6,9 @@ Create resources to manage infrastructure and app monitoring:
   - Create resources to export CloudWatch log groups to S3 via Lambda-Kinesis_Firehose
   - Create SNS topic to send infrastructure alerts, and a SQS queue that subscribes to
     the topic
-  - Create an IAM role which allows the AWS X-Ray daemon to upload trace data to
-    AWS X-Ray (only required while trace data is sent from Carrenza)
+  - Create an IAM user which allows Terraboard to read Terraform state files from S3
+  - Create an IAM user and role which allows the X-Ray daemon to upload trace
+    data to X-Ray (only required while trace data is sent from Carrenza)
 
 
 ## Inputs


### PR DESCRIPTION
This commit adds new IAM users that have read-only access to the S3 buckets that hold Terraform state for each AWS environment. These users will have keys generated that will be provided to Terraboard for authentication.

Trello: https://trello.com/c/6UMlTRpa/490-get-terraboard-running-on-the-monitoring-machines-in-each-environment