### PR TITLE
Adding new management stack projects

### DIFF
--- a/doc/guides/environment-provisioning.md
+++ b/doc/guides/environment-provisioning.md
@@ -208,6 +208,10 @@ Create the following projects (in no particular order):
 
 `app-apt`
 `app-db-admin`
+`app-email-alert-api-db-admin`
+`app-publishing-api-db-admin`
+`app-transition-db-admin`
+`app-warehouse-db-admin`
 `app-graphite`
 `app-monitoring`
 


### PR DESCRIPTION
There were four missing projects that have now been added. For a list of these check in the repo `govuk-aws/terraform/projects`