### PR TITLE
Reduce length of Lambda function name

### DIFF
--- a/terraform/modules/aws/cloudwatch_log_exporter/main.tf
+++ b/terraform/modules/aws/cloudwatch_log_exporter/main.tf
@@ -92,7 +92,7 @@ resource "aws_cloudwatch_log_group" "lambda_logs_to_firehose_log_group" {
 
 resource "aws_lambda_function" "lambda_logs_to_firehose" {
   filename      = "${var.lambda_filename}"
-  function_name = "${format("CloudWatchLogsToFirehose-%s", replace(var.log_group_name, "/", "-"))}"
+  function_name = "${format("CloudWatchLogsToFirehose-%s", basename(var.log_group_name))}"
   role          = "${var.lambda_role_arn}"
   handler       = "main.lambda_handler"
   runtime       = "python2.7"


### PR DESCRIPTION
AWS limits this to 64 characters, so take the basename only.

Trello card: https://trello.com/c/44CAPD5j/57-set-up-export-of-logs-from-cloudwatch-to-s3