### PR TITLE
Fix data.gov.uk education standards backend

### DIFF
--- a/terraform/projects/fastly-datagovuk/main.tf
+++ b/terraform/projects/fastly-datagovuk/main.tf
@@ -87,8 +87,8 @@ resource "fastly_service_v1" "datagovuk" {
     name              = "education_standards"
     action            = "set"
     type              = "request"
-    destination       = "req.url"
-    source            = "regsub(req.url, \"^/education-standards\", \"\");"
+    destination       = "url"
+    source            = "regsub(req.url, \"^/education-standards\", \"\")"
     request_condition = "education_standards"
   }
 


### PR DESCRIPTION
A request-type header assumes the `req` prefix to all variables. In addition, a `;` is automatically added at the end of the `source` field.