### PR TITLE
Update the managed Elasticsearch cluster architecture

### DIFF
--- a/terraform/projects/app-elasticsearch5/README.md
+++ b/terraform/projects/app-elasticsearch5/README.md
@@ -10,10 +10,14 @@ Managed Elasticsearch 5 cluster
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | `90` | no |
+| elasticsearch5_dedicated_master_enabled | Indicates whether dedicated master nodes are enabled for the cluster | boolean | `true` | no |
 | elasticsearch5_ebs_encrypt | Whether to encrypt the EBS volume at rest | string | - | yes |
 | elasticsearch5_ebs_size | The amount of EBS storage to attach | string | `32` | no |
+| elasticsearch5_ebs_type | The type of EBS storage to attach | string | `gp2` | no |
 | elasticsearch5_instance_count | The number of ElasticSearch nodes | string | `3` | no |
-| elasticsearch5_instance_type | The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported | string | `m4.2xlarge.elasticsearch` | no |
+| elasticsearch5_instance_type | The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported | string | `r4.large.elasticsearch` | no |
+| elasticsearch5_master_instance_count | Number of dedicated master nodes in the cluster | string | `3` | no |
+| elasticsearch5_master_instance_type | Instance type of the dedicated master nodes in the cluster | string | `c4.large.elasticsearch` | no |
 | elasticsearch5_snapshot_start_hour | The hour in which the daily snapshot is taken | string | `1` | no |
 | elasticsearch_subnet_names | Names of the subnets to place the ElasticSearch domain in | list | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-elasticsearch5/main.tf
+++ b/terraform/projects/app-elasticsearch5/main.tf
@@ -22,7 +22,7 @@ variable "stackname" {
 variable "elasticsearch5_instance_type" {
   type        = "string"
   description = "The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported"
-  default     = "m4.2xlarge.elasticsearch"
+  default     = "r4.large.elasticsearch"
 }
 
 variable "elasticsearch5_instance_count" {
@@ -31,9 +31,33 @@ variable "elasticsearch5_instance_count" {
   default     = "3"
 }
 
+variable "elasticsearch5_dedicated_master_enabled" {
+  type        = "boolean"
+  description = "Indicates whether dedicated master nodes are enabled for the cluster"
+  default     = true
+}
+
+variable "elasticsearch5_master_instance_type" {
+  type        = "string"
+  description = "Instance type of the dedicated master nodes in the cluster"
+  default     = "c4.large.elasticsearch"
+}
+
+variable "elasticsearch5_master_instance_count" {
+  type        = "string"
+  description = "Number of dedicated master nodes in the cluster"
+  default     = "3"
+}
+
 variable "elasticsearch5_ebs_encrypt" {
   type        = "string"
   description = "Whether to encrypt the EBS volume at rest"
+}
+
+variable "elasticsearch5_ebs_type" {
+  type        = "string"
+  description = "The type of EBS storage to attach"
+  default     = "gp2"
 }
 
 variable "elasticsearch5_ebs_size" {
@@ -154,14 +178,17 @@ resource "aws_elasticsearch_domain" "elasticsearch5" {
   elasticsearch_version = "5.6"
 
   cluster_config {
-    instance_type          = "${var.elasticsearch5_instance_type}"
-    instance_count         = "${var.elasticsearch5_instance_count}"
-    zone_awareness_enabled = true
+    instance_type            = "${var.elasticsearch5_instance_type}"
+    instance_count           = "${var.elasticsearch5_instance_count}"
+    dedicated_master_enabled = "${var.elasticsearch5_dedicated_master_enabled}"
+    dedicated_master_type    = "${var.elasticsearch5_master_instance_type}"
+    dedicated_master_count   = "${var.elasticsearch5_master_instance_count}"
+    zone_awareness_enabled   = true
   }
 
   ebs_options {
     ebs_enabled = true
-    volume_type = "gp2"
+    volume_type = "${var.elasticsearch5_ebs_type}"
     volume_size = "${var.elasticsearch5_ebs_size}"
   }
 


### PR DESCRIPTION
This updates the architecture of the managed Elasticsearch cluster, based on the Google doc: https://docs.google.com/document/d/1rnXMNQVUWa4rNGH1L6H7dI3NPXD_Niuht9uZyAI_XjM/edit

No changes have been made to the sharding strategy.  Two methods of sharding will be implemented later and compared.

Trello card: https://trello.com/c/nLemuXWJ/62-update-es5-cluster-configuration-based-on-architecture-decision