### PR TITLE
Allow passing the context to govukcli ssh

### DIFF
--- a/tools/govukcli
+++ b/tools/govukcli
@@ -104,7 +104,7 @@ function error {
 function check_allowed_contexts {
   if [[ ! $CONTEXT =~ $ALLOWED_CONTEXTS ]]; then
     if [[ $OUT != 'silent' ]]; then
-      error "Invalid context"
+      error "Invalid context '$CONTEXT'"
       echo "Must be one of: "
       for i in $CONTEXTS; do
         echo "  $i"

--- a/tools/govukcli
+++ b/tools/govukcli
@@ -232,9 +232,16 @@ function run_ssh {
           ssh_usage
         fi
         exit 1
-      fi
+      elif [ "$1" = "--context" ]; then
+          CONTEXT="$2"
+          check_allowed_contexts
+          GOVUK_ENV="$2"
+          configure_ssh
 
-      NODE_CLASS=$1
+          NODE_CLASS=$3
+      else
+          NODE_CLASS=$1
+      fi
 
       load_user
 

--- a/tools/govukcli
+++ b/tools/govukcli
@@ -166,10 +166,7 @@ function load_user {
   fi
 }
 
-function run_ssh {
-  get_context
-  GOVUK_ENV="$CONTEXT"
-
+function configure_ssh {
   case $GOVUK_ENV in
     'ci')             JUMPBOX="ci-jumpbox.integration.publishing.service.gov.uk";
                       CARRENZA=true;;
@@ -183,6 +180,13 @@ function run_ssh {
     'staging-aws')    JUMPBOX="jumpbox.staging.govuk.digital";;
     *)                JUMPBOX="jumpbox.${GOVUK_ENV}.govuk.digital";;
   esac
+}
+
+function run_ssh {
+  get_context
+  GOVUK_ENV="$CONTEXT"
+
+  configure_ssh
 
   case $OUT in
     silent) SSH_OPTS='-q';;


### PR DESCRIPTION
Builds on top of https://github.com/alphagov/govuk-aws/pull/736

These changes mean that the following command works for example:

  govukcli ssh --context staging-aws backend

I personally would like the govukcli ssh behaviour to be more
predictable, based on the command being run. So rather than relying on
the correct context being set, instead, passing it in every time and
being explicit. I think this is easier to understand and use, as well
as being less error prone.