### PR TITLE
Revert "Fix govukcli bug"

### DIFF
--- a/tools/govukcli
+++ b/tools/govukcli
@@ -246,7 +246,7 @@ function run_ssh {
           ssh -At $SSH_OPTS $SSH_USER@$JUMPBOX "ssh -q ${NODE_CLASS}"
         else
           # shellcheck disable=SC2029
-          ssh -At $SSH_OPTS $SSH_USER@$JUMPBOX "ssh -q \\\`govuk_node_list --single-node -c ${NODE_CLASS}\\\`"
+          ssh -At $SSH_OPTS $SSH_USER@$JUMPBOX "ssh -q \`govuk_node_list --single-node -c ${NODE_CLASS}\`"
         fi
       fi
     ;;


### PR DESCRIPTION
Reverts alphagov/govuk-aws#682

This change is throwing up the following error[1] for myself and @theseanything, but undoing it for on my GDS MacBook running bash works again.

1
```bash
$govukcli ssh monitoring                            
unknown option -- -
usage: ssh [-1246AaCfgKkMNnqsTtVvXxYy] [-b bind_address] [-c cipher_spec]
           [-D [bind_address:]port] [-E log_file] [-e escape_char]
           [-F configfile] [-I pkcs11] [-i identity_file]
           [-L [bind_address:]port:host:hostport] [-l login_name] [-m mac_spec]
           [-O ctl_cmd] [-o option] [-p port]
           [-Q cipher | cipher-auth | mac | kex | key]
           [-R [bind_address:]port:host:hostport] [-S ctl_path] [-W host:port]
           [-w local_tun[:remote_tun]] [user@]hostname [command]```