### PR TITLE
Do not report hits under 10 occurrences

### DIFF
--- a/terraform/queries/transition_logs_query.sql
+++ b/terraform/queries/transition_logs_query.sql
@@ -9,4 +9,5 @@ WHERE year = year(current_date - interval '1' day)
   AND month = month(current_date - interval '1' day)
   AND date = day(current_date - interval '1' day)
 GROUP BY status, host, url
+HAVING count(*) >= 10
 ORDER BY 2 DESC


### PR DESCRIPTION
The current Transition logs importer uses a threshold of 10 to exclude
infrequently hit paths.  This has a massive effect on the number of
hits reported: on 2018-09-18 there are 8404 entries in the hit stats
file with the threshold, and 481371 without.

In principle, dropping this threshold would allow more precise
statistics.  However, after the logs are imported into Transition
every day, the statistics are generated from scratch.

Going from 10,000 records a day to nearly 500,000 is likely to reveal
inefficiencies in the current code, which we otherwise would not have
to worry about for years.

---

[Trello card](https://trello.com/c/dNtEfmJM/395-move-transition-hit-stats-processing-to-s3-and-athena-%F0%9F%8D%90-portunity)