### PR TITLE
Add stackname variable for fastly-datagovuk

### DIFF
--- a/terraform/projects/fastly-datagovuk/README.md
+++ b/terraform/projects/fastly-datagovuk/README.md
@@ -19,4 +19,5 @@ Manages the Fastly service for data.gov.uk
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| stackname | Stackname | string | - | yes |
 

--- a/terraform/projects/fastly-datagovuk/main.tf
+++ b/terraform/projects/fastly-datagovuk/main.tf
@@ -4,6 +4,11 @@
 * Manages the Fastly service for data.gov.uk
 */
 
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+}
+
 variable "aws_environment" {
   type        = "string"
   description = "AWS Environment"


### PR DESCRIPTION
This commit adds the `stackname` variable for the `fastly-datagovuk` project, since this variable is used in the project.