### PR TITLE
2ndline-trello-386: fix healthcheck for content-store alb

### DIFF
--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -800,7 +800,7 @@ module "content-store_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/healthcheck"
+  target_group_health_check_path = "/_healthcheck"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_external_elb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]


### PR DESCRIPTION
The content-store ALB has its healthcheck for its target backends
wrongly configured. The healthcheck path should be /_healthcheck.

Pair: @ronocg <conor.glynn@digital.cabinet-office.gov.uk
@karlbaker02 <karl.baker@digital.cabinet-office.gov.uk