### PR TITLE
Give the transition downloader user access to the correct bucket

### DIFF
--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -113,7 +113,7 @@ data "template_file" "transition_downloader_policy_template" {
   template = "${file("${path.module}/../../policies/transition_downloader_policy.tpl")}"
 
   vars {
-    bucket_arn = "${aws_s3_bucket.fastly_logs.arn}"
+    bucket_arn = "${aws_s3_bucket.transition_fastly_logs.arn}"
   }
 }
 


### PR DESCRIPTION
'fastly_logs' is the bucket which Fastly writes the logs to, it's the
input to the Athena query.

'transition_fastly_logs' is the bucket which Athena writes the
processed stats to, which transition reads from.