### PR TITLE
add draft_whitehall_frontend cnaming to whitehall_frontend

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -48,6 +48,7 @@ This project adds global resources for app components:
 | draft_content_store_public_service_names |  | list | `<list>` | no |
 | draft_frontend_internal_service_cnames |  | list | `<list>` | no |
 | draft_frontend_internal_service_names |  | list | `<list>` | no |
+| draft_whitehall_frontend_internal_service_names |  | list | `<list>` | no |
 | elb_public_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_public_secondary_certname | The ACM secondary cert domain name to find the ARN of | string | - | yes |
 | email_alert_api_internal_service_names |  | list | `<list>` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -262,6 +262,11 @@ variable "draft_frontend_internal_service_cnames" {
   default = []
 }
 
+variable "draft_whitehall_frontend_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
 variable "email_alert_api_internal_service_names" {
   type    = "list"
   default = []
@@ -1942,6 +1947,16 @@ resource "aws_route53_record" "whitehall_backend_internal_service_cnames" {
 #
 # whitehall_frontend
 #
+
+# draft_whitehall internal names are actually alias for whitehall internal names
+resource "aws_route53_record" "draft_whitehall_frontend_internal_service_names" {
+  count   = "${length(var.draft_whitehall_frontend_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.draft_whitehall_frontend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.whitehall_frontend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
 
 resource "aws_route53_record" "whitehall_frontend_internal_service_names" {
   count   = "${length(var.whitehall_frontend_internal_service_names)}"


### PR DESCRIPTION
# Context

A interruptibe task was raised by gov.uk 2nd line (@kevindew) to cname the draft-whitehall-frontend internal dns name to the whitehall-frontend internal dns name.

# Decisions:
1. Modify the infra-public-services terraform project's logic to reflect this and then also modify the corresponding terraform aws data: https://github.com/alphagov/govuk-aws-data/pull/301