### PR TITLE
GovUK Migr Trello 1646: Deny EIP Release

### DIFF
--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -135,6 +135,21 @@ resource "aws_key_pair" "govuk-infra-key" {
   public_key = "${var.ssh_public_key}"
 }
 
+# Deny EIP Releasing for all users
+data "aws_iam_policy_document" "deny-eip-release" {
+  statement {
+    actions   = ["ec2:ReleaseAddress"]
+    effect    = "Deny"
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "deny-eip-release" {
+  name        = "DenyEipRelease"
+  description = "Deny users the ability to release allocated Elastic IPs"
+  policy      = "${data.aws_iam_policy_document.deny-eip-release.json}"
+}
+
 # CloudTrail configuration
 resource "aws_cloudwatch_log_group" "cloudtrail" {
   name              = "CloudTrail/logs"


### PR DESCRIPTION
Adding Policy to make sure they are unable to release/remove
EIPs from the environments.

The reason we wish to deny removal of the EIPs, is that we do not want
the EIPs changing. These EIPs are attahced to teh NAT gateways and if we
did have to re-spin the nat gateways then we would re-attach these EIPs
again.

This needs to be merged with branch https://github.com/alphagov/govuk-aws-data/tree/GovUK-Migr-Trello-1646

Pair: @ronocg @th31nitiate