### PR TITLE
Double backend capacity to match Carrenza

### DIFF
--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -192,7 +192,7 @@ module "backend" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend", "aws_hostname", "backend-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}", "${data.terraform_remote_state.infra_security_groups.sg_aws-vpn_id}"]
-  instance_type                 = "m5.xlarge"
+  instance_type                 = "m5.2xlarge"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "2"
   instance_elb_ids              = ["${aws_elb.backend_elb_internal.id}", "${aws_elb.backend_elb_external.id}"]


### PR DESCRIPTION
We noticed on 2nd line that the backend machines in Carrenza are 8 CPU 32GB of ram whereas in AWS they are 4 CPU and 16GB. 

This PR rather simply changes the EC2 class to be 8 CPU and 32GB which leaves the hard work of how we actually change this.

The problem this seems to be causing in integration is that there isn't enough memory to run clamav.

When trying to start clamav this error occurs:

```
Feb 22 16:23:43 ip-10-1-5-128.eu-west-1.compute.internal clamd[19758]: daemonize() failed: Cannot allocate memory
```