### PR TITLE
Allow db-admin to SSH into the ckan machine

### DIFF
--- a/terraform/projects/infra-security-groups/ckan.tf
+++ b/terraform/projects/infra-security-groups/ckan.tf
@@ -3,6 +3,7 @@
 #
 # CKAN needs to be accessible on ports:
 #   - 80 from its ELB
+#   - 22 from db-admin
 #
 # === Variables:
 # stackname - string
@@ -106,4 +107,15 @@ resource "aws_security_group_rule" "ckan-elb-external_egress_any_any" {
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.ckan_elb_external.id}"
+}
+
+# Allow SSH access from db-admin for data sync
+resource "aws_security_group_rule" "ckan-elb_ingress_db_admin_ssh" {
+  type      = "ingress"
+  from_port = 22
+  to_port   = 22
+  protocol  = "tcp"
+
+  security_group_id        = "${aws_security_group.ckan_elb_internal.id}"
+  source_security_group_id = "${aws_security_group.db-admin.id}"
 }


### PR DESCRIPTION
We need this to support the data sync from production to staging as it needs to run some post processing task on the ckan machine.

See https://github.com/alphagov/govuk-aws/pull/811 for more information.

[Trello Card](https://trello.com/c/RiOpZ1qs/762-get-ckan-database-up-and-running-on-staging)