### PR TITLE
Remove non-permitted slash characters from lambda permission name

### DIFF
--- a/terraform/modules/aws/cloudwatch_log_exporter/main.tf
+++ b/terraform/modules/aws/cloudwatch_log_exporter/main.tf
@@ -77,7 +77,7 @@ resource "aws_kinesis_firehose_delivery_stream" "logs_s3" {
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch" {
-  statement_id   = "AllowExecutionFromCloudWatchLog-${var.log_group_name}"
+  statement_id   = "${format("AllowExecutionFromCloudWatchLog-%s", replace(var.log_group_name, "/", "-"))}"
   action         = "lambda:InvokeFunction"
   function_name  = "${aws_lambda_function.lambda_logs_to_firehose.arn}"
   principal      = "logs.${data.aws_region.current.name}.amazonaws.com"


### PR DESCRIPTION
The Elasticsearch logs have slashes in their names, which are not permitted by the regex `"^[a-zA-Z0-9-_]+$"`.  This replaces them with a permitted character.  Putting it here so we don't encounter the same problem with any future log exports.

Trello card: https://trello.com/c/44CAPD5j/57-set-up-export-of-logs-from-cloudwatch-to-s3