### PR TITLE
Trello-1827: Place ALB on the private subnet

### DIFF
--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1125,7 +1125,7 @@ module "feedback_public_lb" {
   }
 
   target_group_health_check_path = "/healthcheck"
-  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  subnets                        = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_feedback_elb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
   default_tags                   = "${map("Project", var.stackname, "aws_migration", "feedback", "aws_environment", var.aws_environment)}"

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -11,6 +11,7 @@ Manage the security groups for the entire infrastructure
 | carrenza_draft_frontend_ips | An array of CIDR blocks for the current environment that will allow access to draft-content-store from Carrenza. | list | `<list>` | no |
 | carrenza_env_ips | An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_integration_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
+| carrenza_internal_net_cidr | The internal carrenza cidr ranges for the environment. | string | - | yes |
 | carrenza_production_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_staging_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_vpn_subnet_cidr | The Carrenza VPN subnet CIDR | list | `<list>` | no |

--- a/terraform/projects/infra-security-groups/feedback.tf
+++ b/terraform/projects/infra-security-groups/feedback.tf
@@ -36,16 +36,12 @@ resource "aws_security_group" "feedback_elb" {
 
 # Allow support (in carrenza) to communicate with feedback (in aws) during migration
 resource "aws_security_group_rule" "feedback-elb_ingress_carrenza_env_ips_https" {
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  # Which security group is the rule assigned to
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
   security_group_id = "${aws_security_group.feedback_elb.id}"
-
-  # Which security group can use this rule
-  source_security_group_id = "${aws_security_group.vpn.id}"
+  cidr_blocks       = ["${var.carrenza_internal_net_cidr}"]
 }
 
 resource "aws_security_group_rule" "feedback-elb_egress_any_any" {

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -55,6 +55,11 @@ variable "carrenza_draft_frontend_ips" {
   default     = []
 }
 
+variable "carrenza_internal_net_cidr" {
+  type        = "string"
+  description = "The internal carrenza cidr ranges for the environment."
+}
+
 variable "traffic_replay_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will replay traffic against an environment"


### PR DESCRIPTION
The feedback ALB should be on the private subnets, as it will only
forward traffic to its target group that comes from Carrenza. The
private subnets have the carenza ranges in their routing tables.

Also setting the security group for the feedback ALB to be specific on
the carrenza ip ranges it is allowing inbound.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>