### PR TITLE
Increase wait time for deploy user creation

### DIFF
--- a/terraform/userdata/30-deploy-apps
+++ b/terraform/userdata/30-deploy-apps
@@ -7,7 +7,7 @@
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START SNIPPET: deploy-apps"
 # First check if the deploy user has been created
 # and if not wait for puppet to do its magic (it could take a while)
-WAIT_TIME=300
+WAIT_TIME=600
 while [ $WAIT_TIME -gt 0 ]; do
   if id deploy; then break; fi
   sleep 1


### PR DESCRIPTION
  We still have cases where the system try to deploy apps before
the deploy user is created.