### PR TITLE
Trello-1827: Sort access to feedback alb from VPN

### DIFF
--- a/terraform/projects/infra-security-groups/feedback.tf
+++ b/terraform/projects/infra-security-groups/feedback.tf
@@ -41,8 +41,11 @@ resource "aws_security_group_rule" "feedback-elb_ingress_carrenza_env_ips_https"
   to_port   = 443
   protocol  = "tcp"
 
+  # Which security group is the rule assigned to
   security_group_id = "${aws_security_group.feedback_elb.id}"
-  cidr_blocks       = "${var.carrenza_env_ips}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.vpn.id}"
 }
 
 resource "aws_security_group_rule" "feedback-elb_egress_any_any" {

--- a/terraform/projects/infra-security-groups/vpn.tf
+++ b/terraform/projects/infra-security-groups/vpn.tf
@@ -33,6 +33,18 @@ resource "aws_security_group_rule" "vpn_egress_carrenza_aws" {
   cidr_blocks = "${var.carrenza_vpn_subnet_cidr}"
 }
 
+resource "aws_security_group_rule" "vpn_egress_carrenza_aws_frontend" {
+  count     = "${length(var.carrenza_vpn_subnet_cidr) > 0 ? 1 : 0}"
+  type      = "egress"
+  from_port = 0
+  to_port   = 0
+  protocol  = "-1"
+
+  security_group_id = "${aws_security_group.vpn.id}"
+
+  cidr_blocks = "${var.carrenza_vpn_subnet_cidr}"
+}
+
 resource "aws_security_group_rule" "vpn_ingress_http_http" {
   count     = "${length(var.carrenza_vpn_subnet_cidr) > 0 ? 1 : 0}"
   type      = "ingress"


### PR DESCRIPTION
The frontend VMs in carrenza will need to speak with feedback (once it
is migrated) in aws.
This communication needs to happen over the VPN, as there can be
personal information present.
This allows the feedback alb to recieve traffic from the carrenza
internal IP ranges coming via the vpn security group.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>