### PR TITLE
Per-database write permissions on backups bucket for db-admin

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -286,6 +286,8 @@ data "aws_iam_policy_document" "dbadmin_database_backups_writer" {
 
     resources = [
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*whitehall*",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*email-alert-api*",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*publishing-api*",
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mysql*",
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*postgres*",
     ]


### PR DESCRIPTION
We need to include each database name as a glob pattern here.