### PR TITLE
BAU: Fixup Terraform resources for VPN

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -13,7 +13,7 @@ Manage the security groups for the entire infrastructure
 | carrenza_integration_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_production_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_staging_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
-| carrenza_subnet_cidr | The Carrenza subnet CIDR | list | - | yes |
+| carrenza_vpn_subnet_cidr | The Carrenza VPN subnet CIDR | list | `<list>` | no |
 | office_ips | An array of CIDR blocks that will be allowed offsite access. | list | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -375,7 +375,7 @@ output "sg_whitehall-frontend_id" {
 }
 
 output "sg_aws-vpn_id" {
-  value = "${aws_security_group.vpn.id}"
+  value = "${aws_security_group.vpn.*.id}"
 }
 
 output "sg_support-api_external_elb_id" {

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -60,7 +60,8 @@ variable "traffic_replay_ips" {
   description = "An array of CIDR blocks that will replay traffic against an environment"
 }
 
-variable "carrenza_subnet_cidr" {
+variable "carrenza_vpn_subnet_cidr" {
   type        = "list"
-  description = "The Carrenza subnet CIDR"
+  description = "The Carrenza VPN subnet CIDR"
+  default     = []
 }

--- a/terraform/projects/infra-security-groups/vpn.tf
+++ b/terraform/projects/infra-security-groups/vpn.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "vpn" {
+  count       = "${length(var.carrenza_vpn_subnet_cidr) > 0 ? 1 : 0}"
   name        = "${var.stackname}_vpn"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "This is the group used to access AWS from Carrenza"
@@ -9,6 +10,7 @@ resource "aws_security_group" "vpn" {
 }
 
 resource "aws_security_group_rule" "vpn_ingress_aws_carrenza" {
+  count     = "${length(var.carrenza_vpn_subnet_cidr) > 0 ? 1 : 0}"
   type      = "ingress"
   from_port = 8
   to_port   = 0
@@ -16,10 +18,11 @@ resource "aws_security_group_rule" "vpn_ingress_aws_carrenza" {
 
   security_group_id = "${aws_security_group.vpn.id}"
 
-  cidr_blocks = "${var.carrenza_subnet_cidr}"
+  cidr_blocks = "${var.carrenza_vpn_subnet_cidr}"
 }
 
 resource "aws_security_group_rule" "vpn_egress_carrenza_aws" {
+  count     = "${length(var.carrenza_vpn_subnet_cidr) > 0 ? 1 : 0}"
   type      = "egress"
   from_port = 8
   to_port   = 0
@@ -27,10 +30,11 @@ resource "aws_security_group_rule" "vpn_egress_carrenza_aws" {
 
   security_group_id = "${aws_security_group.vpn.id}"
 
-  cidr_blocks = "${var.carrenza_subnet_cidr}"
+  cidr_blocks = "${var.carrenza_vpn_subnet_cidr}"
 }
 
 resource "aws_security_group_rule" "vpn_ingress_http_http" {
+  count     = "${length(var.carrenza_vpn_subnet_cidr) > 0 ? 1 : 0}"
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -38,10 +42,11 @@ resource "aws_security_group_rule" "vpn_ingress_http_http" {
 
   security_group_id = "${aws_security_group.vpn.id}"
 
-  cidr_blocks = "${var.carrenza_subnet_cidr}"
+  cidr_blocks = "${var.carrenza_vpn_subnet_cidr}"
 }
 
 resource "aws_security_group_rule" "vpn_ingress_https_https" {
+  count     = "${length(var.carrenza_vpn_subnet_cidr) > 0 ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -49,5 +54,5 @@ resource "aws_security_group_rule" "vpn_ingress_https_https" {
 
   security_group_id = "${aws_security_group.vpn.id}"
 
-  cidr_blocks = "${var.carrenza_subnet_cidr}"
+  cidr_blocks = "${var.carrenza_vpn_subnet_cidr}"
 }


### PR DESCRIPTION
The VPN resources / security group will not exist in integration_aws but
will exist in staging and production aws.

This PR is to put in place a count loop for the vpn security group and
rules, so that terraform will not attempt to create them for
environments that do not have the correct variable set.

Solo: @ronocg <conor.glynn@digital.cabinet-office.gov.uk>