### PR TITLE
Carrenza rummanger a records aws

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -84,6 +84,7 @@ This project adds global resources for app components:
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
 | router_backend_internal_service_names |  | list | `<list>` | no |
+| rummager_elasticsearch_carrenza_internal_service_records |  | map | `<map>` | no |
 | rummager_elasticsearch_internal_service_names |  | list | `<list>` | no |
 | search_api_internal_service_names |  | list | `<list>` | no |
 | search_internal_service_cnames |  | list | `<list>` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -358,6 +358,11 @@ variable "rummager_elasticsearch_internal_service_names" {
   default = []
 }
 
+variable "rummager_elasticsearch_carrenza_internal_service_records" {
+  type    = "map"
+  default = {}
+}
+
 variable "search_internal_service_names" {
   type    = "list"
   default = []
@@ -1745,6 +1750,19 @@ resource "aws_route53_record" "rummager_elasticsearch_internal_service_names" {
   type    = "CNAME"
   records = ["${element(var.rummager_elasticsearch_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
   ttl     = "300"
+}
+
+#
+# rummager_elasticsearch_carrenza
+#
+
+resource "aws_route53_record" "rummager_elasticsearch_carrenza_internal_service_records" {
+  count   = "${length(keys(var.rummager_elasticsearch_carrenza_internal_service_records))}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(keys(var.rummager_elasticsearch_carrenza_internal_service_records), count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "A"
+
+  records = ["${element(values(var.rummager_elasticsearch_carrenza_internal_service_records), count.index)}"]
 }
 
 #


### PR DESCRIPTION
# Context

As part of the AWS migration of the licence finder frontend, the frontend needs to directly contact the rummager elastic search instances directly. These instances are not migrated from Carrenza. Hence, we need to add internal DNS A records so that AWS license finder can find the Carrenza rummager elastic search instances.

# Decisions
1. Add A records for the Carrenza rummager elastic search instances in the AWS internal DNS.

# Notes:
1. The data for the logic applied here is located in PR: https://github.com/alphagov/govuk-aws-data/pull/317