### PR TITLE
Trello-1796: Add ALB for support-api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .terraform/
 *.tfstate
 *.tfstate.backup
+*.swp

--- a/terraform/modules/aws/lb/README.md
+++ b/terraform/modules/aws/lb/README.md
@@ -68,5 +68,6 @@ http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/elb-metricscollect
 | lb_dns_name | The DNS name of the load balancer. |
 | lb_id | The ARN of the load balancer (matches arn). |
 | lb_zone_id | The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record). |
+| load_balancer_ssl_listeners | List of https listeners on the Load Balancer. |
 | target_group_arns | List of the default target group ARNs. |
 

--- a/terraform/modules/aws/lb/main.tf
+++ b/terraform/modules/aws/lb/main.tf
@@ -388,3 +388,8 @@ output "target_group_arns" {
   value       = ["${aws_lb_target_group.tg_default.*.arn}"]
   description = "List of the default target group ARNs."
 }
+
+output "load_balancer_ssl_listeners" {
+  value       = ["${aws_lb_listener.listener.*.arn}"]
+  description = "List of https listeners on the Load Balancer."
+}

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -16,6 +16,7 @@ This project adds global resources for app components:
 | asset_master_internal_service_names |  | list | `<list>` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| backend_alb_blocked_host_headers |  | list | `<list>` | no |
 | backend_internal_service_cnames |  | list | `<list>` | no |
 | backend_internal_service_names |  | list | `<list>` | no |
 | backend_public_service_cnames |  | list | `<list>` | no |
@@ -82,6 +83,7 @@ This project adds global resources for app components:
 | search_internal_service_cnames |  | list | `<list>` | no |
 | search_internal_service_names |  | list | `<list>` | no |
 | stackname | Stackname | string | - | yes |
+| support_api_public_service_names |  | list | `<list>` | no |
 | transition_db_admin_internal_service_names |  | list | `<list>` | no |
 | transition_postgresql_internal_service_names |  | list | `<list>` | no |
 | ubuntutest_public_service_names |  | list | `<list>` | no |

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -105,6 +105,7 @@ Manage the security groups for the entire infrastructure
 | sg_rummager-elasticsearch_id |  |
 | sg_search_elb_id |  |
 | sg_search_id |  |
+| sg_support-api_external_elb_id |  |
 | sg_transition-db-admin_elb_id |  |
 | sg_transition-db-admin_id |  |
 | sg_transition-postgresql-primary_id |  |

--- a/terraform/projects/infra-security-groups/backend.tf
+++ b/terraform/projects/infra-security-groups/backend.tf
@@ -48,6 +48,19 @@ resource "aws_security_group_rule" "backend_ingress_backend-elb-external_http" {
   source_security_group_id = "${aws_security_group.backend_elb_external.id}"
 }
 
+resource "aws_security_group_rule" "support-api_ingress_elb_external_http" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.backend.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.support-api_external_elb.id}"
+}
+
 resource "aws_security_group" "backend_elb_internal" {
   name        = "${var.stackname}_backend_elb_internal_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -377,3 +377,7 @@ output "sg_whitehall-frontend_id" {
 output "sg_aws-vpn_id" {
   value = "${aws_security_group.vpn.id}"
 }
+
+output "sg_support-api_external_elb_id" {
+  value = "${aws_security_group.support-api_external_elb.id}"
+}

--- a/terraform/projects/infra-security-groups/support-api.tf
+++ b/terraform/projects/infra-security-groups/support-api.tf
@@ -1,0 +1,41 @@
+#
+# == Manifest: Project: Security Groups: support-api
+#
+# The puppetmaster needs to be accessible on ports:
+#   - 443 from the other VMs
+#
+# === Variables:
+# stackname - string
+#
+# === Outputs:
+# sg_support-api_elb_id
+
+resource "aws_security_group" "support-api_external_elb" {
+  name        = "${var.stackname}_support-api_external_elb_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access the support-api external ELB"
+
+  tags {
+    Name = "${var.stackname}_support-api_external_elb_access"
+  }
+}
+
+resource "aws_security_group_rule" "support-api_ingress_external-elb_https" {
+  count     = "${length(var.carrenza_env_ips) > 0 ? 1 : 0}"
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id = "${aws_security_group.support-api_external_elb.id}"
+  cidr_blocks       = ["${var.carrenza_env_ips}"]
+}
+
+resource "aws_security_group_rule" "support-api_egress_external_elb_any_any" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.support-api_external_elb.id}"
+}


### PR DESCRIPTION
This adds an application load balancer for the support-api service.
The support-api services resides on the backend instances, the backend
instances already have an LB associated with them as the other services
that run on the backend need to be accessible by the world, but
support-api needs to be tied down to the carrenza egress ips.

Therefore here we place a rule on the current backedn application load
balancer that gives back a 404 for support-api host-headers. And we
roll a new ALB that is limited via security group to the carrenza egress
ips, the new ALB will only be used for support-api backend services.

Solo: @ronocg <conor.glynn@digital.cabnet-office.gov.uk>