### PR TITLE
Trello-1827: Add feedback public lb

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -52,6 +52,7 @@ This project adds global resources for app components:
 | elb_public_secondary_certname | The ACM secondary cert domain name to find the ARN of | string | - | yes |
 | email_alert_api_internal_service_names |  | list | `<list>` | no |
 | email_alert_api_public_service_names |  | list | `<list>` | no |
+| feedback_public_service_names |  | list | `<list>` | no |
 | frontend_internal_service_cnames |  | list | `<list>` | no |
 | frontend_internal_service_names |  | list | `<list>` | no |
 | graphite_internal_service_names |  | list | `<list>` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -107,6 +107,11 @@ variable "email_alert_api_public_service_names" {
   default = []
 }
 
+variable "feedback_public_service_names" {
+  type    = "list"
+  default = []
+}
+
 variable "graphite_public_service_names" {
   type    = "list"
   default = []
@@ -1099,6 +1104,62 @@ resource "aws_route53_record" "email_alert_api_internal_service_names" {
   type    = "CNAME"
   records = ["${element(var.email_alert_api_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
   ttl     = "300"
+}
+
+#
+# feedback
+#
+
+module "feedback_public_lb" {
+  source                                     = "../../modules/aws/lb"
+  name                                       = "${var.stackname}-feedback-public"
+  internal                                   = true
+  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix                  = "elb/${var.stackname}-feedback-public-elb"
+  listener_certificate_domain_name           = "${var.elb_public_certname}"
+  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
+
+  listener_action = {
+    "HTTPS:443" = "HTTP:80"
+  }
+
+  target_group_health_check_path = "/healthcheck"
+  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_feedback_elb_id}"]
+  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  default_tags                   = "${map("Project", var.stackname, "aws_migration", "feedback", "aws_environment", var.aws_environment)}"
+}
+
+resource "aws_route53_record" "feedback_public_service_names" {
+  count   = "${length(var.feedback_public_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.feedback_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${module.feedback_public_lb.lb_dns_name}"
+    zone_id                = "${module.feedback_public_lb.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+data "aws_autoscaling_groups" "frontend" {
+  filter {
+    name   = "key"
+    values = ["Name"]
+  }
+
+  filter {
+    name   = "value"
+    values = ["blue-frontend"]
+  }
+}
+
+resource "aws_autoscaling_attachment" "frontend_asg_attachment_alb" {
+  count                  = "${length(data.aws_autoscaling_groups.frontend.names) > 0 ? 1 : 0}"
+  autoscaling_group_name = "${element(data.aws_autoscaling_groups.frontend.names, 0)}"
+  alb_target_group_arn   = "${element(module.feedback_public_lb.target_group_arns, 0)}"
 }
 
 #

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -70,6 +70,7 @@ Manage the security groups for the entire infrastructure
 | sg_email-alert-api_elb_external_id |  |
 | sg_email-alert-api_elb_internal_id |  |
 | sg_email-alert-api_id |  |
+| sg_feedback_elb_id |  |
 | sg_frontend_elb_id |  |
 | sg_frontend_id |  |
 | sg_graphite_external_elb_id |  |

--- a/terraform/projects/infra-security-groups/feedback.tf
+++ b/terraform/projects/infra-security-groups/feedback.tf
@@ -1,0 +1,55 @@
+#
+# == Manifest: Project: Security Groups: feedback
+#
+# The feedback lb needs to be accessible on ports:
+#   - 443 from the other VMs
+#
+# === Variables:
+# stackname - string
+# carrenza_env_ips - list
+#
+# === Outputs:
+# sg_feedback_elb_id
+
+resource "aws_security_group_rule" "frontend_ingress_feedback-elb_http" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.frontend.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.feedback_elb.id}"
+}
+
+resource "aws_security_group" "feedback_elb" {
+  name        = "${var.stackname}_feedback_elb_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access the feedback ELB"
+
+  tags {
+    Name = "${var.stackname}_feedback_elb_access"
+  }
+}
+
+# Allow support (in carrenza) to communicate with feedback (in aws) during migration
+resource "aws_security_group_rule" "feedback-elb_ingress_carrenza_env_ips_https" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id = "${aws_security_group.feedback_elb.id}"
+  cidr_blocks       = "${var.carrenza_env_ips}"
+}
+
+resource "aws_security_group_rule" "feedback-elb_egress_any_any" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.feedback_elb.id}"
+}

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -186,6 +186,10 @@ output "sg_email-alert-api-postgresql-standby_id" {
   value = "${aws_security_group.email-alert-api-postgresql-standby.id}"
 }
 
+output "sg_feedback_elb_id" {
+  value = "${aws_security_group.feedback_elb.id}"
+}
+
 output "sg_frontend_elb_id" {
   value = "${aws_security_group.frontend_elb.id}"
 }


### PR DESCRIPTION
Adding feedback public LB and dns entry for it in the environments root
zone. Also setting security groups to restrict access to feedback from
carrenza egress env IPs.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>