### PR TITLE
allow carrenza cache machines to reach aws cache machines

### DIFF
--- a/terraform/projects/infra-security-groups/cache.tf
+++ b/terraform/projects/infra-security-groups/cache.tf
@@ -125,7 +125,7 @@ resource "aws_security_group_rule" "cache-external-elb_ingress_public_https" {
   from_port         = 443
   protocol          = "tcp"
   security_group_id = "${aws_security_group.cache_external_elb.id}"
-  cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}", "${var.traffic_replay_ips}"]
+  cidr_blocks       = ["${data.fastly_ip_ranges.fastly.cidr_blocks}", "${var.office_ips}", "${var.traffic_replay_ips}"]
 }
 
 resource "aws_security_group_rule" "cache-external-elb_egress_any_any" {

--- a/terraform/projects/infra-security-groups/cache.tf
+++ b/terraform/projects/infra-security-groups/cache.tf
@@ -125,7 +125,7 @@ resource "aws_security_group_rule" "cache-external-elb_ingress_public_https" {
   from_port         = 443
   protocol          = "tcp"
   security_group_id = "${aws_security_group.cache_external_elb.id}"
-  cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}"]
+  cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}", "${var.traffic_replay_ips}"]
 }
 
 resource "aws_security_group_rule" "cache-external-elb_egress_any_any" {

--- a/terraform/projects/infra-security-groups/draft-cache.tf
+++ b/terraform/projects/infra-security-groups/draft-cache.tf
@@ -103,7 +103,7 @@ resource "aws_security_group_rule" "draft-cache-external-elb_ingress_public_http
   from_port         = 443
   protocol          = "tcp"
   security_group_id = "${aws_security_group.draft-cache_external_elb.id}"
-  cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}"]
+  cidr_blocks       = ["${data.fastly_ip_ranges.fastly.cidr_blocks}", "${var.office_ips}"]
 }
 
 # This is required to commit routes using router-api at the end of the data sync


### PR DESCRIPTION
# Context

In order to have Gor traffic replay between Carrenza and AWS cache machines, there is a need to allow Carrenza cache machines IPs to pass through the AWS cache ELB.

# Decisions
1. open the security group of the AWS Cache ELB to Carrenza outbound traffic IPs