### PR TITLE
Upgrade data-science-2 instance type p3.8xlarge

### DIFF
--- a/terraform/projects/app-data-science/main.tf
+++ b/terraform/projects/app-data-science/main.tf
@@ -130,7 +130,7 @@ module "data-science-2" {
   default_tags                  = "${map("aws_environment", var.aws_environment, "aws_migration", "data-science", "aws_hostname", "data-science-2")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.public_subnet_ids}"
   instance_security_group_ids   = ["${aws_security_group.data-science.id}"]
-  instance_type                 = "p3.2xlarge"
+  instance_type                 = "p3.8xlarge"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.data-science_external_elb.id}"]
   instance_elb_ids_length       = "1"


### PR DESCRIPTION
This PR upgrades the `data-science-2` EC2 instance type from `p3.2xlarge` to `p3.8xlarge`.

This instance is being used to evaulate the implementation of a GraphSAGE algorithm which will be used to generate related links for content pages across GOV.UK. To perform this evaluation, it is necessary to run the algorithm against a set of sample data.

Currently on the `p3.2xlarge` instance, it takes approximately 20 minutes to evaluate one page of the sample data (one content item) using the algorithm. By switching the instance type to `p3.8xlarge`, we roughly estimate that this time can be brought down to 5 minutes per page of the sample data.

By speeding up the evaluation process, we will be able to determine the suitability of the algorithm for the purpose of generating related links and will then productionise the process to be able to evaluate ~200K content items for the actual A/B test.

In terms of cost (at the time of writing), the `p3.8xlarge` is priced at $12.24/hr; we anticipate that we will need up to 8 hours of compute time, which would result in a total cost of $97.92. In comparison, the `p3.2xlarge` currently costs $3.06/hr - this would result in the same total cost of $97.92 as we anticipate it would take up to four times as long to completely evaluate our sample data.

To ensure maximum value from this upgraded instance, we should make it available early on Wednesday, 20th February and spin down at the end of day.