### PR TITLE
Fix govukcli getting context for aws commands

### DIFF
--- a/tools/govukcli
+++ b/tools/govukcli
@@ -303,7 +303,8 @@ EOF
   unset AWS_SESSION_TOKEN
 
   check_context
-  GOVUK_ENV=$(get_context)
+  get_context
+  GOVUK_ENV="$CONTEXT"
 
   GOVUK_SESSION=~/.aws/gds/govuk/${GOVUK_ENV}
   mkdir -p ~/.aws/gds/govuk


### PR DESCRIPTION
This commit fixes an issue with `govukcli` when used to run `aws` commands. In this case, it doesn’t correctly get the currently set context, which means any `aws` commands that are environment-specific fail.