### PR TITLE
Add a security group for Gatling

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -73,6 +73,7 @@ Manage the security groups for the entire infrastructure
 | sg_feedback_elb_id |  |
 | sg_frontend_elb_id |  |
 | sg_frontend_id |  |
+| sg_gatling_id |  |
 | sg_graphite_external_elb_id |  |
 | sg_graphite_id |  |
 | sg_graphite_internal_elb_id |  |

--- a/terraform/projects/infra-security-groups/gatling.tf
+++ b/terraform/projects/infra-security-groups/gatling.tf
@@ -1,0 +1,57 @@
+#
+# == Manifest: Project: Security Groups: gatling
+#
+# Gatling needs to be accessible on ports:
+#   - 22
+#   - 80
+#
+# === Variables:
+# stackname - string
+#
+# === Outputs:
+# sg_gatling_id
+
+resource "aws_security_group" "gatling" {
+  name        = "${var.stackname}_gatling_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access to the gatling host"
+
+  tags {
+    Name = "${var.stackname}_gatling_access"
+  }
+}
+
+resource "aws_security_group_rule" "gatling_ingress_gatling_ssh" {
+  type      = "ingress"
+  from_port = 22
+  to_port   = 22
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.gatling.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.gatling.id}"
+}
+
+resource "aws_security_group_rule" "gatling_ingress_gatling_http" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.gatling.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.gatling.id}"
+}
+
+resource "aws_security_group_rule" "gatling_egress_any_any" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.gatling.id}"
+}

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -198,6 +198,10 @@ output "sg_frontend_id" {
   value = "${aws_security_group.frontend.id}"
 }
 
+output "sg_gatling_id" {
+  value = "${aws_security_group.gatling.id}"
+}
+
 output "sg_graphite_id" {
   value = "${aws_security_group.graphite.id}"
 }


### PR DESCRIPTION
We will start Gatling FrontLine instances using this security group.

It allows inbound traffic on port 22 and 80 and all outbound traffic.

[Trello Card](https://trello.com/c/kxP64gJo/700-redo-the-load-test-to-see-what-impact-weve-had-with-our-changes)