### PR TITLE
Update ingress rules for managed Elasticsearch cluster

### DIFF
--- a/terraform/projects/infra-security-groups/elasticsearch5.tf
+++ b/terraform/projects/infra-security-groups/elasticsearch5.tf
@@ -2,8 +2,8 @@
 # == Manifest: Project: Security Groups: elasticsearch5
 #
 # The elasticsearch cluster needs to be accessible on ports:
-#   - 9200 from 'calculators_frontend' (for licence-finder)
-#   - 9200 from 'search' (for search-api)
+#   - 443 from 'calculators_frontend' (for licence-finder)
+#   - 443 from 'search' (for search-api)
 #
 # === Variables:
 # stackname - string
@@ -24,8 +24,8 @@ resource "aws_security_group" "elasticsearch5" {
 
 resource "aws_security_group_rule" "elasticsearch5_ingress_calculators-frontend_elasticsearch-api" {
   type      = "ingress"
-  from_port = 9200
-  to_port   = 9200
+  from_port = 443
+  to_port   = 443
   protocol  = "tcp"
 
   # Which security group is the rule assigned to
@@ -37,8 +37,8 @@ resource "aws_security_group_rule" "elasticsearch5_ingress_calculators-frontend_
 
 resource "aws_security_group_rule" "elasticsearch5_ingress_search_elasticsearch-api" {
   type      = "ingress"
-  from_port = 9200
-  to_port   = 9200
+  from_port = 443
+  to_port   = 443
   protocol  = "tcp"
 
   # Which security group is the rule assigned to


### PR DESCRIPTION
Managed Elasticsearch provides access via HTTPS on port 443, not the Elasticsearch default of 9200.  This updates the ingress rules so calculators_frontend and search machines can access the search endpoint.

Trello card: https://trello.com/c/ut3wIgN6/31-set-up-new-managed-elasticsearch-cluster-in-aws