### PR TITLE
Add more permissions for Terraboard

### DIFF
--- a/terraform/policies/terraboard_policy.tpl
+++ b/terraform/policies/terraboard_policy.tpl
@@ -4,7 +4,8 @@
         {
             "Effect": "Allow",
             "Action": [
-                "s3:ListBucket"
+                "s3:ListBucket",
+                "s3:ListBucketVersions"
              ],
             "Resource": [
                 "arn:aws:s3:::govuk-terraform-steppingstone-${aws_environment}"
@@ -13,7 +14,8 @@
         {
             "Effect": "Allow",
             "Action": [
-                "s3:GetObject"
+                "s3:GetObject",
+                "s3:GetObjectVersion"
              ],
             "Resource": [
                 "arn:aws:s3:::govuk-terraform-steppingstone-${aws_environment}/*"

--- a/terraform/projects/infra-monitoring/main.tf
+++ b/terraform/projects/infra-monitoring/main.tf
@@ -243,7 +243,7 @@ data "template_file" "terraboard_policy_template" {
 resource "aws_iam_policy" "terraboard_policy" {
   name        = "${var.aws_environment}-terraboard-policy"
   path        = "/"
-  description = "Allow read access to S3 govuk-terraform-state bucket"
+  description = "Allow read access to S3 govuk-terraform-steppingstone bucket for the environment"
   policy      = "${data.template_file.terraboard_policy_template.rendered}"
 }
 


### PR DESCRIPTION
This commit adds versioning permissions for Terraboard’s access to the Terraform state S3 buckets, which is required to compare across multiple versions of a state file.

Trello: https://trello.com/c/6UMlTRpa/490-get-terraboard-running-on-the-monitoring-machines-in-each-environment