### PR TITLE
Fix govukcli bug

### DIFF
--- a/tools/govukcli
+++ b/tools/govukcli
@@ -246,7 +246,7 @@ function run_ssh {
           ssh -At $SSH_OPTS $SSH_USER@$JUMPBOX "ssh -q ${NODE_CLASS}"
         else
           # shellcheck disable=SC2029
-          ssh -At $SSH_OPTS $SSH_USER@$JUMPBOX "ssh -q \`govuk_node_list --single-node -c ${NODE_CLASS}\`"
+          ssh -At $SSH_OPTS $SSH_USER@$JUMPBOX "ssh -q \\\`govuk_node_list --single-node -c ${NODE_CLASS}\\\`"
         fi
       fi
     ;;


### PR DESCRIPTION
The escaping here seems to be insufficient to
prevent the script from trying to run
govuk_node_list locally rather than running it
on the jumpbox.