### PR TITLE
Remove references to Policy Publisher

### DIFF
--- a/doc/guides/redeploying-applications-on-rebuild.md
+++ b/doc/guides/redeploying-applications-on-rebuild.md
@@ -35,7 +35,6 @@ local-links-manager
 kibana
 manuals-publisher
 maslow
-policy-publisher
 publisher
 release
 search-admin

--- a/tools/migration-hosts.sh
+++ b/tools/migration-hosts.sh
@@ -22,7 +22,6 @@ kibana
 local-links-manager
 manuals-publisher
 maslow
-policy-publisher
 publisher
 release
 search-admin


### PR DESCRIPTION
This application no longer exists. The policy pages have been replaced
by topic pages, part of the GOV.UK Topic Taxonomy.