### PR TITLE
 Migration-plan for feedback

### DIFF
--- a/terraform/projects/app-frontend/README.md
+++ b/terraform/projects/app-frontend/README.md
@@ -30,5 +30,6 @@ Frontend application servers
 | Name | Description |
 |------|-------------|
 | frontend_elb_dns_name | DNS name to access the frontend service |
+| frontend_elb_zone_id | Zone ID for frontend elb |
 | service_dns_name | DNS name to access the node service |
 

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -170,6 +170,11 @@ output "frontend_elb_dns_name" {
   description = "DNS name to access the frontend service"
 }
 
+output "frontend_elb_zone_id" {
+  value       = "${aws_elb.frontend_elb.zone_id}"
+  description = "Zone ID for frontend elb"
+}
+
 output "service_dns_name" {
   value       = "${aws_route53_record.service_record.name}"
   description = "DNS name to access the node service"

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -52,6 +52,8 @@ This project adds global resources for app components:
 | elb_public_secondary_certname | The ACM secondary cert domain name to find the ARN of | string | - | yes |
 | email_alert_api_internal_service_names |  | list | `<list>` | no |
 | email_alert_api_public_service_names |  | list | `<list>` | no |
+| feedback_public_service_names |  | list | `<list>` | no |
+| feedback_public_to_internallb_name |  | list | `<list>` | no |
 | frontend_internal_service_cnames |  | list | `<list>` | no |
 | frontend_internal_service_names |  | list | `<list>` | no |
 | graphite_internal_service_names |  | list | `<list>` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -107,6 +107,16 @@ variable "email_alert_api_public_service_names" {
   default = []
 }
 
+variable "feedback_public_to_internallb_name" {
+  type    = "list"
+  default = []
+}
+
+variable "feedback_public_service_names" {
+  type    = "list"
+  default = []
+}
+
 variable "graphite_public_service_names" {
   type    = "list"
   default = []
@@ -1121,6 +1131,19 @@ resource "aws_route53_record" "frontend_internal_service_cnames" {
   type    = "CNAME"
   records = ["${element(var.frontend_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
   ttl     = "300"
+}
+
+resource "aws_route53_record" "feedback_public_service_names" {
+  count   = "${length(var.feedback_public_to_internallb_name)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.feedback_public_to_internallb_name, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${data.terraform_remote_state.app_frontend.frontend_elb_dns_name}"
+    zone_id                = "${data.terraform_remote_state.app_frontend.frontend_elb_zone_id}"
+    evaluate_target_health = true
+  }
 }
 
 #

--- a/terraform/projects/infra-public-services/remote_state.tf
+++ b/terraform/projects/infra-public-services/remote_state.tf
@@ -109,3 +109,13 @@ data "terraform_remote_state" "infra_monitoring" {
     region = "eu-west-1"
   }
 }
+
+data "terraform_remote_state" "app_frontend" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "blue/app-frontend.tfstate"
+    region = "eu-west-1"
+  }
+}


### PR DESCRIPTION
Traffic from Carrenza to the feedback service in AWS will need to
traverse the VPN, therefore we cannot use an external load balancer to
load balance the traffic into the frontend machines in AWS (feedback
lives on the frontend).

So we need to use the existing internal load balancer that the frontends
have, so in order to use that we need a dns record in the external
govuk.digital zone. This puts that in place.

Solo: @ronocg <conor.glynn@digital.cabinet-office.gov.uk>