### PR TITLE
Trello-1903: update prometheus lb security group

### DIFF
--- a/terraform/projects/app-prometheus/main.tf
+++ b/terraform/projects/app-prometheus/main.tf
@@ -57,8 +57,6 @@ keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map),
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_prometheus_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "t2.micro"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
-  instance_elb_ids_length       = "1"
-  instance_elb_ids              = ["${aws_elb.prometheus_external_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
 }

--- a/terraform/projects/infra-security-groups/prometheus.tf
+++ b/terraform/projects/infra-security-groups/prometheus.tf
@@ -57,3 +57,16 @@ resource "aws_security_group_rule" "prometheus-elb_ingress_officeips_https" {
   # Which security group can use this rule
   cidr_blocks = ["${var.office_ips}"]
 }
+
+resource "aws_security_group_rule" "prometheus-elb_egress_prometheus_http" {
+  type      = "egress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.prometheus_external_elb.id}"
+
+  # Which security group can use this rule
+  security_group_id = "${aws_security_group.prometheus.id}"
+}


### PR DESCRIPTION
The prometheus load balancer needs to be able to forward http traffic
down to the security group attached to the prometheus instance, this
commit puts that egress rule in place.

Also removingthe instance_elb_ids from teh prometheus module, as we are
no longer building an elb at this state level, there is an application
load balancer built within infra-public-services that takes care of the
laod-balancing to prometheus.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>