### PR TITLE
Do not group Athena query results by request_received

### DIFF
--- a/terraform/queries/transition_logs_query.sql
+++ b/terraform/queries/transition_logs_query.sql
@@ -8,5 +8,5 @@ FROM bouncer
 WHERE year = year(current_date - interval '1' day)
   AND month = month(current_date - interval '1' day)
   AND date = day(current_date - interval '1' day)
-GROUP BY cast(request_received as date), status, host, url
+GROUP BY status, host, url
 ORDER BY 2 DESC


### PR DESCRIPTION
This causes problems around midnight, where a request can be received
on one day but be logged for the next, if the duration of the request
pushed it over the day change.  The SELECT hard-codes the date, rather
than returning the request_received, so we see two apparently
identical requests on the same day.

We don't really need the data to be as precise as possible, so we'll
just say that all requests which finished processing on a given day
were received on that day.  The error introduced in Day N by pushing
some requests on Day N+1 is resolved by some requests on Day N+1
inevitably being pushed to Day N+2, and so on.

---

[Trello card](https://trello.com/c/dNtEfmJM/395-move-transition-hit-stats-processing-to-s3-and-athena-%F0%9F%8D%90-portunity)