### PR TITLE
Add access policy for AWS Elasticsearch cluster

### DIFF
--- a/terraform/projects/app-elasticsearch5/main.tf
+++ b/terraform/projects/app-elasticsearch5/main.tf
@@ -98,6 +98,26 @@ resource "aws_elasticsearch_domain" "elasticsearch5" {
     automated_snapshot_start_hour = "${var.elasticsearch5_snapshot_start_hour}"
   }
 
+  access_policies = <<CONFIG
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "*"
+        ]
+      },
+      "Action": [
+        "es:*"
+      ],
+      "Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain}/*"
+    }
+  ]
+}
+CONFIG
+
   tags {
     Name            = "${var.stackname}-elasticsearch5"
     Project         = "${var.stackname}"

--- a/terraform/projects/infra-security-groups/elasticsearch5.tf
+++ b/terraform/projects/infra-security-groups/elasticsearch5.tf
@@ -2,8 +2,8 @@
 # == Manifest: Project: Security Groups: elasticsearch5
 #
 # The elasticsearch cluster needs to be accessible on ports:
-#   - 443 from 'calculators_frontend' (for licence-finder)
-#   - 443 from 'search' (for search-api)
+#   - 80 from 'calculators_frontend' (for licence-finder)
+#   - 80 from 'search' (for search-api)
 #
 # === Variables:
 # stackname - string
@@ -24,8 +24,8 @@ resource "aws_security_group" "elasticsearch5" {
 
 resource "aws_security_group_rule" "elasticsearch5_ingress_calculators-frontend_elasticsearch-api" {
   type      = "ingress"
-  from_port = 443
-  to_port   = 443
+  from_port = 80
+  to_port   = 80
   protocol  = "tcp"
 
   # Which security group is the rule assigned to
@@ -37,8 +37,8 @@ resource "aws_security_group_rule" "elasticsearch5_ingress_calculators-frontend_
 
 resource "aws_security_group_rule" "elasticsearch5_ingress_search_elasticsearch-api" {
   type      = "ingress"
-  from_port = 443
-  to_port   = 443
+  from_port = 80
+  to_port   = 80
   protocol  = "tcp"
 
   # Which security group is the rule assigned to


### PR DESCRIPTION
This policy permits access to all clients within the VPC (without signing the requests), subject to the ingress filtering specified in the security group.

Trello card: https://trello.com/c/ut3wIgN6/31-set-up-new-managed-elasticsearch-cluster-in-aws