### PR TITLE
fix the aws/lb module for when no secondary certificate is specified

### DIFF
--- a/terraform/modules/aws/lb/main.tf
+++ b/terraform/modules/aws/lb/main.tf
@@ -238,7 +238,7 @@ resource "aws_lb_listener" "listener" {
 }
 
 resource "aws_lb_listener_certificate" "secondary" {
-  count           = "${length(compact(data.null_data_source.values.*.inputs.ssl_arn_index))}"
+  count           = "${var.listener_secondary_certificate_domain_name == ""? 0 : length(compact(data.null_data_source.values.*.inputs.ssl_arn_index))}"
   listener_arn    = "${element(aws_lb_listener.listener.*.arn, count.index)}"
   certificate_arn = "${data.aws_acm_certificate.secondary_cert.0.arn}"
 }


### PR DESCRIPTION
For secondary certificate attachment:
1. IF certificate name is PRESENT, then CREATE attach certificate to HTTPS listeners only
2. ELSE do not create secondary certificate attachment

TESTING:
1. tested for `infra-public-services` project for no change -> module keeps previous functionality
2. tested for `app-bouncer` project for no secondary certificate created -> fix issue