### PR TITLE
Add office IPs to data science machines

### DIFF
--- a/terraform/projects/app-data-science/README.md
+++ b/terraform/projects/app-data-science/README.md
@@ -13,6 +13,7 @@ Run resource intensive scripts for data science purposes.
 | aws_region | AWS region | string | `eu-west-2` | no |
 | data_science_1_subnet | Name of the subnet to place the data science instance 1 | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `Deep Learning AMI (Ubuntu) Version 21.0` | no |
+| office_ips | An array of CIDR blocks that will be allowed offsite access. | list | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-data-science/main.tf
+++ b/terraform/projects/app-data-science/main.tf
@@ -27,6 +27,11 @@ variable "data_science_1_subnet" {
   description = "Name of the subnet to place the data science instance 1"
 }
 
+variable "office_ips" {
+  type        = "list"
+  description = "An array of CIDR blocks that will be allowed offsite access."
+}
+
 variable "stackname" {
   type        = "string"
   description = "Stackname"
@@ -59,7 +64,7 @@ resource "aws_security_group_rule" "data-science_ingress_offsite-ssh_ssh" {
   to_port           = 22
   from_port         = 22
   protocol          = "tcp"
-  cidr_blocks       = ["${concat(var.office_ips)}"]
+  cidr_blocks       = ["${var.office_ips}"]
   security_group_id = "${aws_security_group.data-science.id}"
 }
 


### PR DESCRIPTION
This commit ads an `office_ips` variable that is set in govuk-aws-data to allow office IPs to access the machines via SSH.