### PR TITLE
Add Terraboard external DNS record

### DIFF
--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -219,6 +219,18 @@ resource "aws_route53_record" "internal_service_record" {
   }
 }
 
+resource "aws_route53_record" "terraboard_external_service_record" {
+  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
+  name    = "terraboard.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_elb.monitoring_internal_elb.dns_name}"
+    zone_id                = "${aws_elb.monitoring_internal_elb.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
 module "alarms-elb-monitoring-internal" {
   source                         = "../../modules/aws/alarms/elb"
   name_prefix                    = "${var.stackname}-monitoring-internal"


### PR DESCRIPTION
This commit adds an external stack-specific DNS record for Terraboard which points to the monitoring machine.

Trello: https://trello.com/c/6UMlTRpa/490-get-terraboard-running-on-the-monitoring-machines-in-each-environment