### PR TITLE
Create Platform Health powerusers role

### DIFF
--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -16,6 +16,8 @@ Infrastructure security settings:
 | aws_region | AWS region | string | `eu-west-1` | no |
 | role_admin_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |
 | role_admin_user_arns | List of ARNs of external users that can assume the role | list | `<list>` | no |
+| role_platformhealth_poweruser_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |
+| role_platformhealth_poweruser_user_arns | List of ARNs of external users that can assume the role | list | `<list>` | no |
 | role_poweruser_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |
 | role_poweruser_user_arns | List of ARNs of external users that can assume the role | list | `<list>` | no |
 | role_user_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -38,6 +38,18 @@ variable "role_admin_policy_arns" {
   default     = []
 }
 
+variable "role_platformhealth_poweruser_user_arns" {
+  type        = "list"
+  description = "List of ARNs of external users that can assume the role"
+  default     = []
+}
+
+variable "role_platformhealth_poweruser_policy_arns" {
+  type        = "list"
+  description = "List of ARNs of policies to attach to the role"
+  default     = []
+}
+
 variable "role_poweruser_user_arns" {
   type        = "list"
   description = "List of ARNs of external users that can assume the role"
@@ -85,6 +97,13 @@ module "role_admin" {
   role_name        = "govuk-administrators"
   role_user_arns   = ["${var.role_admin_user_arns}"]
   role_policy_arns = ["${var.role_admin_policy_arns}"]
+}
+
+module "role_platformhealth_poweruser" {
+  source           = "../../modules/aws/iam/role_user"
+  role_name        = "govuk-platformhealth-powerusers"
+  role_user_arns   = ["${var.role_platformhealth_poweruser_user_arns}"]
+  role_policy_arns = ["${var.role_platformhealth_poweruser_policy_arns}"]
 }
 
 module "role_poweruser" {


### PR DESCRIPTION
This commit creates a new role named `platformhealth-powerusers`. This role will be assumed by developers with production access who are in the Platform Health team. The main reason is to split the currently large `powerusers` role which has hit hard AWS limits on size.