### PR TITLE
Add port 80 bouncer load balancer

### DIFF
--- a/doc/architecture/decisions/0035-alb-ssl-redirect.md
+++ b/doc/architecture/decisions/0035-alb-ssl-redirect.md
@@ -1,0 +1,31 @@
+# 3. Terraform Bouncer ALB redirect 80 to internal 80
+ 
+Date: 2018-10-22
+ 
+## Status
+ 
+Pending
+ 
+## Context
+
+This ADR is part of the GOV.UK migration. The aim is to send HTTP requests that come from bouncer to the correct internal resource. The redirect should send requests to internal port 80. We want to service bouncer request on port 80.
+
+The current certificate that is created has got the following: *.govuk.digital. Bouncer is currently not HTTPS aware.
+
+The project path is the following: govuk-aws/terraform/projects/infra-public-services
+The resource module that cause problems is the following: bouncer_public_lb
+
+We have added the following to enable redirects from both port.
+
+    listener_action = {
+    "HTTP:80"   = "HTTP:80"
+    "HTTPS:443" = "HTTP:80"
+    }
+
+The module would try to create two certifcates to place on to both ports. We needed a way to make sure that only one certificate was created and added to the correct endpoint of the ALB. In this instance the correct endpoint is port 443. Port 80 should be left intact with no certificate serving HTTP.
+
+## Decision
+
+
+
+## Consequences

--- a/terraform/modules/aws/lb/main.tf
+++ b/terraform/modules/aws/lb/main.tf
@@ -202,24 +202,45 @@ resource "aws_lb" "lb" {
   )}"
 }
 
-resource "aws_lb_listener" "listener" {
-  count             = "${length(keys(var.listener_action))}"
+data "null_data_source" "values" {
+  count = "${length(keys(var.listener_action))}"
+
+  inputs = {
+    ssl_arn_index = "${element(split(":", element(keys(var.listener_action), count.index)), 0) == "HTTPS" ? format("%d",count.index) : ""}"
+    arn_index     = "${element(split(":", element(keys(var.listener_action), count.index)), 0) == "HTTP" ? format("%d",count.index) : ""}"
+  }
+}
+
+resource "aws_lb_listener" "listener_non_ssl" {
+  count             = "${length(compact(data.null_data_source.values.*.inputs.arn_index))}"
   load_balancer_arn = "${aws_lb.lb.arn}"
-  port              = "${element(split(":", element(keys(var.listener_action), count.index)), 1)}"
-  protocol          = "${element(split(":", element(keys(var.listener_action), count.index)), 0)}"
-  ssl_policy        = "${element(split(":", element(keys(var.listener_action), count.index)), 0) == "HTTPS" ? var.listener_ssl_policy : ""}"
-  certificate_arn   = "${element(split(":", element(keys(var.listener_action), count.index)), 0) == "HTTPS" ? data.aws_acm_certificate.cert.0.arn : ""}"
+  port              = "${element(split(":", element(keys(var.listener_action), element(compact(data.null_data_source.values.*.inputs.arn_index),count.index))), 1)}"
+  protocol          = "${element(split(":", element(keys(var.listener_action), element(compact(data.null_data_source.values.*.inputs.arn_index),count.index))), 0)}"
 
   default_action {
-    target_group_arn = "${lookup(local.target_groups_arns, "${element(values(var.listener_action), count.index)}")}"
+    target_group_arn = "${lookup(local.target_groups_arns, "${element(values(var.listener_action), element(compact(data.null_data_source.values.*.inputs.arn_index),count.index))}")}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "listener" {
+  count             = "${length(compact(data.null_data_source.values.*.inputs.ssl_arn_index))}"
+  load_balancer_arn = "${aws_lb.lb.arn}"
+  port              = "${element(split(":", element(keys(var.listener_action), element(compact(data.null_data_source.values.*.inputs.ssl_arn_index),count.index))), 1)}"
+  protocol          = "${element(split(":", element(keys(var.listener_action), element(compact(data.null_data_source.values.*.inputs.ssl_arn_index),count.index))), 0)}"
+  ssl_policy        = "${element(split(":", element(keys(var.listener_action), element(compact(data.null_data_source.values.*.inputs.ssl_arn_index),count.index))), 0) == "HTTPS" ? var.listener_ssl_policy : ""}"
+  certificate_arn   = "${element(split(":", element(keys(var.listener_action), element(compact(data.null_data_source.values.*.inputs.ssl_arn_index),count.index))), 0) == "HTTPS" ? data.aws_acm_certificate.cert.0.arn : ""}"
+
+  default_action {
+    target_group_arn = "${lookup(local.target_groups_arns, "${element(values(var.listener_action), element(compact(data.null_data_source.values.*.inputs.ssl_arn_index),count.index))}")}"
     type             = "forward"
   }
 }
 
 resource "aws_lb_listener_certificate" "secondary" {
-  listener_arn    = "${aws_lb_listener.listener.arn}"
+  count           = "${length(compact(data.null_data_source.values.*.inputs.ssl_arn_index))}"
+  listener_arn    = "${element(aws_lb_listener.listener.*.arn, element(compact(data.null_data_source.values.*.inputs.ssl_arn_index),count.index))}"
   certificate_arn = "${data.aws_acm_certificate.secondary_cert.0.arn}"
-  count           = "${var.listener_secondary_certificate_domain_name == "" ? 0 : 1}"
 }
 
 locals {

--- a/terraform/modules/aws/lb/main.tf
+++ b/terraform/modules/aws/lb/main.tf
@@ -239,7 +239,7 @@ resource "aws_lb_listener" "listener" {
 
 resource "aws_lb_listener_certificate" "secondary" {
   count           = "${length(compact(data.null_data_source.values.*.inputs.ssl_arn_index))}"
-  listener_arn    = "${element(aws_lb_listener.listener.*.arn, element(compact(data.null_data_source.values.*.inputs.ssl_arn_index),count.index))}"
+  listener_arn    = "${element(aws_lb_listener.listener.*.arn, count.index)}"
   certificate_arn = "${data.aws_acm_certificate.secondary_cert.0.arn}"
 }
 

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -499,12 +499,17 @@ module "bouncer_public_lb" {
   access_logs_bucket_prefix                  = "elb/${var.stackname}-bouncer-public-elb"
   listener_certificate_domain_name           = "${var.elb_public_certname}"
   listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-  listener_action                            = "${map("HTTPS:443", "HTTP:80")}"
-  target_group_health_check_path             = "/healthcheck"
-  subnets                                    = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups                            = ["${data.terraform_remote_state.infra_security_groups.sg_bouncer_elb_id}"]
-  alarm_actions                              = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                               = "${map("Project", var.stackname, "aws_migration", "bouncer", "aws_environment", var.aws_environment)}"
+
+  listener_action = {
+    "HTTP:80"   = "HTTP:80"
+    "HTTPS:443" = "HTTP:80"
+  }
+
+  target_group_health_check_path = "/healthcheck"
+  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_bouncer_elb_id}"]
+  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  default_tags                   = "${map("Project", var.stackname, "aws_migration", "bouncer", "aws_environment", var.aws_environment)}"
 }
 
 resource "aws_route53_record" "bouncer_public_service_names" {


### PR DESCRIPTION
Add port 80 as a new listener for the bouncer load balancer

2 bugs have been found in the "aws/lb" terraform module and fixed:
1. `ssl_policy` is set for non-ssl listener. an option is set by its mere presence in terraform resource. Hence, there is a need to have 2 listener resource definitions: one for ssl and one for non-ssl.
2. secondary certificates were add to all listeners including the non-ssl listeners