### PR TITLE
Add a S3 bucket for data.gov.uk organograms

### DIFF
--- a/terraform/projects/infra-datagovuk-organogram-bucket/README.md
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/README.md
@@ -1,0 +1,19 @@
+## Project: datagovuk-organogram-bucket
+
+This creates an s3 bucket
+
+datagovuk-organogram-bucket: A bucket to hold data.gov.uk organogram files
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
+| s3_bucket_read_ips | Additional IPs to allow read access from | list | - | yes |
+| stackname | Stackname | string | - | yes |
+

--- a/terraform/projects/infra-datagovuk-organogram-bucket/datagovuk-write-policy.tf
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/datagovuk-write-policy.tf
@@ -1,0 +1,39 @@
+data "aws_iam_policy_document" "s3_datagovuk_organogram_writer_policy_doc" {
+  statement {
+    sid = "S3SyncReadLists"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    sid     = "S3SyncReadWriteBucket"
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.datagovuk-organogram.id}",
+      "arn:aws:s3:::${aws_s3_bucket.datagovuk-organogram.id}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "s3_datagovuk_organogram_writer_policy" {
+  name   = "s3_datagovuk_writer_policy_for_${aws_s3_bucket.datagovuk-organogram.id}"
+  policy = "${data.aws_iam_policy_document.s3_datagovuk_organogram_writer_policy_doc.json}"
+}
+
+resource "aws_iam_user" "s3_datagovuk_organogram_writer_user" {
+  name = "s3_datagovuk_organogram_writer"
+}
+
+resource "aws_iam_policy_attachment" "s3_datagovuk_organogram_writer_user_policy" {
+  name       = "s3_datagovuk_organogram_writers_user_policy_attachment"
+  users      = ["${aws_iam_user.s3_datagovuk_organogram_writer_user.name}"]
+  policy_arn = "${aws_iam_policy.s3_datagovuk_organogram_writer_policy.arn}"
+}

--- a/terraform/projects/infra-datagovuk-organogram-bucket/fastly-read-policy.tf
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/fastly-read-policy.tf
@@ -1,0 +1,33 @@
+provider "fastly" {
+  # We only want to use fastly's data API
+  api_key = "test"
+}
+
+data "fastly_ip_ranges" "fastly" {}
+
+data "aws_iam_policy_document" "s3_fastly_read_policy_doc" {
+  statement {
+    sid     = "S3FastlyReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.datagovuk-organogram.id}",
+      "arn:aws:s3:::${aws_s3_bucket.datagovuk-organogram.id}/*",
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+
+      values = [
+        "${data.fastly_ip_ranges.fastly.cidr_blocks}",
+        "${var.s3_bucket_read_ips}",
+      ]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}

--- a/terraform/projects/infra-datagovuk-organogram-bucket/integration.govuk.backend
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/integration.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "govuk/infra-datagovuk-organogram-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
@@ -1,0 +1,84 @@
+/**
+* ## Project: datagovuk-organogram-bucket
+*
+* This creates an s3 bucket
+*
+* datagovuk-organogram-bucket: A bucket to hold data.gov.uk organogram files
+*
+*/
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "S3 bucket we store our terraform state in"
+}
+
+variable "remote_state_infra_monitoring_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_monitoring remote state "
+  default     = ""
+}
+
+variable "s3_bucket_read_ips" {
+  type        = "list"
+  description = "Additional IPs to allow read access from"
+}
+
+# Set up the backend & provider for each region
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.14.0"
+}
+
+data "terraform_remote_state" "infra_monitoring" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+resource "aws_s3_bucket" "datagovuk-organogram" {
+  bucket = "datagovuk-${var.aws_environment}-ckan-organogram"
+
+  tags {
+    Name            = "datagovuk-${var.aws_environment}-ckan-organogram"
+    aws_environment = "${var.aws_environment}"
+  }
+
+  logging {
+    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    target_prefix = "s3/datagovuk-${var.aws_environment}-ckan-organogram/"
+  }
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_s3_bucket_policy" "govuk_datagovuk_organogram_read_policy" {
+  bucket = "${aws_s3_bucket.datagovuk-organogram.id}"
+  policy = "${data.aws_iam_policy_document.s3_fastly_read_policy_doc.json}"
+}

--- a/terraform/projects/infra-datagovuk-organogram-bucket/production.govuk.backend
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/production.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "govuk/infra-datagovuk-organogram-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-datagovuk-organogram-bucket/staging.govuk.backend
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/staging.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+key     = "govuk/infra-datagovuk-organogram-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"


### PR DESCRIPTION
We are using a S3 bucket to store organograms in the new data.gov.uk publishing tool (upgraded CKAN).

This Terraform will: 
- Provision a S3 bucket `datagovuk-organogram` for storing organogram data for data.gov.uk
- Create a user `s3_datagovuk_organogram_writer_user` that will be used by CKAN to write organograms to this bucket
- Ensure Fastly is able to read from this bucket

Trello card: https://trello.com/c/odHiWSoq/63-implement-upload-organogram-to-s3