### PR TITLE
Switch data science EC2 instance type to p2.xlarge

### DIFF
--- a/terraform/projects/app-data-science/main.tf
+++ b/terraform/projects/app-data-science/main.tf
@@ -114,7 +114,7 @@ module "data-science" {
   default_tags                  = "${map("aws_environment", var.aws_environment, "aws_migration", "data-science", "aws_hostname", "data-science-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${aws_security_group.data-science.id}"]
-  instance_type                 = "c5.4xlarge"
+  instance_type                 = "p2.xlarge"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.data-science_external_elb.id}"]
   instance_elb_ids_length       = "1"


### PR DESCRIPTION
https://trello.com/c/52Lcfble/359-migrate-to-p2xlarge-aws-instance-to-produce-related-links-using-graphsage

This is part of the related links project.