### PR TITLE
Add explicit PSK for AWS production VPN to Carrenza

### DIFF
--- a/terraform/projects/infra-carrenza-vpn/README.md
+++ b/terraform/projects/infra-carrenza-vpn/README.md
@@ -1,0 +1,25 @@
+## Module: projects/infra-carrenza-vpn
+
+Creates a VPN for AWS to connect to Carrenza
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_region | AWS region | string | `eu-west-1` | no |
+| aws_tunnel1_psk | Explicit PSK in format required by Carrenza | string | - | yes |
+| aws_tunnel2_psk | Explicit PSK in format required by Carrenza | string | - | yes |
+| carrenza_internal_net_cidr | Internal network range of the environment in Carrenza | string | - | yes |
+| carrenza_vpn_endpoint_ip | Public IP address of the VPN gateway in Carrenza | string | - | yes |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
+| remote_state_infra_vpc_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
+| stackname | Stackname | string | `` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| aws_vpn_connection_id | The ID of the AWS to Carrenza VPN |
+

--- a/terraform/projects/infra-carrenza-vpn/main.tf
+++ b/terraform/projects/infra-carrenza-vpn/main.tf
@@ -1,0 +1,137 @@
+/**
+* ## Module: projects/infra-carrenza-vpn
+*
+* Creates a VPN for AWS to connect to Carrenza
+*/
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+  default     = ""
+}
+
+variable "carrenza_vpn_endpoint_ip" {
+  type        = "string"
+  description = "Public IP address of the VPN gateway in Carrenza"
+}
+
+variable "carrenza_internal_net_cidr" {
+  type        = "string"
+  description = "Internal network range of the environment in Carrenza"
+}
+
+variable "aws_tunnel1_psk" {
+  type        = "string"
+  description = "Explicit PSK in format required by Carrenza"
+}
+
+variable "aws_tunnel2_psk" {
+  type        = "string"
+  description = "Explicit PSK in format required by Carrenza"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "S3 bucket we store our terraform state in"
+}
+
+variable "remote_state_infra_networking_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_monitoring remote state "
+  default     = ""
+}
+
+variable "remote_state_infra_vpc_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_monitoring remote state "
+  default     = ""
+}
+
+# Resources
+# --------------------------------------------------------------
+
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.40.0"
+}
+
+data "terraform_remote_state" "infra_networking" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_vpc" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+resource "aws_customer_gateway" "carrenza_vpn_gateway" {
+  bgp_asn    = 65000
+  ip_address = "${var.carrenza_vpn_endpoint_ip}"
+  type       = "ipsec.1"
+
+  tags {
+    Name = "Carrenza - ${var.stackname}"
+  }
+}
+
+resource "aws_vpn_gateway" "aws_vpn_gateway" {
+  vpc_id = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+
+  tags {
+    Name = "${var.stackname} VPN Gateway"
+  }
+}
+
+resource "aws_vpn_connection" "aws_carrenza_vpn" {
+  vpn_gateway_id        = "${aws_vpn_gateway.aws_vpn_gateway.id}"
+  customer_gateway_id   = "${aws_customer_gateway.carrenza_vpn_gateway.id}"
+  tunnel1_preshared_key = "${var.aws_tunnel1_psk}"
+  tunnel2_preshared_key = "${var.aws_tunnel2_psk}"
+  type                  = "ipsec.1"
+  static_routes_only    = true
+
+  tags {
+    Name = "${var.stackname} AWS to Carrenza"
+  }
+}
+
+resource "aws_vpn_connection_route" "Carrenza" {
+  destination_cidr_block = "${var.carrenza_internal_net_cidr}"
+  vpn_connection_id      = "${aws_vpn_connection.aws_carrenza_vpn.id}"
+}
+
+resource "aws_vpn_gateway_route_propagation" "Carrenza_route_propagation" {
+  count          = "${length(data.terraform_remote_state.infra_networking.private_subnet_names_route_tables_map)}"
+  vpn_gateway_id = "${aws_vpn_gateway.aws_vpn_gateway.id}"
+  route_table_id = "${element(values(data.terraform_remote_state.infra_networking.private_subnet_names_route_tables_map), count.index)}"
+}
+
+# Outputs
+# --------------------------------------------------------------
+
+output "aws_vpn_connection_id" {
+  value       = "${aws_vpn_connection.aws_carrenza_vpn.id}"
+  description = "The ID of the AWS to Carrenza VPN"
+}

--- a/terraform/projects/infra-carrenza-vpn/production.govuk.backend
+++ b/terraform/projects/infra-carrenza-vpn/production.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "govuk/infra-carrenza-vpn.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-vpc/README.md
+++ b/terraform/projects/infra-vpc/README.md
@@ -9,10 +9,6 @@ and resources to export these logs to S3
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | aws_region | AWS region | string | `eu-west-1` | no |
-| aws_tunnel1_psk | Explicit PSK in format required by Carrenza | string | - | yes |
-| aws_tunnel2_psk | Explicit PSK in format required by Carrenza | string | - | yes |
-| carrenza_internal_net_cidr | Internal network range of the environment in Carrenza | string | - | yes |
-| carrenza_vpn_endpoint_ip | Public IP address of the VPN gateway in Carrenza | string | - | yes |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
@@ -25,7 +21,6 @@ and resources to export these logs to S3
 
 | Name | Description |
 |------|-------------|
-| aws_vpn_connection_id | The ID of the AWS to Carrenza VPN |
 | internet_gateway_id | The ID of the Internet Gateway |
 | route_table_public_id | The ID of the public routing table |
 | vpc_cidr | The CIDR block of the VPC |

--- a/terraform/projects/infra-vpc/README.md
+++ b/terraform/projects/infra-vpc/README.md
@@ -9,6 +9,8 @@ and resources to export these logs to S3
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | aws_region | AWS region | string | `eu-west-1` | no |
+| aws_tunnel1_psk | Explicit PSK in format required by Carrenza | string | - | yes |
+| aws_tunnel2_psk | Explicit PSK in format required by Carrenza | string | - | yes |
 | carrenza_internal_net_cidr | Internal network range of the environment in Carrenza | string | - | yes |
 | carrenza_vpn_endpoint_ip | Public IP address of the VPN gateway in Carrenza | string | - | yes |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |

--- a/terraform/projects/infra-vpc/main.tf
+++ b/terraform/projects/infra-vpc/main.tf
@@ -59,6 +59,16 @@ variable "carrenza_internal_net_cidr" {
   description = "Internal network range of the environment in Carrenza"
 }
 
+variable "aws_tunnel1_psk" {
+  type        = "string"
+  description = "Explicit PSK in format required by Carrenza"
+}
+
+variable "aws_tunnel2_psk" {
+  type        = "string"
+  description = "Explicit PSK in format required by Carrenza"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -152,10 +162,12 @@ resource "aws_vpn_gateway" "aws_vpn_gateway" {
 }
 
 resource "aws_vpn_connection" "aws_carrenza_vpn" {
-  vpn_gateway_id      = "${aws_vpn_gateway.aws_vpn_gateway.id}"
-  customer_gateway_id = "${aws_customer_gateway.carrenza_vpn_gateway.id}"
-  type                = "ipsec.1"
-  static_routes_only  = true
+  vpn_gateway_id        = "${aws_vpn_gateway.aws_vpn_gateway.id}"
+  customer_gateway_id   = "${aws_customer_gateway.carrenza_vpn_gateway.id}"
+  tunnel1_preshared_key = "${var.aws_tunnel1_psk}"
+  tunnel2_preshared_key = "${var.aws_tunnel2_psk}"
+  type                  = "ipsec.1"
+  static_routes_only    = true
 
   tags {
     Name = "${var.stackname} AWS to Carrenza"

--- a/terraform/projects/infra-vpc/main.tf
+++ b/terraform/projects/infra-vpc/main.tf
@@ -49,26 +49,6 @@ variable "remote_state_infra_monitoring_key_stack" {
   default     = ""
 }
 
-variable "carrenza_vpn_endpoint_ip" {
-  type        = "string"
-  description = "Public IP address of the VPN gateway in Carrenza"
-}
-
-variable "carrenza_internal_net_cidr" {
-  type        = "string"
-  description = "Internal network range of the environment in Carrenza"
-}
-
-variable "aws_tunnel1_psk" {
-  type        = "string"
-  description = "Explicit PSK in format required by Carrenza"
-}
-
-variable "aws_tunnel2_psk" {
-  type        = "string"
-  description = "Explicit PSK in format required by Carrenza"
-}
-
 # Resources
 # --------------------------------------------------------------
 
@@ -143,42 +123,6 @@ module "vpc_flow_log_exporter" {
   lambda_log_retention_in_days = "${var.cloudwatch_log_retention}"
 }
 
-resource "aws_customer_gateway" "carrenza_vpn_gateway" {
-  bgp_asn    = 65000
-  ip_address = "${var.carrenza_vpn_endpoint_ip}"
-  type       = "ipsec.1"
-
-  tags {
-    Name = "Carrenza - ${var.stackname}"
-  }
-}
-
-resource "aws_vpn_gateway" "aws_vpn_gateway" {
-  vpc_id = "${module.vpc.vpc_id}"
-
-  tags {
-    Name = "${var.stackname} VPN Gateway"
-  }
-}
-
-resource "aws_vpn_connection" "aws_carrenza_vpn" {
-  vpn_gateway_id        = "${aws_vpn_gateway.aws_vpn_gateway.id}"
-  customer_gateway_id   = "${aws_customer_gateway.carrenza_vpn_gateway.id}"
-  tunnel1_preshared_key = "${var.aws_tunnel1_psk}"
-  tunnel2_preshared_key = "${var.aws_tunnel2_psk}"
-  type                  = "ipsec.1"
-  static_routes_only    = true
-
-  tags {
-    Name = "${var.stackname} AWS to Carrenza"
-  }
-}
-
-resource "aws_vpn_connection_route" "Carrenza" {
-  destination_cidr_block = "${var.carrenza_internal_net_cidr}"
-  vpn_connection_id      = "${aws_vpn_connection.aws_carrenza_vpn.id}"
-}
-
 # Outputs
 # --------------------------------------------------------------
 
@@ -200,9 +144,4 @@ output "internet_gateway_id" {
 output "route_table_public_id" {
   value       = "${module.vpc.route_table_public_id}"
   description = "The ID of the public routing table"
-}
-
-output "aws_vpn_connection_id" {
-  value       = "${aws_vpn_connection.aws_carrenza_vpn.id}"
-  description = "The ID of the AWS to Carrenza VPN"
 }


### PR DESCRIPTION
- Carrenza expects 32 digit alphanumerical PSK
- Carrenza needed to configure a single subnet of /20 range in order for
the VPN to work AWS side

aws-data part: https://github.com/alphagov/govuk-aws-data/pull/256

pair: @schmie @stephenharker