### PR TITLE
add content store external elb for gor traffic replay

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -34,6 +34,7 @@ This project adds global resources for app components:
 | ckan_public_service_cnames |  | list | `<list>` | no |
 | ckan_public_service_names |  | list | `<list>` | no |
 | content_store_internal_service_names |  | list | `<list>` | no |
+| content_store_public_service_names |  | list | `<list>` | no |
 | db_admin_internal_service_names |  | list | `<list>` | no |
 | deploy_internal_service_names |  | list | `<list>` | no |
 | deploy_public_service_names |  | list | `<list>` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -77,6 +77,11 @@ variable "ckan_public_service_cnames" {
   default = []
 }
 
+variable "content_store_public_service_names" {
+  type    = "list"
+  default = []
+}
+
 variable "deploy_public_service_names" {
   type    = "list"
   default = []
@@ -740,6 +745,58 @@ resource "aws_route53_record" "ckan_internal_service_cnames" {
 }
 
 # Content-store
+
+module "content-store_public_lb" {
+  source                                     = "../../modules/aws/lb"
+  name                                       = "${var.stackname}-content-store-public"
+  internal                                   = false
+  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix                  = "elb/${var.stackname}-content-store-public-elb"
+  listener_certificate_domain_name           = "${var.elb_public_certname}"
+  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
+
+  listener_action = {
+    "HTTPS:443" = "HTTP:80"
+  }
+
+  target_group_health_check_path = "/healthcheck"
+  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_external_elb_id}"]
+  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  default_tags                   = "${map("Project", var.stackname, "aws_migration", "content-store", "aws_environment", var.aws_environment)}"
+}
+
+resource "aws_route53_record" "content-store_public_service_names" {
+  count   = "${length(var.content_store_public_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.content_store_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${module.content-store_public_lb.lb_dns_name}"
+    zone_id                = "${module.content-store_public_lb.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+data "aws_autoscaling_groups" "content-store" {
+  filter {
+    name   = "key"
+    values = ["Name"]
+  }
+
+  filter {
+    name   = "value"
+    values = ["blue-content-store"]
+  }
+}
+
+resource "aws_autoscaling_attachment" "content-store_asg_attachment_alb" {
+  count                  = "${length(data.aws_autoscaling_groups.content-store.names) > 0 ? 1 : 0}"
+  autoscaling_group_name = "${element(data.aws_autoscaling_groups.content-store.names, 0)}"
+  alb_target_group_arn   = "${element(module.content-store_public_lb.target_group_arns, 0)}"
+}
 
 resource "aws_route53_record" "content_store_internal_service_names" {
   count   = "${length(var.content_store_internal_service_names)}"


### PR DESCRIPTION
# Context

During the AWS migration, it is desirable to have traffic replay from Carrenza Staging to AWS staging for the `content-store` app. 

Since the traffic is HTTPS and uses the production certificate, the load balancer in AWS Staging must have this production certificate also. 

Unfortunately, the classic public load balancer in AWS staging for the content-store does not allow a secondary certificate.

# Decisions

1. Create an application load balancer (rather than a classic load balancer) for the content-store. This load balancer will have both AWS certificate as well as the production one. This will allow this application load balancer to terminate the Gor traffic replace.

2. The application load balancer is created via a terraform module (has no count option) and is present for all AWS environment and therefore, it impacts all environment.

# Related PRs:
1. https://github.com/alphagov/govuk-aws-data/pull/250

