### PR TITLE
GovUK-Migr-Trello-16: Fix CNAMES for monitoring

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -58,6 +58,7 @@ This project adds global resources for app components:
 | mapit_public_service_names |  | list | `<list>` | no |
 | mongo_internal_service_names |  | list | `<list>` | no |
 | monitoring_internal_service_names |  | list | `<list>` | no |
+| monitoring_internal_service_names_cname_dest | This variable specifies the CNAME record destination to be associated with the service names defined in monitoring_internal_service_names | string | `alert` | no |
 | monitoring_public_service_names |  | list | `<list>` | no |
 | mysql_internal_service_names |  | list | `<list>` | no |
 | postgresql_internal_service_names |  | list | `<list>` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -272,6 +272,12 @@ variable "monitoring_internal_service_names" {
   default = []
 }
 
+variable "monitoring_internal_service_names_cname_dest" {
+  description = "This variable specifies the CNAME record destination to be associated with the service names defined in monitoring_internal_service_names"
+  type        = "string"
+  default     = "alert"
+}
+
 variable "mysql_internal_service_names" {
   type    = "list"
   default = []
@@ -1372,7 +1378,7 @@ resource "aws_route53_record" "monitoring_internal_service_names" {
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
   name    = "${element(var.monitoring_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
   type    = "CNAME"
-  records = ["${element(var.monitoring_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  records = ["${var.monitoring_internal_service_names_cname_dest}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
   ttl     = "300"
 }
 


### PR DESCRIPTION
alert and alert.cluster CNAMES should point to
alert.blue.'env'.govuk-internal.digital

But due to the way the code is setup alert will point correctly but
alert.cluster will end up pointing to alert.cluster.'env'.govuk-internal.digital
which does not go anywhere.

This fix will get both records pointing into the correct destination.

Solo: @ronocg