### PR TITLE
Don't set final snapshot parameters on RDS Replicas

### DIFF
--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -204,9 +204,6 @@ resource "aws_db_instance" "db_instance_replica" {
     update = "${var.terraform_update_rds_timeout}"
   }
 
-  final_snapshot_identifier = "${var.name}-final-snapshot"
-  skip_final_snapshot       = "${var.skip_final_snapshot}"
-
   tags = "${merge(var.default_tags, map("Name", var.name))}"
 }
 


### PR DESCRIPTION
Replica RDS instances don't support final snapshots. With `final_snapshot_identifier` set, we're getting an error from the API when destroying a replica instance.