### PR TITLE
Fix elasticsearch snapshot hour format & linked service role name

### DIFF
--- a/terraform/modules/aws/es_domain/README.md
+++ b/terraform/modules/aws/es_domain/README.md
@@ -15,7 +15,7 @@ Create an ElasticSearch domain
 | instance_type | The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported | string | `m4.2xlarge.elasticsearch` | no |
 | name | The common name for all the resources created by this module | string | - | yes |
 | security_group_ids | Security group IDs to apply to this cluster | list | - | yes |
-| snapshot_start_hour | The hour in which the daily snapshot is taken | string | `01:00` | no |
+| snapshot_start_hour | The hour in which the daily snapshot is taken | string | `1` | no |
 | subnet_ids | Subnet IDs to assign to the aws_elasticsearch_domain | list | `<list>` | no |
 
 ## Outputs

--- a/terraform/modules/aws/es_domain/main.tf
+++ b/terraform/modules/aws/es_domain/main.tf
@@ -57,7 +57,7 @@ variable "security_group_ids" {
 variable "snapshot_start_hour" {
   type        = "string"
   description = "The hour in which the daily snapshot is taken"
-  default     = "01:00"
+  default     = 1
 }
 
 # Resources

--- a/terraform/modules/aws/es_domain/main.tf
+++ b/terraform/modules/aws/es_domain/main.tf
@@ -64,7 +64,6 @@ variable "snapshot_start_hour" {
 # --------------------------------------------------------------
 
 resource "aws_iam_service_linked_role" "es" {
-  name             = "${var.name}-role"
   aws_service_name = "elasticsearch.amazonaws.com"
 }
 

--- a/terraform/projects/app-elasticsearch/README.md
+++ b/terraform/projects/app-elasticsearch/README.md
@@ -13,7 +13,7 @@ Elasticsearch cluster
 | elasticsearch_ebs_size | The amount of EBS storage to attach | string | `32` | no |
 | elasticsearch_instance_count | The number of ElasticSearch nodes | string | `3` | no |
 | elasticsearch_instance_type | The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported | string | `m4.2xlarge.elasticsearch` | no |
-| elasticsearch_snapshot_start_hour | The hour in which the daily snapshot is taken | string | `01:00` | no |
+| elasticsearch_snapshot_start_hour | The hour in which the daily snapshot is taken | string | `1` | no |
 | elasticsearch_subnet_names | Names of the subnets to place the ElasticSearch domain in | list | - | yes |
 | elasticsearch_version | Which version of ElasticSearch to use (eg 5.6) | string | `5.6` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-elasticsearch/main.tf
+++ b/terraform/projects/app-elasticsearch/main.tf
@@ -51,7 +51,7 @@ variable "elasticsearch_ebs_size" {
 variable "elasticsearch_snapshot_start_hour" {
   type        = "string"
   description = "The hour in which the daily snapshot is taken"
-  default     = "01:00"
+  default     = 1
 }
 
 variable "elasticsearch_subnet_names" {


### PR DESCRIPTION
See also https://github.com/alphagov/govuk-aws-data/pull/311

---

With this change, planning locally fails complaining about missing keys in the remote state.  But one of them (`data.terraform_remote_state.infra_networking.private_subnet_names_ids_map`) is used in a bunch of other places, and I used the boilerplate remote state set-up.  So I suspect that this is some kind of local problem.