### PR TITLE
Add draft-publicapi DNS and firewall entries

### DIFF
--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -131,6 +131,16 @@ resource "aws_route53_record" "draft-router-api_internal_record" {
   }
 }
 
+# TODO publicapi is a special set of nginx config that routes /api requests to
+# their relevant apps upstream.
+resource "aws_route53_record" "draft-cache_publicapi_service_record" {
+  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
+  name    = "draft-publicapi.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
+  type    = "CNAME"
+  records = ["draft-cache.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"]
+  ttl     = 300
+}
+
 resource "aws_elb" "draft-cache_external_elb" {
   name            = "${var.stackname}-draft-cache-external"
   subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]

--- a/terraform/projects/infra-security-groups/draft-cache.tf
+++ b/terraform/projects/infra-security-groups/draft-cache.tf
@@ -72,6 +72,21 @@ resource "aws_security_group" "draft-cache_elb" {
   }
 }
 
+# Allow draft-cache to speak to it's own ELB to reroute publicapi traffic
+# to itself
+resource "aws_security_group_rule" "draft-cache-elb_ingress_cache_https" {
+  type      = "ingress"
+  to_port   = 443
+  from_port = 443
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.draft-cache_elb.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.draft-cache.id}"
+}
+
 resource "aws_security_group" "draft-cache_external_elb" {
   name        = "${var.stackname}_draft-cache_elb_external_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"


### PR DESCRIPTION
This commit adds a DNS CNAME entry for `draft-publicapi` and also allows the draft_cache ELB to route to itself similar to the live stack cache machines.

Trello: https://trello.com/c/JDiLJ8h1/570-enable-viewing-content-store-on-draft-stack