### PR TITLE
increase content store ebs from 20 gb to 40gb

### DIFF
--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -177,6 +177,7 @@ module "content-store" {
   asg_min_size                  = "${var.asg_size}"
   asg_desired_capacity          = "${var.asg_size}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "40"
 }
 
 module "alarms-elb-content-store-internal" {


### PR DESCRIPTION
# Context

The content-store in AWS production is complaining about a lack of disk space (most of the disk space is consumed by logs) and therefore, we need to increase it from its current 20 GB to 40 GB.

# Decisions
1. increase volume from 20GB to 40GB (no new variable was introduced from govuk-aws-data to keep the way it is done now)