### PR TITLE
Bump the terraform provider version

### DIFF
--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -54,7 +54,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 locals {

--- a/terraform/projects/app-asset-master/main.tf
+++ b/terraform/projects/app-asset-master/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 resource "aws_efs_file_system" "assets-efs-fs" {

--- a/terraform/projects/app-backend-redis/main.tf
+++ b/terraform/projects/app-backend-redis/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 resource "aws_route53_record" "service_record" {

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -56,7 +56,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -68,7 +68,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -63,7 +63,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/app-ckan/main.tf
+++ b/terraform/projects/app-ckan/main.tf
@@ -60,7 +60,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -42,7 +42,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 resource "aws_elb" "db-admin_elb" {

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -72,7 +72,7 @@ data "terraform_remote_state" "artefact_bucket" {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-docker-management/main.tf
+++ b/terraform/projects/app-docker-management/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 resource "aws_elb" "docker_management_etcd_elb" {

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -56,7 +56,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -51,7 +51,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/app-email-alert-api-db-admin/main.tf
+++ b/terraform/projects/app-email-alert-api-db-admin/main.tf
@@ -42,7 +42,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 resource "aws_elb" "email-alert-api-db-admin_elb" {

--- a/terraform/projects/app-email-alert-api-postgresql/main.tf
+++ b/terraform/projects/app-email-alert-api-postgresql/main.tf
@@ -66,7 +66,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 module "email-alert-api-postgresql-primary_rds_instance" {

--- a/terraform/projects/app-email-alert-api/main.tf
+++ b/terraform/projects/app-email-alert-api/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -51,7 +51,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -60,7 +60,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 resource "aws_elb" "jumpbox_external_elb" {

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -60,7 +60,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 module "mirrorer" {

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -90,7 +90,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 # Instance 1

--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -54,7 +54,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -66,7 +66,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 # MySQL Primary instance

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -66,7 +66,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 module "postgresql-primary_rds_instance" {

--- a/terraform/projects/app-publishing-api-db-admin/main.tf
+++ b/terraform/projects/app-publishing-api-db-admin/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 resource "aws_elb" "publishing-api-db-admin_elb" {

--- a/terraform/projects/app-publishing-api-postgresql/main.tf
+++ b/terraform/projects/app-publishing-api-postgresql/main.tf
@@ -60,7 +60,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 module "publishing-api-postgresql-primary_rds_instance" {

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -51,7 +51,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-rabbitmq/main.tf
+++ b/terraform/projects/app-rabbitmq/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 resource "aws_elb" "rabbitmq_elb" {

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -90,7 +90,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-rummager-elasticsearch/main.tf
+++ b/terraform/projects/app-rummager-elasticsearch/main.tf
@@ -83,7 +83,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 resource "aws_elb" "rummager-elasticsearch_elb" {

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -63,7 +63,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 resource "aws_elb" "transition-db-admin_elb" {

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -66,7 +66,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 module "transition-postgresql-primary_rds_instance" {

--- a/terraform/projects/app-ubuntu-test/main.tf
+++ b/terraform/projects/app-ubuntu-test/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 resource "aws_elb" "ubuntutest_external_elb" {

--- a/terraform/projects/app-warehouse-db-admin/main.tf
+++ b/terraform/projects/app-warehouse-db-admin/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 resource "aws_elb" "warehouse-db-admin_elb" {

--- a/terraform/projects/app-warehouse/main.tf
+++ b/terraform/projects/app-warehouse/main.tf
@@ -60,7 +60,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 module "warehouse-postgresql-primary_rds_instance" {

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -56,7 +56,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -45,7 +45,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/infra-artefact-bucket/main.tf
+++ b/terraform/projects/infra-artefact-bucket/main.tf
@@ -101,13 +101,13 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 provider "aws" {
   alias   = "secondary"
   region  = "${var.aws_secondary_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {

--- a/terraform/projects/infra-content-publisher/main.tf
+++ b/terraform/projects/infra-content-publisher/main.tf
@@ -29,7 +29,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.25.0"
+  version = "1.40.0"
 }
 
 resource "aws_s3_bucket" "content_publisher_activestorage" {

--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -54,13 +54,13 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 provider "aws" {
   alias   = "eu-london"
   region  = "${var.aws_backup_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {

--- a/terraform/projects/infra-datagovuk-static-bucket/main.tf
+++ b/terraform/projects/infra-datagovuk-static-bucket/main.tf
@@ -47,7 +47,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {

--- a/terraform/projects/infra-email-alert-api-archive/main.tf
+++ b/terraform/projects/infra-email-alert-api-archive/main.tf
@@ -30,7 +30,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.25.0"
+  version = "1.40.0"
 }
 
 resource "aws_s3_bucket" "email_alert_api_archive" {

--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -28,7 +28,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.25.0"
+  version = "1.40.0"
 }
 
 resource "aws_s3_bucket" "fastly_logs" {

--- a/terraform/projects/infra-govuk-cdn-logs-monitor-bucket/main.tf
+++ b/terraform/projects/infra-govuk-cdn-logs-monitor-bucket/main.tf
@@ -33,7 +33,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 resource "aws_s3_bucket" "cdn_logs_monitor" {

--- a/terraform/projects/infra-govuk-repo-mirror/main.tf
+++ b/terraform/projects/infra-govuk-repo-mirror/main.tf
@@ -27,7 +27,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.27.0"
+  version = "1.40.0"
 }
 
 resource "aws_iam_user" "govuk_code_commit_user" {

--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -48,13 +48,13 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 provider "aws" {
   region  = "${var.aws_backup_region}"
   alias   = "aws_secondary"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {

--- a/terraform/projects/infra-monitoring/main.tf
+++ b/terraform/projects/infra-monitoring/main.tf
@@ -38,7 +38,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "aws_elb_service_account" "main" {}

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -106,7 +106,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "terraform_remote_state" "infra_vpc" {

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -366,7 +366,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 #

--- a/terraform/projects/infra-root-dns-zones/main.tf
+++ b/terraform/projects/infra-root-dns-zones/main.tf
@@ -58,7 +58,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "terraform_remote_state" "infra_vpc" {

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -11,7 +11,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 # used by the fastly ip ranges provider.

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -77,7 +77,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 module "role_admin" {

--- a/terraform/projects/infra-stack-dns-zones/main.tf
+++ b/terraform/projects/infra-stack-dns-zones/main.tf
@@ -64,7 +64,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "terraform_remote_state" "infra_vpc" {

--- a/terraform/projects/infra-vpc/main.tf
+++ b/terraform/projects/infra-vpc/main.tf
@@ -69,7 +69,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {

--- a/terraform/projects/infra-wal-e-warehouse-bucket/main.tf
+++ b/terraform/projects/infra-wal-e-warehouse-bucket/main.tf
@@ -48,13 +48,13 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 provider "aws" {
   alias   = "eu-london"
   region  = "${var.aws_backup_region}"
-  version = "1.14.0"
+  version = "1.40.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {


### PR DESCRIPTION
We are starting to lag a long way behind and need the newer version for ALB redirects. This is a purely code level change and the projects will need to be `plan`ed against the new version. 