### PR TITLE
Trello-1885: Splunk Discovery

### DIFF
--- a/terraform/projects/infra-splunk/README.md
+++ b/terraform/projects/infra-splunk/README.md
@@ -1,0 +1,11 @@
+## Module: projects/infra-splunk
+
+Role and policy for Splunk Discovery delegated by the Cyber Security Team
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_region | AWS region | string | `eu-west-1` | no |
+

--- a/terraform/projects/infra-splunk/integration.govuk.backend
+++ b/terraform/projects/infra-splunk/integration.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "govuk/infra-splunk.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-splunk/main.tf
+++ b/terraform/projects/infra-splunk/main.tf
@@ -1,0 +1,113 @@
+/**
+* ## Module: projects/infra-splunk
+*
+* Role and policy for Splunk Discovery delegated by the Cyber Security Team
+*/
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+# Resources
+# --------------------------------------------------------------
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.40.0"
+}
+
+resource "aws_iam_role" "splunk_aws_ro_role" {
+  name = "SplunkAWSRORole"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "AWS": "arn:aws:iam::779799343306:role/SplunkRole"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "splunk_aws_ro_policy" {
+  name = "policy"
+  role = "${aws_iam_role.splunk_aws_ro_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeReservedInstances",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeRegions",
+        "ec2:DescribeKeyPairs",
+        "ec2:DescribeNetworkAcls",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeImages",
+        "ec2:DescribeAddresses",
+        "lambda:ListFunctions",
+        "rds:DescribeDBInstances",
+        "cloudfront:ListDistributions",
+        "iam:GetUser",
+        "iam:ListUsers",
+        "iam:GetAccountPasswordPolicy",
+        "iam:ListAccessKeys",
+        "iam:GetAccessKeyLastUsed",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeInstanceHealth",
+        "elasticloadbalancing:DescribeTags",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:DescribeListeners",
+        "s3:ListAllMyBuckets",
+        "s3:GetAccelerateConfiguration",
+        "s3:GetBucketCORS",
+        "s3:GetLifecycleConfiguration",
+        "s3:GetBucketLocation",
+        "s3:GetBucketLogging",
+        "s3:GetBucketTagging"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "config:DescribeConfigRules",
+        "config:DescribeConfigRuleEvaluationStatus",
+        "config:GetComplianceDetailsByConfigRule",
+        "config:GetComplianceSummaryByConfigRule"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "inspector:Describe*",
+        "inspector:List*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}

--- a/terraform/projects/infra-splunk/production.govuk.backend
+++ b/terraform/projects/infra-splunk/production.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "govuk/infra-splunk.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-splunk/staging.govuk.backend
+++ b/terraform/projects/infra-splunk/staging.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+key     = "govuk/infra-splunk.tfstate"
+encrypt = true
+region  = "eu-west-1"


### PR DESCRIPTION
This policy and role is required by the Cyber Security Team, in order to
probe the resources and services in our account and gather that
info/data into splunk cloud. The policy has been passed directly to us
by the Cyber Team.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>