### PR TITLE
Trello-1903: fix source security group

### DIFF
--- a/terraform/projects/infra-security-groups/prometheus.tf
+++ b/terraform/projects/infra-security-groups/prometheus.tf
@@ -68,5 +68,5 @@ resource "aws_security_group_rule" "prometheus-elb_egress_prometheus_http" {
   security_group_id = "${aws_security_group.prometheus_external_elb.id}"
 
   # Which security group can use this rule
-  security_group_id = "${aws_security_group.prometheus.id}"
+  source_security_group_id = "${aws_security_group.prometheus.id}"
 }


### PR DESCRIPTION
There needs to be a source_security_group_id defined, in this instance
the source security group would be the security that egress to, being
the prometheus instance security group.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>