### PR TITLE
Remove aws_security_group_rules that are not used

### DIFF
--- a/terraform/projects/infra-security-groups/monitoring.tf
+++ b/terraform/projects/infra-security-groups/monitoring.tf
@@ -151,25 +151,3 @@ resource "aws_security_group_rule" "monitoring-internal-elb_egress_any_any" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.monitoring_internal_elb.id}"
 }
-
-resource "aws_security_group_rule" "monitoring_ingress_monitoring-elb_syslog-tls" {
-  type      = "ingress"
-  from_port = 6514
-  to_port   = 6516
-  protocol  = "tcp"
-
-  # Which security group is the rule assigned to
-  security_group_id = "${aws_security_group.monitoring.id}"
-
-  # Which security group can use this rule
-  source_security_group_id = "${aws_security_group.monitoring_external_elb.id}"
-}
-
-resource "aws_security_group_rule" "monitoring-elb_ingress_fastly_syslog-tls" {
-  type              = "ingress"
-  to_port           = 6516
-  from_port         = 6514
-  protocol          = "tcp"
-  security_group_id = "${aws_security_group.monitoring_external_elb.id}"
-  cidr_blocks       = ["${data.fastly_ip_ranges.fastly.cidr_blocks}"]
-}


### PR DESCRIPTION
# Context
The security group, aws_security_group.monitoring_external_elb.id, is applied
to loadbalancers that are only listening on port 443 and have members that
accept traffic on port 80. The high port numbers in these rules allow traffic
through but there is nothing is configured to listen.

This was discovered through the trusted advisor report in production
(https://console.aws.amazon.com/trustedadvisor/home?#/category/security).

# Decision 
Remove the redundant rules.