### PR TITLE
Trello-1903: Removing prometheus elb

### DIFF
--- a/terraform/projects/app-prometheus/README.md
+++ b/terraform/projects/app-prometheus/README.md
@@ -5,7 +5,6 @@
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
-| elb_external_certname | Name of the name of domain | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*` | no |
 | prometheus_1_subnet | Name of the subnet to place the Prometheus instance and EBS volume | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
@@ -17,10 +16,4 @@
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
 | stackname | Stackname | string | - | yes |
 | user_data_snippets | List of user-data snippets | list | - | yes |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| prometheus_external_elb_dns_name | DNS name to access the Prometheus external service |
 

--- a/terraform/projects/app-prometheus/main.tf
+++ b/terraform/projects/app-prometheus/main.tf
@@ -32,11 +32,6 @@ variable "prometheus_1_subnet" {
   description = "Name of the subnet to place the Prometheus instance and EBS volume"
 }
 
-variable "elb_external_certname" {
-  type        = "string"
-  description = "Name of the name of domain"
-}
-
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -47,64 +42,6 @@ terraform {
 provider "aws" {
   region  = "${var.aws_region}"
   version = "1.14.0"
-}
-
-data "aws_acm_certificate" "elb_external_cert" {
-  domain   = "${var.elb_external_certname}"
-  statuses = ["ISSUED"]
-}
-
-resource "aws_elb" "prometheus_external_elb" {
-  name            = "${var.stackname}-prometheus-external"
-  subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_prometheus_external_elb_id}"]
-
-  internal = "false"
-
-  access_logs {
-    bucket        = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-    bucket_prefix = "elb/${var.stackname}-prometheus-external-elb"
-    interval      = 60
-  }
-
-  listener {
-    instance_port     = 80
-    instance_protocol = "http"
-    lb_port           = 443
-    lb_protocol       = "https"
-
-    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
-  }
-
-  health_check {
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-    timeout             = 3
-
-    target   = "TCP:80"
-    interval = 30
-  }
-
-  cross_zone_load_balancing   = true
-  idle_timeout                = 400
-  connection_draining         = true
-  connection_draining_timeout = 400
-
-  tags = "${map("Name", "${var.stackname}-prometheus-external",
-"Project", var.stackname, "aws_environment", var.aws_environment,
-"aws_migration", "prometheus")}"
-}
-
-resource "aws_route53_record" "prometheus_external_service_record" {
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
-  name    = "prometheus.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${aws_elb.prometheus_external_elb.dns_name}"
-    zone_id                = "${aws_elb.prometheus_external_elb.zone_id}"
-    evaluate_target_health = true
-  }
 }
 
 module "prometheus-1" {
@@ -156,12 +93,4 @@ resource "aws_iam_role_policy_attachment" "prometheus_1_iam_role_policy_attachme
 resource "aws_iam_role_policy_attachment" "prometheus_1_iam_role_policy_cloudwatch_attachment" {
   role       = "${module.prometheus-1.instance_iam_role_name}"
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
-}
-
-# Outputs
-# --------------------------------------------------------------
-
-output "prometheus_external_elb_dns_name" {
-  value       = "${aws_route53_record.prometheus_external_service_record.fqdn}"
-  description = "DNS name to access the Prometheus external service"
 }

--- a/terraform/projects/app-prometheus/production.blue.backend
+++ b/terraform/projects/app-prometheus/production.blue.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "blue/app-prometheus.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/app-prometheus/staging.blue.backend
+++ b/terraform/projects/app-prometheus/staging.blue.backend
@@ -1,0 +1,4 @@
+bucket   = "govuk-terraform-steppingstone-staging"
+key      = "blue/app-prometheus.tfstate"
+encrypt  = true
+region   = "eu-west-1"

--- a/terraform/projects/infra-security-groups/prometheus.tf
+++ b/terraform/projects/infra-security-groups/prometheus.tf
@@ -15,17 +15,17 @@
 resource "aws_security_group" "prometheus" {
   name        = "${var.stackname}_prometheus"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  description = "Access to prometheus"
+  description = "Access to prometheus instance from the prometheus LB"
 
   tags {
     Name = "${var.stackname}_prometheus"
   }
 }
 
-resource "aws_security_group_rule" "prometheuselb_ingress_prometheus_https" {
+resource "aws_security_group_rule" "prometheuselb_ingress_prometheus_http" {
   type      = "ingress"
-  from_port = 443
-  to_port   = 443
+  from_port = 80
+  to_port   = 80
   protocol  = "tcp"
 
   # Which security group is the rule assigned to
@@ -38,14 +38,14 @@ resource "aws_security_group_rule" "prometheuselb_ingress_prometheus_https" {
 resource "aws_security_group" "prometheus_external_elb" {
   name        = "${var.stackname}_prometheus_external_elb"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  description = "Access to prometheus"
+  description = "Access to prometheus LB"
 
   tags {
     Name = "${var.stackname}_prometheus_external_elb"
   }
 }
 
-resource "aws_security_group_rule" "officeips_ingress_prometheuselb_https" {
+resource "aws_security_group_rule" "prometheus-elb_ingress_officeips_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443


### PR DESCRIPTION
The prometheus elb is not required, there is an existing ALB that will
do the job it is spun up in infra-public-services.

Also allowing from the alb to the instance on port 80.

Putting config in place to roll prometheus to staging and production
also.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>
@jstandring-gds <julian.standring@digital.cabinet-office.gov.uk>