### PR TITLE
Change aws linked service name to es.amazonaws.com

### DIFF
--- a/terraform/modules/aws/es_domain/main.tf
+++ b/terraform/modules/aws/es_domain/main.tf
@@ -64,7 +64,7 @@ variable "snapshot_start_hour" {
 # --------------------------------------------------------------
 
 resource "aws_iam_service_linked_role" "es" {
-  aws_service_name = "elasticsearch.amazonaws.com"
+  aws_service_name = "es.amazonaws.com"
 }
 
 resource "aws_elasticsearch_domain" "es" {


### PR DESCRIPTION
The terraform documentation is wrong:
https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/slr-es.html