### PR TITLE
Add Fastly API key for data.gov.uk

### DIFF
--- a/terraform/projects/fastly-datagovuk/README.md
+++ b/terraform/projects/fastly-datagovuk/README.md
@@ -8,6 +8,7 @@ Manages the Fastly service for data.gov.uk
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
+| fastly_api_key | API key to authenticate with Fastly | string | - | yes |
 | logging_aws_access_key_id | IAM key ID with access to put logs into the S3 bucket | string | - | yes |
 | logging_aws_secret_access_key | IAM secret key with access to put logs into the S3 bucket | string | - | yes |
 

--- a/terraform/projects/fastly-datagovuk/main.tf
+++ b/terraform/projects/fastly-datagovuk/main.tf
@@ -9,6 +9,11 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "fastly_api_key" {
+  type        = "string"
+  description = "API key to authenticate with Fastly"
+}
+
 variable "logging_aws_access_key_id" {
   type        = "string"
   description = "IAM key ID with access to put logs into the S3 bucket"
@@ -24,6 +29,10 @@ variable "logging_aws_secret_access_key" {
 terraform {
   backend          "s3"             {}
   required_version = "= 0.11.7"
+}
+
+provider "fastly" {
+  api_key = "${var.fastly_api_key}"
 }
 
 resource "fastly_service_v1" "datagovuk" {


### PR DESCRIPTION
This commit adds a Fastly API key (retrieved from SOPS) to be used when deploying the `fastly-datagovuk` project.