### PR TITLE
Add user accounts for the new govuk-tools AWS account

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Start by reading [the getting started guide](doc/guides/getting-started.md).
 
 Please see [the environment provisioning guide](doc/guides/environment-provisioning.md) for building a fresh environment.
 
+## govuk-tools account
+
+The `govuk-tools` account does not behave like a normal environment. It contains one-off resources and does not need to be built like a normal environment.
+
 ## Architecture Decision Records
 
 We're recording architecture decisions we make so we have a history and context on our implementation.

--- a/terraform/projects/infra-security/tools.govuk.backend
+++ b/terraform/projects/infra-security/tools.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-tools"
+key     = "govuk/infra-security.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/tools/deploy.rb
+++ b/tools/deploy.rb
@@ -13,7 +13,7 @@ project = ARGV[3]
 
 # Valid values for each field
 valid_commands = %w(plan apply destroy).freeze
-valid_environments = %w(integration staging production test).freeze
+valid_environments = %w(integration staging production test tools).freeze
 valid_stacks = %w(blue green govuk).freeze
 
 usage = 'Usage: GITHUB_USERNAME=... GITHUB_TOKEN=... ruby deploy.rb <command> <environment> <stack> <project>'


### PR DESCRIPTION
This account will contain resources that are one-off, or otherwise outside the usual production/staging/integration environments.

The initial user accounts and roles are identical to production.