### PR TITLE
Remove Office IPs from external CS access

### DIFF
--- a/terraform/projects/infra-security-groups/content-store.tf
+++ b/terraform/projects/infra-security-groups/content-store.tf
@@ -95,7 +95,7 @@ resource "aws_security_group_rule" "content-store-external-elb_ingress_public_ht
   protocol  = "tcp"
 
   security_group_id = "${aws_security_group.content-store_external_elb.id}"
-  cidr_blocks       = ["${var.carrenza_env_ips}", "${var.office_ips}"]
+  cidr_blocks       = ["${var.carrenza_env_ips}"]
 }
 
 resource "aws_security_group_rule" "content-store-external-elb_egress_any_any" {


### PR DESCRIPTION
We don't want the office IPs to be able to access the content-store
external IP address directly for now, it should only be the relevant IPs
in the GOV.UK Carrenza environment.