### PR TITLE
Add Jenkins SSH key to CodeCommit IAM user

### DIFF
--- a/terraform/projects/infra-govuk-repo-mirror/README.md
+++ b/terraform/projects/infra-govuk-repo-mirror/README.md
@@ -10,6 +10,7 @@ to push to AWS CodeCommit
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| jenkins_ssh_public_key | The SSH public key of the Jenkins instance for the relevant environment | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/infra-govuk-repo-mirror/main.tf
+++ b/terraform/projects/infra-govuk-repo-mirror/main.tf
@@ -20,6 +20,11 @@ variable "stackname" {
   description = "Stackname"
 }
 
+variable "jenkins_ssh_public_key" {
+  type        = "string"
+  description = "The SSH public key of the Jenkins instance for the relevant environment"
+}
+
 terraform {
   backend          "s3"             {}
   required_version = "= 0.11.7"
@@ -37,4 +42,10 @@ resource "aws_iam_user" "govuk_code_commit_user" {
 resource "aws_iam_user_policy_attachment" "committer_managed_policy" {
   user       = "${aws_iam_user.govuk_code_commit_user.name}"
   policy_arn = "arn:aws:iam::aws:policy/AWSCodeCommitPowerUser"
+}
+
+resource "aws_iam_user_ssh_key" "govuk_code_commit_user_jenkins_ssh_key" {
+  username   = "${aws_iam_user.govuk_code_commit_user.name}"
+  encoding   = "SSH"
+  public_key = "${var.jenkins_ssh_public_key}"
 }


### PR DESCRIPTION
This commit adds the Jenkins SSH public key for the relevant environment to the CodeCommit IAM user. This will allow the Jenkins Deploy_App job to deploy apps from CodeCommit repositories.

Depends on: https://github.com/alphagov/govuk-aws-data/pull/269