### PR TITLE
Increase spec of calculator-frontends

### DIFF
--- a/terraform/projects/app-calculators-frontend/README.md
+++ b/terraform/projects/app-calculators-frontend/README.md
@@ -8,13 +8,12 @@ Calculators Frontend application servers
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| asg_desired_capacity | The desired capacity of the autoscaling group | string | `2` | no |
-| asg_max_size | The maximum size of the autoscaling group | string | `2` | no |
-| asg_min_size | The minimum size of the autoscaling group | string | `2` | no |
+| asg_size | The autoscaling groups desired/max/min capacity | string | `3` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type | string | `c5.xlarge` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
@@ -22,6 +21,7 @@ Calculators Frontend application servers
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| root_block_device_volume_size | The size of the instance root volume in gigabytes | string | `60` | no |
 | stackname | Stackname | string | - | yes |
 | user_data_snippets | List of user-data snippets | list | - | yes |
 

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -30,28 +30,28 @@ variable "elb_internal_certname" {
   description = "The ACM cert domain name to find the ARN of"
 }
 
-variable "asg_max_size" {
+variable "asg_size" {
   type        = "string"
-  description = "The maximum size of the autoscaling group"
-  default     = "2"
-}
-
-variable "asg_min_size" {
-  type        = "string"
-  description = "The minimum size of the autoscaling group"
-  default     = "2"
-}
-
-variable "asg_desired_capacity" {
-  type        = "string"
-  description = "The desired capacity of the autoscaling group"
-  default     = "2"
+  description = "The autoscaling groups desired/max/min capacity"
+  default     = "3"
 }
 
 variable "app_service_records" {
   type        = "list"
   description = "List of application service names that get traffic via this loadbalancer"
   default     = []
+}
+
+variable "root_block_device_volume_size" {
+  type        = "string"
+  description = "The size of the instance root volume in gigabytes"
+  default     = "60"
+}
+
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type"
+  default     = "c5.xlarge"
 }
 
 # Resources
@@ -137,15 +137,16 @@ module "calculators-frontend" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "calculators_frontend", "aws_hostname", "calculators-frontend-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_calculators-frontend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "1"
   instance_elb_ids              = ["${aws_elb.calculators-frontend_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
-  asg_max_size                  = "${var.asg_max_size}"
-  asg_min_size                  = "${var.asg_min_size}"
-  asg_desired_capacity          = "${var.asg_desired_capacity}"
+  asg_max_size                  = "${var.asg_size}"
+  asg_min_size                  = "${var.asg_size}"
+  asg_desired_capacity          = "${var.asg_size}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "${var.root_block_device_volume_size}"
 }
 
 module "alarms-elb-calculators-frontend-internal" {


### PR DESCRIPTION
We want to match the spec to Carrenza before moving the apps.

To do this the following is needed:

- Increase ASG size to 3
- Change EBS volume size from default 20 GB to 60 GB
- Change instance type to c5.xlarge