### PR TITLE
add mapit alb and security group for Carrenza

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -55,6 +55,7 @@ This project adds global resources for app components:
 | graphite_public_service_names |  | list | `<list>` | no |
 | jumpbox_public_service_names |  | list | `<list>` | no |
 | mapit_internal_service_names |  | list | `<list>` | no |
+| mapit_public_service_names |  | list | `<list>` | no |
 | mongo_internal_service_names |  | list | `<list>` | no |
 | monitoring_internal_service_names |  | list | `<list>` | no |
 | monitoring_public_service_names |  | list | `<list>` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -112,6 +112,11 @@ variable "ubuntutest_public_service_names" {
   default = []
 }
 
+variable "mapit_public_service_names" {
+  type    = "list"
+  default = []
+}
+
 variable "monitoring_public_service_names" {
   type    = "list"
   default = []
@@ -1218,6 +1223,63 @@ resource "aws_autoscaling_attachment" "ubuntutest_asg_attachment_elb" {
 #
 # Mapit
 #
+
+module "mapit_public_lb" {
+  source                                     = "../../modules/aws/lb"
+  name                                       = "${var.stackname}-mapit-public"
+  internal                                   = false
+  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix                  = "elb/${var.stackname}-mapit-public-elb"
+  listener_certificate_domain_name           = "${var.elb_public_certname}"
+  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
+
+  listener_action = {
+    "HTTPS:443" = "HTTP:80"
+  }
+
+  target_group_health_check_path = "/healthcheck"
+  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_carrenza_alb_id}"]
+  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  default_tags                   = "${map("Project", var.stackname, "aws_migration", "mapit", "aws_environment", var.aws_environment)}"
+}
+
+data "aws_autoscaling_groups" "mapit-1" {
+  filter {
+    name   = "key"
+    values = ["Name"]
+  }
+
+  filter {
+    name   = "value"
+    values = ["blue-mapit-1"]
+  }
+}
+
+resource "aws_autoscaling_attachment" "mapit-1_asg_attachment_alb" {
+  count                  = "${length(data.aws_autoscaling_groups.mapit-1.names) > 0 ? 1 : 0}"
+  autoscaling_group_name = "${element(data.aws_autoscaling_groups.mapit-1.names, 0)}"
+  alb_target_group_arn   = "${element(module.mapit_public_lb.target_group_arns, 0)}"
+}
+
+data "aws_autoscaling_groups" "mapit-2" {
+  filter {
+    name   = "key"
+    values = ["Name"]
+  }
+
+  filter {
+    name   = "value"
+    values = ["blue-mapit-2"]
+  }
+}
+
+resource "aws_autoscaling_attachment" "mapit-2_asg_attachment_alb" {
+  count                  = "${length(data.aws_autoscaling_groups.mapit-2.names) > 0 ? 1 : 0}"
+  autoscaling_group_name = "${element(data.aws_autoscaling_groups.mapit-2.names, 0)}"
+  alb_target_group_arn   = "${element(module.mapit_public_lb.target_group_arns, 0)}"
+}
 
 resource "aws_route53_record" "mapit_internal_service_names" {
   count   = "${length(var.mapit_internal_service_names)}"

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1238,7 +1238,7 @@ module "mapit_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/healthcheck"
+  target_group_health_check_path = "/postcode/W54XA"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_carrenza_alb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1290,6 +1290,19 @@ resource "aws_route53_record" "mapit_internal_service_names" {
   ttl     = "300"
 }
 
+resource "aws_route53_record" "mapit_public_service_names" {
+  count   = "${length(var.mapit_public_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.mapit_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${module.mapit_public_lb.lb_dns_name}"
+    zone_id                = "${module.mapit_public_lb.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
 #
 # Mongo
 #

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -8,6 +8,7 @@ Manage the security groups for the entire infrastructure
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | aws_region | AWS region | string | `eu-west-1` | no |
+| carrenza_env_ips | An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_integration_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_production_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_staging_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
@@ -73,6 +74,7 @@ Manage the security groups for the entire infrastructure
 | sg_graphite_internal_elb_id |  |
 | sg_jumpbox_id |  |
 | sg_management_id |  |
+| sg_mapit_carrenza_alb_id |  |
 | sg_mapit_elb_id |  |
 | sg_mapit_id |  |
 | sg_mirrorer_id |  |

--- a/terraform/projects/infra-security-groups/mapit.tf
+++ b/terraform/projects/infra-security-groups/mapit.tf
@@ -61,3 +61,35 @@ resource "aws_security_group_rule" "mapit-elb_egress_any_any" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.mapit_elb.id}"
 }
+
+
+# Security resources for ALB set up for Carrenza access to AWS Mapit
+
+resource "aws_security_group" "mapit_carrenza_alb" {
+  name        = "${var.stackname}_mapit_carrenza_alb"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access the mapit Carrenza ALB "
+
+  tags {
+    Name = "${var.stackname}_mapit_carrenza_alb_access"
+  }
+}
+
+resource "aws_security_group_rule" "mapit_carrenza_alb_ingress_443_carrenza" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  cidr_blocks       = ["${var.carrenza_env_ips}"]
+  security_group_id = "${aws_security_group.mapit_carrenza_alb.id}"
+}
+
+resource "aws_security_group_rule" "mapit_carrenza_alb_egress_any_any" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.mapit_carrenza_alb.id}"
+}

--- a/terraform/projects/infra-security-groups/mapit.tf
+++ b/terraform/projects/infra-security-groups/mapit.tf
@@ -74,7 +74,7 @@ resource "aws_security_group" "mapit_carrenza_alb" {
   }
 }
 
-resource "aws_security_group_rule" "mapit_carrenza_alb_ingress_443_carrenza" {
+resource "aws_security_group_rule" "mapit-carrenza-alb_ingress_443_carrenza" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -84,7 +84,7 @@ resource "aws_security_group_rule" "mapit_carrenza_alb_ingress_443_carrenza" {
   security_group_id = "${aws_security_group.mapit_carrenza_alb.id}"
 }
 
-resource "aws_security_group_rule" "mapit_carrenza_alb_egress_any_any" {
+resource "aws_security_group_rule" "mapit-carrenza-alb_egress_any_any" {
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/mapit.tf
+++ b/terraform/projects/infra-security-groups/mapit.tf
@@ -62,7 +62,6 @@ resource "aws_security_group_rule" "mapit-elb_egress_any_any" {
   security_group_id = "${aws_security_group.mapit_elb.id}"
 }
 
-
 # Security resources for ALB set up for Carrenza access to AWS Mapit
 
 resource "aws_security_group" "mapit_carrenza_alb" {

--- a/terraform/projects/infra-security-groups/mapit.tf
+++ b/terraform/projects/infra-security-groups/mapit.tf
@@ -62,6 +62,19 @@ resource "aws_security_group_rule" "mapit-elb_egress_any_any" {
   security_group_id = "${aws_security_group.mapit_elb.id}"
 }
 
+resource "aws_security_group_rule" "mapit_ingress_mapit-carrenza-alb_http" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.mapit.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.mapit_carrenza_alb.id}"
+}
+
 # Security resources for ALB set up for Carrenza access to AWS Mapit
 
 resource "aws_security_group" "mapit_carrenza_alb" {

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -218,6 +218,10 @@ output "sg_mapit_id" {
   value = "${aws_security_group.mapit.id}"
 }
 
+output "sg_mapit_carrenza_alb_id" {
+  value = "${aws_security_group.mapit_carrenza_alb.id}"
+}
+
 output "sg_mapit_elb_id" {
   value = "${aws_security_group.mapit_elb.id}"
 }

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -44,6 +44,11 @@ variable "carrenza_production_ips" {
   description = "An array of CIDR blocks that will be allowed to SSH to the jumpbox."
 }
 
+variable "carrenza_env_ips" {
+  type        = "list"
+  description = "An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox."
+}
+
 variable "traffic_replay_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will replay traffic against an environment"


### PR DESCRIPTION
# Context

When transitioning from Carrenza to AWS provider, it was decided to split the different different components of the Mapit service across the 2 providers for operational reasons.

In essence:
1. the backend of the Mapit service will reside in the AWS provider along with its database
2. the frontend of the Mapit service will still reside in the Carrenza provider

# Consequences

There is a need for the frontend of Mapit in Carrenza to access its Backend in AWS. The current terraform plans do not allow for this because backend services are by default within private subnets.

# Decisions

The decision is to create an Application load balancer in AWS which allows Carrenza IPs to access the Mapit backend in AWS. 

# Linked resources

1. https://trello.com/c/CFCVBVZS/1643-create-configure-inet-facing-mapit-load-balancer-with-limited-reachability
2. https://github.com/alphagov/govuk-aws-data/pull/241