### PR TITLE
Change region for steppingstone S3 bucket

### DIFF
--- a/terraform/projects/infra-security/tools.govuk.backend
+++ b/terraform/projects/infra-security/tools.govuk.backend
@@ -1,4 +1,4 @@
-bucket  = "govuk-terraform-steppingstone-tools-tfstate"
+bucket  = "govuk-terraform-steppingstone-tools"
 key     = "govuk/infra-security.tfstate"
 encrypt = true
-region  = "eu-west-1"
+region  = "eu-west-2"


### PR DESCRIPTION
This bucket is in London. Also, change the name back since we’ve now been able to create a bucket with the original name.