### PR TITLE
Variable name change for infra-security-groups

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -11,7 +11,6 @@ Manage the security groups for the entire infrastructure
 | carrenza_draft_frontend_ips | An array of CIDR blocks for the current environment that will allow access to draft-content-store from Carrenza. | list | `<list>` | no |
 | carrenza_env_ips | An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_integration_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
-| carrenza_internal_net_cidr | The internal carrenza cidr ranges for the environment. | string | - | yes |
 | carrenza_production_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_staging_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_vpn_subnet_cidr | The Carrenza VPN subnet CIDR | list | `<list>` | no |

--- a/terraform/projects/infra-security-groups/feedback.tf
+++ b/terraform/projects/infra-security-groups/feedback.tf
@@ -41,7 +41,7 @@ resource "aws_security_group_rule" "feedback-elb_ingress_carrenza_env_ips_https"
   to_port           = 443
   protocol          = "tcp"
   security_group_id = "${aws_security_group.feedback_elb.id}"
-  cidr_blocks       = ["${var.carrenza_internal_net_cidr}"]
+  cidr_blocks       = ["${var.carrenza_vpn_subnet_cidr}"]
 }
 
 resource "aws_security_group_rule" "feedback-elb_egress_any_any" {

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -55,11 +55,6 @@ variable "carrenza_draft_frontend_ips" {
   default     = []
 }
 
-variable "carrenza_internal_net_cidr" {
-  type        = "string"
-  description = "The internal carrenza cidr ranges for the environment."
-}
-
 variable "traffic_replay_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will replay traffic against an environment"


### PR DESCRIPTION
A new var was previously defined and the value needed exists in a different
var. It makes sense to use the value from the existing var instead of
introducing a new one.

var.carrenza_internal_net_cidr is replaced with var.carrenza_vpn_subnet_cidr