### PR TITLE
Remove Elasticsearch advanced_options

### DIFF
--- a/terraform/projects/app-elasticsearch5/main.tf
+++ b/terraform/projects/app-elasticsearch5/main.tf
@@ -94,10 +94,6 @@ resource "aws_elasticsearch_domain" "elasticsearch5" {
     security_group_ids = ["${data.terraform_remote_state.infra_security_groups.sg_elasticsearch5_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   }
 
-  advanced_options {
-    "action.destructive_requires_name" = "true"
-  }
-
   snapshot_options {
     automated_snapshot_start_hour = "${var.elasticsearch5_snapshot_start_hour}"
   }


### PR DESCRIPTION
The only advanced option we are setting is not supported.  We will look at an alternative way of implementing `action.destructive_requires_name`.  It is not essential for initially setting up the cluster..

Trello card: https://trello.com/c/ut3wIgN6/31-set-up-new-managed-elasticsearch-cluster-in-aws