### PR TITLE
Add govuk-tools account to govukcli

### DIFF
--- a/tools/govukcli
+++ b/tools/govukcli
@@ -9,7 +9,7 @@ set -e
 ### Global settings
 CONFIG_DIR=~/.govukcli
 CONTEXT_FILE=$CONFIG_DIR/current-context
-CONTEXTS='ci test integration staging production staging-aws production-aws'
+CONTEXTS='ci test tools integration staging production staging-aws production-aws'
 
 ### Help output
 function usage {


### PR DESCRIPTION
This commit adds the new govuk-tools AWS account to `govukcli` so it can run commands against the new account.