### PR TITLE
Add IAM role for CodeCommit Concourse pipeline

### DIFF
--- a/terraform/projects/infra-govuk-repo-mirror/README.md
+++ b/terraform/projects/infra-govuk-repo-mirror/README.md
@@ -1,7 +1,8 @@
 ## Module: govuk-repo-mirror
 
-Configures a user to allow the govuk-repo-mirror CI task
-to push to AWS CodeCommit
+Configures a user and role to allow the govuk-repo-mirror CI task
+to push to AWS CodeCommit (the user is used by the existing Jenkins
+job and the role is used by the new Concourse job)
 
 
 ## Inputs

--- a/terraform/projects/infra-govuk-repo-mirror/main.tf
+++ b/terraform/projects/infra-govuk-repo-mirror/main.tf
@@ -1,8 +1,9 @@
 /**
 * ## Module: govuk-repo-mirror
 *
-* Configures a user to allow the govuk-repo-mirror CI task
-* to push to AWS CodeCommit
+* Configures a user and role to allow the govuk-repo-mirror CI task
+* to push to AWS CodeCommit (the user is used by the existing Jenkins
+* job and the role is used by the new Concourse job)
 */
 variable "aws_region" {
   type        = "string"
@@ -35,17 +36,43 @@ provider "aws" {
   version = "1.40.0"
 }
 
-resource "aws_iam_user" "govuk_code_commit_user" {
+resource "aws_iam_user" "govuk_codecommit_user" {
   name = "govuk-${var.aws_environment}-govuk-code-commit-user"
 }
 
-resource "aws_iam_user_policy_attachment" "committer_managed_policy" {
-  user       = "${aws_iam_user.govuk_code_commit_user.name}"
+resource "aws_iam_user_policy_attachment" "govuk_codecommit_user_policy_attachment" {
+  user       = "${aws_iam_user.govuk_codecommit_user.name}"
   policy_arn = "arn:aws:iam::aws:policy/AWSCodeCommitPowerUser"
 }
 
-resource "aws_iam_user_ssh_key" "govuk_code_commit_user_jenkins_ssh_key" {
-  username   = "${aws_iam_user.govuk_code_commit_user.name}"
+resource "aws_iam_user_ssh_key" "govuk_codecommit_user_jenkins_ssh_key" {
+  username   = "${aws_iam_user.govuk_codecommit_user.name}"
   encoding   = "SSH"
   public_key = "${var.jenkins_ssh_public_key}"
+}
+
+resource "aws_iam_role" "govuk_concourse_codecommit_role" {
+  name = "govuk-concourse-codecommit-role"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "AWS": "arn:aws:iam::047969882937:role/cd-govuk-tools-concourse-worker"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "govuk_concourse_codecommit_role_policy_attachment" {
+  role       = "${aws_iam_user.govuk_concourse_codecommit_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodeCommitPowerUser"
 }


### PR DESCRIPTION
This commit adds a new IAM role which will be used by a new Concourse pipeline to backup all GOV.UK git repositories from GitHub to AWS CodeCommit in the `govuk-tools` account.