### PR TITLE
Increase PostgreSQL primary DB to next instance class

### DIFF
--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -80,7 +80,7 @@ module "postgresql-primary_rds_instance" {
   username            = "${var.username}"
   password            = "${var.password}"
   allocated_storage   = "190"
-  instance_class      = "db.m4.xlarge"
+  instance_class      = "db.m5.2xlarge"
   instance_name       = "${var.stackname}-postgresql-primary"
   multi_az            = "${var.multi_az}"
   security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]
@@ -102,7 +102,7 @@ module "postgresql-standby_rds_instance" {
 
   name                       = "${var.stackname}-postgresql-standby"
   default_tags               = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "postgresql_standby")}"
-  instance_class             = "db.m4.xlarge"
+  instance_class             = "db.m5.2xlarge"
   instance_name              = "${var.stackname}-postgresql-standby"
   security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]
   create_replicate_source_db = "1"


### PR DESCRIPTION
This commit increases the PostgreSQL primary DB instances to the next instance class to provide more CPUs and RAM. This is due to CKAN now using this database, resuting in increased load. The instances are changed from M4 to M5 since they have improved performance and are cheaper for the equivalent instances than M4.

The changes will be made during the next maintenance window, which is Monday 4-6am, since `apply_immediately` is not set and defaults to `false`.

Trello: https://trello.com/c/gEzC3bPn/756-add-more-resources-to-aws-rds