### PR TITLE
Trello-1808: Tie down access to content-stores AWS

### DIFF
--- a/terraform/projects/infra-security-groups/content-store.tf
+++ b/terraform/projects/infra-security-groups/content-store.tf
@@ -95,7 +95,7 @@ resource "aws_security_group_rule" "content-store-external-elb_ingress_public_ht
   protocol  = "tcp"
 
   security_group_id = "${aws_security_group.content-store_external_elb.id}"
-  cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}"]
+  cidr_blocks       = ["${var.carrenza_env_ips}", "${var.office_ips}"]
 }
 
 resource "aws_security_group_rule" "content-store-external-elb_egress_any_any" {


### PR DESCRIPTION
The content-store external ALB and external ELB in staging_aws and
production_aws are currently opened to the world. Here we are limiting
access to the content-stores from the corresponding environment in
Carrenza. This is so teh frontends in Carrenza which have not been
migrated yet are allowed to talk with the content-store.

Allowing the GDS Office IP ranges in also. 

Solo: @ronocg <conor.glynn@digital.cabinet-office.gov.uk>