### PR TITLE
Remove non-breaking spaces

### DIFF
--- a/terraform/projects/app-publishing-api-db-admin/README.md
+++ b/terraform/projects/app-publishing-api-db-admin/README.md
@@ -1,6 +1,6 @@
 ## Project: app-publishing-api-db-admin
 
- DB admin boxes for publishing-api's RDS instance
+DB admin boxes for publishing-api's RDS instance
 
 
 ## Inputs

--- a/terraform/projects/app-publishing-api-db-admin/main.tf
+++ b/terraform/projects/app-publishing-api-db-admin/main.tf
@@ -1,7 +1,7 @@
 /**
 * ## Project: app-publishing-api-db-admin
 *
-* DB admin boxes for publishing-api's RDS instance
+* DB admin boxes for publishing-api's RDS instance
 */
 variable "aws_region" {
   type        = "string"

--- a/terraform/projects/app-transition-db-admin/README.md
+++ b/terraform/projects/app-transition-db-admin/README.md
@@ -1,6 +1,6 @@
 ## Project: app-transition-db-admin
 
- DB admin boxes for Transition's RDS instance
+DB admin boxes for Transition's RDS instance
 
 
 ## Inputs

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -1,7 +1,7 @@
 /**
 * ## Project: app-transition-db-admin
 *
-* DB admin boxes for Transition's RDS instance
+* DB admin boxes for Transition's RDS instance
 */
 variable "aws_region" {
   type        = "string"

--- a/terraform/projects/app-warehouse-db-admin/README.md
+++ b/terraform/projects/app-warehouse-db-admin/README.md
@@ -1,6 +1,6 @@
 ## Project: app-warehouse-db-admin
 
- DB admin boxes for Warehouse's RDS instance
+DB admin boxes for Warehouse's RDS instance
 
 
 ## Inputs

--- a/terraform/projects/app-warehouse-db-admin/main.tf
+++ b/terraform/projects/app-warehouse-db-admin/main.tf
@@ -1,7 +1,7 @@
 /**
 * ## Project: app-warehouse-db-admin
 *
-* DB admin boxes for Warehouse's RDS instance
+* DB admin boxes for Warehouse's RDS instance
 */
 variable "aws_region" {
   type        = "string"

--- a/terraform/userdata/90-data-science-base
+++ b/terraform/userdata/90-data-science-base
@@ -11,8 +11,9 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] START SNIPPET: data-science-base"
 
 export DEBIAN_FRONTEND=noninteractive
 
-# SSH keys are hardcoded here since puppet doesn't run on these machines, and they are special-purpose
-# machines with short lifetimes.
+# SSH keys are hardcoded here since puppet doesn't run on these
+# machines, and they are special-purpose machines with short
+# lifetimes.
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] data-science-base: add SSH keys for users that will use this machine..."
 
 {


### PR DESCRIPTION
Also reflow a comment so the lines are not so long.

Unless theres a need for fancier kinds of whitespace, it's probably
better just to stick to spaces, and maybe tabs.