### PR TITLE
Double disk size for warehouse db

### DIFF
--- a/terraform/projects/app-warehouse/main.tf
+++ b/terraform/projects/app-warehouse/main.tf
@@ -73,7 +73,7 @@ module "warehouse-postgresql-primary_rds_instance" {
   subnet_ids          = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
   username            = "${var.username}"
   password            = "${var.password}"
-  allocated_storage   = "128"
+  allocated_storage   = "256"
   instance_class      = "db.m4.large"
   instance_name       = "${var.stackname}-warehouse-postgresql-primary"
   multi_az            = "${var.multi_az}"


### PR DESCRIPTION
The data syncs are failing because there's not enough space for it
to carry out the job.

https://deploy.publishing.service.gov.uk/job/copy_data_to_integration/857/console