### PR TITLE
Enable govukcli ssh node-types to work in Carrenza

### DIFF
--- a/tools/govukcli
+++ b/tools/govukcli
@@ -212,15 +212,12 @@ function run_ssh {
       fi;;
 
     'node-types')
-      if [[ $CARRENZA == 'true' ]]; then
-        error "Only available in AWS."
-        ssh_usage
-        exit 1
-      fi
-
       load_user
-
-      ssh $SSH_USER@$JUMPBOX "aws ec2 describe-instances --region eu-west-1 |jq -r ' .Reservations[] | .Instances[] | .Tags[] | select(.Key | contains(\"aws_migration\")) | .Value' |sort |uniq |sort"
+      if [[ $CARRENZA == 'true' ]]; then
+        ssh $SSH_USER@$JUMPBOX "govuk_node_list --classes"
+      else
+        ssh $SSH_USER@$JUMPBOX "aws ec2 describe-instances --region eu-west-1 |jq -r ' .Reservations[] | .Instances[] | .Tags[] | select(.Key | contains(\"aws_migration\")) | .Value' |sort |uniq |sort"
+      fi
     ;;
 
     'help') ssh_usage;;


### PR DESCRIPTION
Previously this was disabled for Carrenza environments. Now that the
govuk_node_list tool supports `--classes` in Carrenza environments
[1], that can be used to provide some useful information here.

1: https://github.com/alphagov/govuk-puppet/pull/8576