### PR TITLE
set healthcheck to /healthcheck to match app endpoint

### DIFF
--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -820,7 +820,7 @@ module "content-store_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/_healthcheck"
+  target_group_health_check_path = "/healthcheck"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_external_elb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]


### PR DESCRIPTION
# Context

We need to test the healthcheck of the app running via nginx rather than nginx itself. Currently nginx provides a health check endpoint on URL `/_healthcheck` but the app will provide a health check endpoint on `/healthcheck`

# Decisions
1. change the health endpoint url from `/_healthcheck`to `/healthcheck`