### PR TITLE
Increase Elasticsearch node count

### DIFF
--- a/terraform/projects/app-elasticsearch5/README.md
+++ b/terraform/projects/app-elasticsearch5/README.md
@@ -11,7 +11,7 @@ Managed Elasticsearch 5 cluster
 | aws_region | AWS region | string | `eu-west-1` | no |
 | elasticsearch5_ebs_encrypt | Whether to encrypt the EBS volume at rest | string | - | yes |
 | elasticsearch5_ebs_size | The amount of EBS storage to attach | string | `32` | no |
-| elasticsearch5_instance_count | The number of ElasticSearch nodes | string | `3` | no |
+| elasticsearch5_instance_count | The number of ElasticSearch nodes | string | `4` | no |
 | elasticsearch5_instance_type | The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported | string | `m4.2xlarge.elasticsearch` | no |
 | elasticsearch5_snapshot_start_hour | The hour in which the daily snapshot is taken | string | `1` | no |
 | elasticsearch_subnet_names | Names of the subnets to place the ElasticSearch domain in | list | - | yes |

--- a/terraform/projects/app-elasticsearch5/main.tf
+++ b/terraform/projects/app-elasticsearch5/main.tf
@@ -28,7 +28,7 @@ variable "elasticsearch5_instance_type" {
 variable "elasticsearch5_instance_count" {
   type        = "string"
   description = "The number of ElasticSearch nodes"
-  default     = "3"
+  default     = "4"
 }
 
 variable "elasticsearch5_ebs_encrypt" {


### PR DESCRIPTION
AWS Managed Elasticsearch requires an even number of nodes when running over multiple availability zones.  This increases the node count from 3 to 4.

Trello card: https://trello.com/c/ut3wIgN6/31-set-up-new-managed-elasticsearch-cluster-in-aws