### PR TITLE
[DO NOT MERGE] Create buckets for primary and transition WAL-E backups

### DIFF
--- a/terraform/projects/infra-wal-e-primary-bucket/README.md
+++ b/terraform/projects/infra-wal-e-primary-bucket/README.md
@@ -1,0 +1,24 @@
+## Project: wal-e-primary-bucket
+
+This creates an s3 bucket
+
+wal-e-primary: The bucket that will hold database backups
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_backup_region | AWS region | string | `eu-west-2` | no |
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
+| stackname | Stackname | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| write_wal_e_primary_policy_arn | ARN of the write wal_e_primary-bucket policy |

--- a/terraform/projects/infra-wal-e-primary-bucket/main.tf
+++ b/terraform/projects/infra-wal-e-primary-bucket/main.tf
@@ -1,0 +1,166 @@
+/**
+* ## Project: wal-e-primary-bucket
+*
+* This creates an s3 bucket
+*
+* wal-e-primary: The bucket that will hold database backups
+*
+*/
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "aws_backup_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-2"
+}
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "S3 bucket we store our terraform state in"
+}
+
+variable "remote_state_infra_monitoring_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_monitoring remote state "
+  default     = ""
+}
+
+# Set up the backend & provider for each region
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.40.0"
+}
+
+provider "aws" {
+  alias   = "eu-london"
+  region  = "${var.aws_backup_region}"
+  version = "1.40.0"
+}
+
+data "terraform_remote_state" "infra_monitoring" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+resource "aws_s3_bucket" "wal_e_primary" {
+  bucket = "govuk-${var.aws_environment}-wal-e-primary"
+  region = "${var.aws_region}"
+
+  tags {
+    Name            = "govuk-${var.aws_environment}-wal-e-primary"
+    aws_environment = "${var.aws_environment}"
+  }
+
+  logging {
+    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    target_prefix = "s3/govuk-${var.aws_environment}-wal-e-primary/"
+  }
+
+  lifecycle_rule {
+    prefix  = "postgres/"
+    enabled = true
+
+    transition {
+      storage_class = "STANDARD_IA"
+      days          = 30
+    }
+
+    transition {
+      storage_class = "GLACIER"
+      days          = 90
+    }
+
+    expiration {
+      days = 120
+    }
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  replication_configuration {
+    role = "${aws_iam_role.wal_e_primary_replication_role.arn}"
+
+    rules {
+      prefix = ""
+      status = "Enabled"
+
+      destination {
+        bucket        = "${aws_s3_bucket.wal_e_primary_replica.arn}"
+        storage_class = "STANDARD"
+      }
+    }
+  }
+}
+
+# Bucket in the second region (Backup of the backup)
+resource "aws_s3_bucket" "wal_e_primary_replica" {
+  bucket   = "govuk-${var.aws_environment}-wal-e-primary-replica"
+  region   = "${var.aws_backup_region}"
+  provider = "aws.eu-london"
+
+  versioning {
+    enabled = true
+  }
+}
+
+# S3 backup replica role configuration
+data "template_file" "s3_backup_replica_assume_role_template" {
+  template = "${file("${path.module}/../../policies/s3_backup_replica_role.tpl")}"
+}
+
+# Adding backup replication role
+resource "aws_iam_role" "wal_e_primary_replication_role" {
+  name               = "${var.stackname}-wal-e-primary-bucket-replication-role"
+  assume_role_policy = "${data.template_file.s3_backup_replica_assume_role_template.rendered}"
+}
+
+# S3 backup replica policy configuration
+data "template_file" "s3_backup_replica_policy_template" {
+  template = "${file("${path.module}/../../policies/s3_backup_replica_policy.json")}"
+
+  vars {
+    govuk_s3_bucket = "${aws_s3_bucket.wal_e_primary.arn}"
+    govuk_s3_backup = "${aws_s3_bucket.wal_e_primary_replica.arn}"
+  }
+}
+
+# Adding backup replication policy
+resource "aws_iam_policy" "wal_e_primary_replication_policy" {
+  name        = "govuk-${var.aws_environment}-wal-e-primary-bucket-replication-policy"
+  policy      = "${data.template_file.s3_backup_replica_policy_template.rendered}"
+  description = "Allows replication of the primary wal-e buckets"
+}
+
+# Combine the role and policy
+resource "aws_iam_policy_attachment" "wal_e_primary_replication_policy_attachment" {
+  name       = "s3-wal-e-primary-bucket-replication-policy-attachment"
+  roles      = ["${aws_iam_role.wal_e_primary_replication_role.name}"]
+  policy_arn = "${aws_iam_policy.wal_e_primary_replication_policy.arn}"
+}

--- a/terraform/projects/infra-wal-e-primary-bucket/production.govuk.backend
+++ b/terraform/projects/infra-wal-e-primary-bucket/production.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "govuk/infra-wal-e-primary-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-wal-e-primary-bucket/staging.govuk.backend
+++ b/terraform/projects/infra-wal-e-primary-bucket/staging.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+key     = "govuk/infra-wal-e-primary-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-wal-e-primary-bucket/writer.tf
+++ b/terraform/projects/infra-wal-e-primary-bucket/writer.tf
@@ -1,0 +1,56 @@
+/**
+* ## Project: wal-e-primary-bucket
+*
+* Create a policy that allows writing of the database-backups bucket. This
+* doesn't create a role as the calling instance is assumed to already
+* have one which should be attached to this policy.
+*
+*/
+
+resource "aws_iam_policy" "wal_e_primary_writer" {
+  name        = "govuk-${var.aws_environment}-wal_e_primary-writer-policy"
+  policy      = "${data.aws_iam_policy_document.wal_e_primary_writer.json}"
+  description = "Allows writing of the database_backups bucket"
+}
+
+data "aws_iam_policy_document" "wal_e_primary_writer" {
+  statement {
+    sid = "ReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    # In theory referencing the bucket ARN should work but it doesn't so use * instead
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    sid     = "WriteGovukWalEPrimaryBackups"
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.wal_e_primary.id}",
+      "arn:aws:s3:::${aws_s3_bucket.wal_e_primary.id}/*",
+    ]
+  }
+}
+
+resource "aws_iam_user" "wal_e_primary_writer" {
+  name = "govuk-${var.aws_environment}-wal-e-primary-writer"
+}
+
+resource "aws_iam_policy_attachment" "wal_e_primary_writer" {
+  name       = "wal_e_primary_writer-policy-attachment"
+  users      = ["${aws_iam_user.wal_e_primary_writer.name}"]
+  policy_arn = "${aws_iam_policy.wal_e_primary_writer.arn}"
+}
+
+output "write_wal_e_primary_policy_arn" {
+  value       = "${aws_iam_policy.wal_e_primary_writer.arn}"
+  description = "ARN of the write wal_e_primary-bucket policy"
+}

--- a/terraform/projects/infra-wal-e-transition-bucket/README.md
+++ b/terraform/projects/infra-wal-e-transition-bucket/README.md
@@ -1,8 +1,8 @@
-## Project: wal-e-primary-bucket
+## Project: wal-e-transition-bucket
 
 This creates an s3 bucket
 
-wal-e-primary: The bucket that will hold database backups
+wal-e-transition: The bucket that will hold database backups
 
 
 
@@ -21,5 +21,5 @@ wal-e-primary: The bucket that will hold database backups
 
 | Name | Description |
 |------|-------------|
-| write_wal_e_primary_policy_arn | ARN of the write wal_e_primary-bucket policy |
+| write_wal_e_transition_policy_arn | ARN of the write wal_e_transition-bucket policy |
 

--- a/terraform/projects/infra-wal-e-transition-bucket/main.tf
+++ b/terraform/projects/infra-wal-e-transition-bucket/main.tf
@@ -1,0 +1,166 @@
+/**
+* ## Project: wal-e-transition-bucket
+*
+* This creates an s3 bucket
+*
+* wal-e-transition: The bucket that will hold database backups
+*
+*/
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "aws_backup_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-2"
+}
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "S3 bucket we store our terraform state in"
+}
+
+variable "remote_state_infra_monitoring_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_monitoring remote state "
+  default     = ""
+}
+
+# Set up the backend & provider for each region
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.40.0"
+}
+
+provider "aws" {
+  alias   = "eu-london"
+  region  = "${var.aws_backup_region}"
+  version = "1.40.0"
+}
+
+data "terraform_remote_state" "infra_monitoring" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+resource "aws_s3_bucket" "wal_e_transition" {
+  bucket = "govuk-${var.aws_environment}-wal-e-transition"
+  region = "${var.aws_region}"
+
+  tags {
+    Name            = "govuk-${var.aws_environment}-wal-e-transition"
+    aws_environment = "${var.aws_environment}"
+  }
+
+  logging {
+    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    target_prefix = "s3/govuk-${var.aws_environment}-wal-e-transition/"
+  }
+
+  lifecycle_rule {
+    prefix  = "postgres/"
+    enabled = true
+
+    transition {
+      storage_class = "STANDARD_IA"
+      days          = 30
+    }
+
+    transition {
+      storage_class = "GLACIER"
+      days          = 90
+    }
+
+    expiration {
+      days = 120
+    }
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  replication_configuration {
+    role = "${aws_iam_role.wal_e_transition_replication_role.arn}"
+
+    rules {
+      prefix = ""
+      status = "Enabled"
+
+      destination {
+        bucket        = "${aws_s3_bucket.wal_e_transition_replica.arn}"
+        storage_class = "STANDARD"
+      }
+    }
+  }
+}
+
+# Bucket in the second region (Backup of the backup)
+resource "aws_s3_bucket" "wal_e_transition_replica" {
+  bucket   = "govuk-${var.aws_environment}-wal-e-transition-replica"
+  region   = "${var.aws_backup_region}"
+  provider = "aws.eu-london"
+
+  versioning {
+    enabled = true
+  }
+}
+
+# S3 backup replica role configuration
+data "template_file" "s3_backup_replica_assume_role_template" {
+  template = "${file("${path.module}/../../policies/s3_backup_replica_role.tpl")}"
+}
+
+# Adding backup replication role
+resource "aws_iam_role" "wal_e_transition_replication_role" {
+  name               = "${var.stackname}-wal-e-transition-bucket-replication-role"
+  assume_role_policy = "${data.template_file.s3_backup_replica_assume_role_template.rendered}"
+}
+
+# S3 backup replica policy configuration
+data "template_file" "s3_backup_replica_policy_template" {
+  template = "${file("${path.module}/../../policies/s3_backup_replica_policy.json")}"
+
+  vars {
+    govuk_s3_bucket = "${aws_s3_bucket.wal_e_transition.arn}"
+    govuk_s3_backup = "${aws_s3_bucket.wal_e_transition_replica.arn}"
+  }
+}
+
+# Adding backup replication policy
+resource "aws_iam_policy" "wal_e_transition_replication_policy" {
+  name        = "govuk-${var.aws_environment}-wal-e-transition-bucket-replication-policy"
+  policy      = "${data.template_file.s3_backup_replica_policy_template.rendered}"
+  description = "Allows replication of the transition wal-e buckets"
+}
+
+# Combine the role and policy
+resource "aws_iam_policy_attachment" "wal_e_transition_replication_policy_attachment" {
+  name       = "s3-wal-e-transition-bucket-replication-policy-attachment"
+  roles      = ["${aws_iam_role.wal_e_transition_replication_role.name}"]
+  policy_arn = "${aws_iam_policy.wal_e_transition_replication_policy.arn}"
+}

--- a/terraform/projects/infra-wal-e-transition-bucket/production.govuk.backend
+++ b/terraform/projects/infra-wal-e-transition-bucket/production.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "govuk/infra-wal-e-transition-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-wal-e-transition-bucket/staging.govuk.backend
+++ b/terraform/projects/infra-wal-e-transition-bucket/staging.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+key     = "govuk/infra-wal-e-transition-bucket.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-wal-e-transition-bucket/writer.tf
+++ b/terraform/projects/infra-wal-e-transition-bucket/writer.tf
@@ -1,0 +1,56 @@
+/**
+* ## Project: wal-e-transition-bucket
+*
+* Create a policy that allows writing of the database-backups bucket. This
+* doesn't create a role as the calling instance is assumed to already
+* have one which should be attached to this policy.
+*
+*/
+
+resource "aws_iam_policy" "wal_e_transition_writer" {
+  name        = "govuk-${var.aws_environment}-wal_e_transition-writer-policy"
+  policy      = "${data.aws_iam_policy_document.wal_e_transition_writer.json}"
+  description = "Allows writing of the database_backups bucket"
+}
+
+data "aws_iam_policy_document" "wal_e_transition_writer" {
+  statement {
+    sid = "ReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    # In theory referencing the bucket ARN should work but it doesn't so use * instead
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    sid     = "WriteGovukWalETransitionBackups"
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.wal_e_transition.id}",
+      "arn:aws:s3:::${aws_s3_bucket.wal_e_transition.id}/*",
+    ]
+  }
+}
+
+resource "aws_iam_user" "wal_e_transition_writer" {
+  name = "govuk-${var.aws_environment}-wal-e-transition-writer"
+}
+
+resource "aws_iam_policy_attachment" "wal_e_transition_writer" {
+  name       = "wal_e_transition_writer-policy-attachment"
+  users      = ["${aws_iam_user.wal_e_transition_writer.name}"]
+  policy_arn = "${aws_iam_policy.wal_e_transition_writer.arn}"
+}
+
+output "write_wal_e_transition_policy_arn" {
+  value       = "${aws_iam_policy.wal_e_transition_writer.arn}"
+  description = "ARN of the write wal_e_transition-bucket policy"
+}

--- a/terraform/projects/infra-wal-e-warehouse-bucket/writer.tf
+++ b/terraform/projects/infra-wal-e-warehouse-bucket/writer.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "wal_e_warehouse_writer" {
       "s3:GetBucketLocation",
     ]
 
-    # In theory  should work but it doesn't so use * instead
+    # In theory referencing the bucket ARN should work but it doesn't so use * instead
     resources = [
       "arn:aws:s3:::*",
     ]


### PR DESCRIPTION
This is based on the infra-wal-e-warehouse-bucket project. Only needed in production and staging as integration is using RDS.

This used to be configured in govuk-terraform-provisioning but we can't deploy that now, so I've created new buckets here and my plan is to configure WAL-E to use the new ones and copy the data across from the old ones.

[Trello Card](https://trello.com/c/DLAEfbPu/542-legacy-terraform-repo-missing-permissions-for-wal-e)