### PR TITLE
normalize app-cache so that only asg_size variable is needed 

### DIFF
--- a/terraform/projects/app-cache/README.md
+++ b/terraform/projects/app-cache/README.md
@@ -8,9 +8,7 @@ Cache application servers
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| asg_desired_capacity | The desired capacity of the autoscaling group | string | `2` | no |
-| asg_max_size | The maximum size of the autoscaling group | string | `2` | no |
-| asg_min_size | The minimum size of the autoscaling group | string | `2` | no |
+| asg_size | The autoscaling groups desired/max/min capacity | string | `2` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -41,21 +41,9 @@ variable "app_service_records" {
   default     = []
 }
 
-variable "asg_max_size" {
+variable "asg_size" {
   type        = "string"
-  description = "The maximum size of the autoscaling group"
-  default     = "2"
-}
-
-variable "asg_min_size" {
-  type        = "string"
-  description = "The minimum size of the autoscaling group"
-  default     = "2"
-}
-
-variable "asg_desired_capacity" {
-  type        = "string"
-  description = "The desired capacity of the autoscaling group"
+  description = "The autoscaling groups desired/max/min capacity"
   default     = "2"
 }
 
@@ -212,9 +200,9 @@ module "cache" {
   instance_elb_ids_length       = "2"
   instance_elb_ids              = ["${aws_elb.cache_elb.id}", "${aws_elb.cache_external_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
-  asg_max_size                  = "${var.asg_max_size}"
-  asg_min_size                  = "${var.asg_min_size}"
-  asg_desired_capacity          = "${var.asg_desired_capacity}"
+  asg_max_size                  = "${var.asg_size}"
+  asg_min_size                  = "${var.asg_size}"
+  asg_desired_capacity          = "${var.asg_size}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
 }
 


### PR DESCRIPTION
# Context

Other app projects only need to have asg_size variable to define the max, min and desired number of machine. Hence, we do the same for app-cache for uniformity because app-cache has no different requirements.

# Decisions
1. declare `asg_size` variable and use it to set the autoscaling max, min and desired number of instances. 
2. remove redundant variables.