### PR TITLE
Add Amazon owner ID to AMI owners

### DIFF
--- a/terraform/modules/aws/node_group/main.tf
+++ b/terraform/modules/aws/node_group/main.tf
@@ -178,7 +178,7 @@ data "aws_ami" "node_ami_ubuntu" {
     values = ["hvm"]
   }
 
-  owners = ["099720109477"]
+  owners = ["099720109477", "898082745236"]
 }
 
 resource "aws_iam_role" "node_iam_role" {


### PR DESCRIPTION
This commit adds the Amazon owner ID to the list of AMI owners that images are filtered by. The ID `898082745236` is an Amazon owner ID that owns the deep learning Ubuntu AMIs.