### PR TITLE
Fix AWS X-Ray permissions

### DIFF
--- a/terraform/policies/xray_traces_assume_policy.tpl
+++ b/terraform/policies/xray_traces_assume_policy.tpl
@@ -5,7 +5,7 @@
       "Sid": "XRayRolePolicy",
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "xray.amazonaws.com"
+        "AWS": "${xray_daemon_user_arn}"
       },
       "Effect": "Allow"
     }

--- a/terraform/policies/xray_traces_policy.json
+++ b/terraform/policies/xray_traces_policy.json
@@ -5,10 +5,7 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTraceSegments",
-          "xray:PutTelemetryRecords",
-          "xray:GetSamplingRules",
-          "xray:GetSamplingTargets",
-          "xray:GetSamplingStatisticSummaries"
+          "xray:PutTelemetryRecords"
       ],
       "Resource": [
           "*"


### PR DESCRIPTION
This commit:

* Detaches the X-Ray permissions policy from the X-Ray user because that user is only used to assume the X-Ray role, which needs the permissions
* Changes the principal used in the X-Ray assume policy to be the X-Ray user
* Removes unknown X-Ray permissions