### PR TITLE
Add carrenza draft-frontend access to aws draft-content-store

### DIFF
--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -19,6 +19,11 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "draft_content_store_public_service_names" {
+  type    = "list"
+  default = []
+}
+
 variable "instance_ami_filter_name" {
   type        = "string"
   description = "Name to use to find AMI images"
@@ -103,6 +108,19 @@ resource "aws_elb" "draft-content-store_external_elb" {
 resource "aws_route53_record" "external_service_record" {
   zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
   name    = "draft-content-store.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_elb.draft-content-store_external_elb.dns_name}"
+    zone_id                = "${aws_elb.draft-content-store_external_elb.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "draft-content-store_public_service_names" {
+  count   = "${length(var.draft_content_store_public_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.draft_content_store_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
   type    = "A"
 
   alias {
@@ -207,6 +225,11 @@ module "alarms-elb-draft-content-store-external" {
 
 # Outputs
 # --------------------------------------------------------------
+
+output "draft-content-store_public_service_dns_names" {
+  value       = "${aws_route53_record.draft-content-store_public_service_names.*.name}"
+  description = "AWS' Public service DNs records for the draft-content-store ELB"
+}
 
 output "draft-content-store_elb_address" {
   value       = "${aws_elb.draft-content-store_external_elb.dns_name}"

--- a/terraform/projects/infra-security-groups/draft-content-store.tf
+++ b/terraform/projects/infra-security-groups/draft-content-store.tf
@@ -96,7 +96,7 @@ resource "aws_security_group_rule" "draft-content-store-external-elb_ingress_off
   protocol  = "tcp"
 
   security_group_id = "${aws_security_group.draft-content-store_external_elb.id}"
-  cidr_blocks       = ["${var.office_ips}"]
+  cidr_blocks       = ["${var.office_ips}", "${var.carrenza_draft_frontend_ips}"]
 }
 
 resource "aws_security_group_rule" "draft-content-store-external-elb_egress_any_any" {

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -49,6 +49,12 @@ variable "carrenza_env_ips" {
   description = "An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox."
 }
 
+variable "carrenza_draft_frontend_ips" {
+  type        = "list"
+  description = "An array of CIDR blocks for the current environment that will allow access to draft-content-store from Carrenza."
+  default     = []
+}
+
 variable "traffic_replay_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will replay traffic against an environment"


### PR DESCRIPTION
Extends the allow list in the security group in Staging and Prod.
Integration has migrated so will use a blank list (default value).

Adding a public service dns entry for draft-content-store to the
external root dns.

This is required as part of the migration work for draft-content-store.

Co-authored-by: Conor Glynn <conor.glynn@digital.cabinet-office.gov.uk>