### PR TITLE
Add carrenza draft-frontend access to aws draft-content-store

### DIFF
--- a/terraform/projects/app-draft-content-store/README.md
+++ b/terraform/projects/app-draft-content-store/README.md
@@ -27,7 +27,7 @@ draft-content-store node
 
 | Name | Description |
 |------|-------------|
-| draft-content-store_elb_address | AWS' internal DNS name for the draft-content-store ELB |
+| draft-content-store_elb_address | AWS' DNS name for the draft-content-store ELB |
 | external_service_dns_name | DNS name to access the node service |
 | internal_service_dns_name | DNS name to access the node service |
 

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -210,7 +210,7 @@ module "alarms-elb-draft-content-store-external" {
 
 output "draft-content-store_elb_address" {
   value       = "${aws_elb.draft-content-store_external_elb.dns_name}"
-  description = "AWS' internal DNS name for the draft-content-store ELB"
+  description = "AWS' DNS name for the draft-content-store ELB"
 }
 
 output "external_service_dns_name" {

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -44,6 +44,7 @@ This project adds global resources for app components:
 | draft_cache_public_service_cnames |  | list | `<list>` | no |
 | draft_cache_public_service_names |  | list | `<list>` | no |
 | draft_content_store_internal_service_names |  | list | `<list>` | no |
+| draft_content_store_public_service_names |  | list | `<list>` | no |
 | draft_frontend_internal_service_cnames |  | list | `<list>` | no |
 | draft_frontend_internal_service_names |  | list | `<list>` | no |
 | elb_public_certname | The ACM cert domain name to find the ARN of | string | - | yes |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -378,6 +378,11 @@ variable "whitehall_frontend_internal_service_names" {
   default = []
 }
 
+variable "draft_content_store_public_service_names" {
+  type    = "list"
+  default = []
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -1736,5 +1741,14 @@ resource "aws_route53_record" "whitehall_frontend_internal_service_names" {
   name    = "${element(var.whitehall_frontend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
   type    = "CNAME"
   records = ["${element(var.whitehall_frontend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+resource "aws_route53_record" "draft_content_store_public_service_names" {
+  count   = "${length(var.draft_content_store_public_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.draft_content_store_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.draft_content_store_public_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"]
   ttl     = "300"
 }

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -8,6 +8,7 @@ Manage the security groups for the entire infrastructure
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | aws_region | AWS region | string | `eu-west-1` | no |
+| carrenza_draft_frontend_ips | An array of CIDR blocks for the current environment that will allow access to draft-content-store from Carrenza. | list | `<list>` | no |
 | carrenza_env_ips | An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_integration_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_production_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |

--- a/terraform/projects/infra-security-groups/draft-content-store.tf
+++ b/terraform/projects/infra-security-groups/draft-content-store.tf
@@ -90,13 +90,14 @@ resource "aws_security_group" "draft-content-store_external_elb" {
 
 # TODO: Audit
 resource "aws_security_group_rule" "draft-content-store-external-elb_ingress_office_https" {
+  count     = "${length(var.carrenza_draft_frontend_ips) > 0 ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443
   protocol  = "tcp"
 
   security_group_id = "${aws_security_group.draft-content-store_external_elb.id}"
-  cidr_blocks       = ["${var.office_ips}"]
+  cidr_blocks       = ["${var.carrenza_draft_frontend_ips}"]
 }
 
 resource "aws_security_group_rule" "draft-content-store-external-elb_egress_any_any" {

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -49,6 +49,12 @@ variable "carrenza_env_ips" {
   description = "An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox."
 }
 
+variable "carrenza_draft_frontend_ips" {
+  type        = "list"
+  description = "An array of CIDR blocks for the current environment that will allow access to draft-content-store from Carrenza."
+  default     = []
+}
+
 variable "traffic_replay_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will replay traffic against an environment"


### PR DESCRIPTION
Extends the allow list in the security group in Staging and Prod.
Integration has migrated so will use a blank list (default value).

Adding a public service dns entry for draft-content-store to the
external root dns.

This is required as part of the migration work for draft-content-store.

Authored-by: Conor Glynn <conor.glynn@digital.cabinet-office.gov.uk> & Julian Standring <julian.standring@digital.cabinet-office.gov.uk>