### PR TITLE
Remove govuk-repo-mirror from all environments

### DIFF
--- a/terraform/projects/infra-govuk-repo-mirror/README.md
+++ b/terraform/projects/infra-govuk-repo-mirror/README.md
@@ -1,8 +1,8 @@
 ## Module: govuk-repo-mirror
 
-Configures a user and role to allow the govuk-repo-mirror CI task
-to push to AWS CodeCommit (the user is used by the existing Jenkins
-job and the role is used by the new Concourse job)
+Configures a user and role to allow the govuk-repo-mirror Concourse pipeline
+to push to AWS CodeCommit (the user is used by the Jenkins
+Deploy_App job and the role is used by the Concourse mirroring job)
 
 
 ## Inputs

--- a/terraform/projects/infra-govuk-repo-mirror/integration.govuk.backend
+++ b/terraform/projects/infra-govuk-repo-mirror/integration.govuk.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-integration"
-key     = "govuk/infra-govuk-repo-mirror.tfstate"
-encrypt = true
-region  = "eu-west-1"

--- a/terraform/projects/infra-govuk-repo-mirror/main.tf
+++ b/terraform/projects/infra-govuk-repo-mirror/main.tf
@@ -1,9 +1,9 @@
 /**
 * ## Module: govuk-repo-mirror
 *
-* Configures a user and role to allow the govuk-repo-mirror CI task
-* to push to AWS CodeCommit (the user is used by the existing Jenkins
-* job and the role is used by the new Concourse job)
+* Configures a user and role to allow the govuk-repo-mirror Concourse pipeline
+* to push to AWS CodeCommit (the user is used by the Jenkins
+* Deploy_App job and the role is used by the Concourse mirroring job)
 */
 variable "aws_region" {
   type        = "string"
@@ -41,7 +41,6 @@ provider "aws" {
   version = "1.40.0"
 }
 
-# These will be removed once we've migrated to govuk-tools
 resource "aws_iam_user" "govuk_codecommit_user" {
   name = "govuk-${var.aws_environment}-govuk-code-commit-user"
 }

--- a/terraform/projects/infra-govuk-repo-mirror/production.govuk.backend
+++ b/terraform/projects/infra-govuk-repo-mirror/production.govuk.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-production"
-key     = "govuk/infra-govuk-repo-mirror.tfstate"
-encrypt = true
-region  = "eu-west-1"

--- a/terraform/projects/infra-govuk-repo-mirror/staging.govuk.backend
+++ b/terraform/projects/infra-govuk-repo-mirror/staging.govuk.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-staging"
-key     = "govuk/infra-govuk-repo-mirror.tfstate"
-encrypt = true
-region  = "eu-west-1"

--- a/terraform/projects/infra-govuk-repo-mirror/test.govuk.backend
+++ b/terraform/projects/infra-govuk-repo-mirror/test.govuk.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-test"
-key     = "govuk/infra-govuk-repo-mirror.tfstate"
-encrypt = true
-region  = "eu-west-1"


### PR DESCRIPTION
This commit removes govuk-repo-mirror from all environements except the tools account, from where it now runs.