### PR TITLE
Bump bouncer instance sizes pre-migration

### DIFF
--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -157,7 +157,7 @@ module "bouncer" {
   default_tags                      = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "bouncer", "aws_hostname", "bouncer-1")}"
   instance_subnet_ids               = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids       = ["${data.terraform_remote_state.infra_security_groups.sg_bouncer_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                     = "t2.medium"
+  instance_type                     = "t3.xlarge"
   instance_additional_user_data     = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length           = "1"
   instance_elb_ids                  = ["${aws_elb.bouncer_external_elb.id}"]


### PR DESCRIPTION
- These had been spec'd a bit tight for my liking.

- Load in Carrenza seems overall low, but I rather reduce instance size
  then risk running into overloading issues on migration

solo: @schmie