### PR TITLE
app-publishing-api-db-admin: fix tags

### DIFF
--- a/terraform/projects/app-publishing-api-db-admin/main.tf
+++ b/terraform/projects/app-publishing-api-db-admin/main.tf
@@ -70,14 +70,14 @@ resource "aws_elb" "publishing-api-db-admin_elb" {
   connection_draining         = true
   connection_draining_timeout = 400
 
-  tags = "${map("Name", "${var.stackname}-publishing-api-db-admin", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "publishing-api_db_admin")}"
+  tags = "${map("Name", "${var.stackname}-publishing-api-db-admin", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "publishing_api_db_admin")}"
 }
 
 module "publishing-api-db-admin" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-publishing-api-db-admin"
   vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "publishing-api_db_admin", "aws_hostname", "publishing-api-db-admin-1")}"
+  default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "publishing_api_db_admin", "aws_hostname", "publishing-api-db-admin-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_publishing-api-db-admin_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "t3.medium"


### PR DESCRIPTION
Transpose hyphen to underscore - this was preventing Puppet from running