### PR TITLE
Change S3 buckets for Terraboard

### DIFF
--- a/terraform/policies/terraboard_policy.tpl
+++ b/terraform/policies/terraboard_policy.tpl
@@ -7,7 +7,7 @@
                 "s3:ListBucket"
              ],
             "Resource": [
-                "arn:aws:s3:::govuk-terraform-state-${aws_environment}"
+                "arn:aws:s3:::govuk-terraform-steppingstone-${aws_environment}"
             ]
         },
         {
@@ -16,7 +16,7 @@
                 "s3:GetObject"
              ],
             "Resource": [
-                "arn:aws:s3:::govuk-terraform-state-${aws_environment}/*"
+                "arn:aws:s3:::govuk-terraform-steppingstone-${aws_environment}/*"
             ]
         }
     ]


### PR DESCRIPTION
This commit changes the S3 buckets that Terraboard reads from. Steppingstone is the new one.

Trello: https://trello.com/c/6UMlTRpa/490-get-terraboard-running-on-the-monitoring-machines-in-each-environment