### PR TITLE
allow monitoring boxes to access the cache external ELB for certificate check

### DIFF
--- a/terraform/modules/aws/network/nat/README.md
+++ b/terraform/modules/aws/network/nat/README.md
@@ -15,6 +15,7 @@ subnets provided.
 
 | Name | Description |
 |------|-------------|
+| nat_gateway_elastic_ips_list | List containing the public IPs associated with the NAT gateways |
 | nat_gateway_ids | List containing the IDs of the NAT gateways |
 | nat_gateway_subnets_ids_map | Map containing the NAT gateway IDs and the public subnet ID where each one is located |
 

--- a/terraform/modules/aws/network/nat/main.tf
+++ b/terraform/modules/aws/network/nat/main.tf
@@ -48,3 +48,8 @@ output "nat_gateway_subnets_ids_map" {
   value       = "${zipmap(aws_nat_gateway.nat.*.subnet_id, aws_nat_gateway.nat.*.id)}"
   description = "Map containing the NAT gateway IDs and the public subnet ID where each one is located"
 }
+
+output "nat_gateway_elastic_ips_list" {
+  value       = ["${aws_eip.nat.*.public_ip}"]
+  description = "List containing the public IPs associated with the NAT gateways"
+}

--- a/terraform/projects/infra-networking/README.md
+++ b/terraform/projects/infra-networking/README.md
@@ -31,6 +31,7 @@ This module governs the creation of full network stacks.
 
 | Name | Description |
 |------|-------------|
+| nat_gateway_elastic_ips_list | List containing the public IPs associated with the NAT gateways |
 | private_subnet_elasticache_ids | List of private subnet IDs |
 | private_subnet_elasticache_names_azs_map |  |
 | private_subnet_elasticache_names_ids_map | Map containing the pair name-id for each private subnet created |

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -242,6 +242,11 @@ output "vpc_id" {
   description = "VPC ID where the stack resources are created"
 }
 
+output "nat_gateway_elastic_ips_list" {
+  value       = "${module.infra_nat.nat_gateway_elastic_ips_list}"
+  description = "List containing the public IPs associated with the NAT gateways"
+}
+
 output "public_subnet_ids" {
   value       = "${module.infra_public_subnet.subnet_ids}"
   description = "List of public subnet IDs"

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -16,6 +16,7 @@ Manage the security groups for the entire infrastructure
 | carrenza_vpn_subnet_cidr | The Carrenza VPN subnet CIDR | list | `<list>` | no |
 | office_ips | An array of CIDR blocks that will be allowed offsite access. | list | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
 | stackname | The name of the stack being built. Must be unique within the environment as it's used for disambiguation. | string | - | yes |
 | traffic_replay_ips | An array of CIDR blocks that will replay traffic against an environment | list | - | yes |

--- a/terraform/projects/infra-security-groups/cache.tf
+++ b/terraform/projects/infra-security-groups/cache.tf
@@ -125,7 +125,12 @@ resource "aws_security_group_rule" "cache-external-elb_ingress_public_https" {
   from_port         = 443
   protocol          = "tcp"
   security_group_id = "${aws_security_group.cache_external_elb.id}"
-  cidr_blocks       = ["${data.fastly_ip_ranges.fastly.cidr_blocks}", "${var.office_ips}", "${var.traffic_replay_ips}"]
+
+  cidr_blocks = ["${data.fastly_ip_ranges.fastly.cidr_blocks}",
+    "${var.office_ips}",
+    "${var.traffic_replay_ips}",
+    "${formatlist("%s/32",data.terraform_remote_state.infra_networking.nat_gateway_elastic_ips_list)}",
+  ]
 }
 
 resource "aws_security_group_rule" "cache-external-elb_egress_any_any" {

--- a/terraform/projects/infra-security-groups/remote_state.tf
+++ b/terraform/projects/infra-security-groups/remote_state.tf
@@ -1,0 +1,18 @@
+variable "remote_state_infra_networking_key_stack" {
+  type        = "string"
+  description = "Override infra_networking remote state path"
+  default     = ""
+}
+
+# Resources
+# --------------------------------------------------------------
+
+data "terraform_remote_state" "infra_networking" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
+    region = "eu-west-1"
+  }
+}


### PR DESCRIPTION
# Context

The monitoring box in each AWS environment should be able to contact the external ELB of the cache machines of that AWS environment because there is an Icinga check to verify the SSL certificate expiry date.

Since the monitoring box uses the NAT gateway to contact the external ELB of the cache machines, the NAT gateway public IPs must be authorized to communicate with the external ELB.

# Decisions
1. output the public IPs of the nat gateways from the infra-networking project.
2. use the outputted public IPs in Step 1 in the list of IPs which are authorized to contact the cache external ELB.
