### PR TITLE
Add ALB for search-api external access, use a CNAME for internal access

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -86,6 +86,7 @@ This project adds global resources for app components:
 | router_backend_internal_service_names |  | list | `<list>` | no |
 | rummager_elasticsearch_carrenza_internal_service_records |  | map | `<map>` | no |
 | rummager_elasticsearch_internal_service_names |  | list | `<list>` | no |
+| search_api_public_service_names |  | list | `<list>` | no |
 | search_internal_service_cnames |  | list | `<list>` | no |
 | search_internal_service_names |  | list | `<list>` | no |
 | stackname | Stackname | string | - | yes |

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -86,7 +86,6 @@ This project adds global resources for app components:
 | router_backend_internal_service_names |  | list | `<list>` | no |
 | rummager_elasticsearch_carrenza_internal_service_records |  | map | `<map>` | no |
 | rummager_elasticsearch_internal_service_names |  | list | `<list>` | no |
-| search_api_internal_service_names |  | list | `<list>` | no |
 | search_internal_service_cnames |  | list | `<list>` | no |
 | search_internal_service_names |  | list | `<list>` | no |
 | stackname | Stackname | string | - | yes |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -373,11 +373,6 @@ variable "search_internal_service_cnames" {
   default = []
 }
 
-variable "search_api_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
 variable "transition_db_admin_internal_service_names" {
   type    = "list"
   default = []
@@ -1785,19 +1780,6 @@ resource "aws_route53_record" "search_internal_service_cnames" {
   name    = "${element(var.search_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
   type    = "CNAME"
   records = ["${element(var.search_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
-# search-api
-#
-
-resource "aws_route53_record" "search_api_internal_service_names" {
-  count   = "${length(var.search_api_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
-  name    = "${element(var.search_api_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.search_api_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
   ttl     = "300"
 }
 

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -373,6 +373,11 @@ variable "search_internal_service_cnames" {
   default = []
 }
 
+variable "search_api_public_service_names" {
+  type    = "list"
+  default = []
+}
+
 variable "transition_db_admin_internal_service_names" {
   type    = "list"
   default = []
@@ -1765,6 +1770,18 @@ resource "aws_route53_record" "rummager_elasticsearch_carrenza_internal_service_
 # search
 #
 
+data "aws_autoscaling_groups" "search" {
+  filter {
+    name   = "key"
+    values = ["Name"]
+  }
+
+  filter {
+    name   = "value"
+    values = ["blue-search"]
+  }
+}
+
 resource "aws_route53_record" "search_internal_service_names" {
   count   = "${length(var.search_internal_service_names)}"
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
@@ -1781,6 +1798,50 @@ resource "aws_route53_record" "search_internal_service_cnames" {
   type    = "CNAME"
   records = ["${element(var.search_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
   ttl     = "300"
+}
+
+#
+# search-api
+#
+
+module "search_api_public_lb" {
+  source                                     = "../../modules/aws/lb"
+  name                                       = "${var.stackname}-search-api-public"
+  internal                                   = false
+  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix                  = "elb/${var.stackname}-search-api-public-elb"
+  listener_certificate_domain_name           = "${var.elb_public_certname}"
+  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
+
+  listener_action = {
+    "HTTPS:443" = "HTTP:80"
+  }
+
+  target_group_health_check_path = "/_healthcheck"
+  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_search-api_external_elb_id}"]
+  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  default_tags                   = "${map("Project", var.stackname, "aws_migration", "search-api", "aws_environment", var.aws_environment)}"
+}
+
+resource "aws_route53_record" "search_api_public_service_names" {
+  count   = "${length(var.search_api_public_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.search_api_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${module.search_api_public_lb.lb_dns_name}"
+    zone_id                = "${module.search_api_public_lb.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_autoscaling_attachment" "search_api_backend_asg_attachment_alb" {
+  count                  = "${length(data.aws_autoscaling_groups.search.names) > 0 ? 1 : 0}"
+  autoscaling_group_name = "${element(data.aws_autoscaling_groups.search.names, 0)}"
+  alb_target_group_arn   = "${element(module.search_api_public_lb.target_group_arns, 0)}"
 }
 
 # support-api

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -109,6 +109,7 @@ Manage the security groups for the entire infrastructure
 | sg_router-backend_id |  |
 | sg_rummager-elasticsearch_elb_id |  |
 | sg_rummager-elasticsearch_id |  |
+| sg_search-api_external_elb_id |  |
 | sg_search_elb_id |  |
 | sg_search_id |  |
 | sg_support-api_external_elb_id |  |

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -314,6 +314,10 @@ output "sg_router-backend_id" {
   value = "${aws_security_group.router-backend.id}"
 }
 
+output "sg_search-api_external_elb_id" {
+  value = "${aws_security_group.search-api_external_elb.id}"
+}
+
 output "sg_search_elb_id" {
   value = "${aws_security_group.search_elb.id}"
 }

--- a/terraform/projects/infra-security-groups/search-api.tf
+++ b/terraform/projects/infra-security-groups/search-api.tf
@@ -1,0 +1,41 @@
+#
+# == Manifest: Project: Security Groups: search-api
+#
+# Search API needs to be accessible on ports:
+#   - 443 from the other VMs
+#
+# === Variables:
+# stackname - string
+#
+# === Outputs:
+# sg_search-api_elb_id
+
+resource "aws_security_group" "search-api_external_elb" {
+  name        = "${var.stackname}_search-api_external_elb_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access the search-api external ELB"
+
+  tags {
+    Name = "${var.stackname}_search-api_external_elb_access"
+  }
+}
+
+resource "aws_security_group_rule" "search-api_ingress_external-elb_https" {
+  count     = "${length(var.carrenza_env_ips) > 0 ? 1 : 0}"
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id = "${aws_security_group.search-api_external_elb.id}"
+  cidr_blocks       = ["${var.carrenza_env_ips}"]
+}
+
+resource "aws_security_group_rule" "search-api_egress_external_elb_any_any" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.search-api_external_elb.id}"
+}

--- a/terraform/projects/infra-security-groups/search.tf
+++ b/terraform/projects/infra-security-groups/search.tf
@@ -44,6 +44,19 @@ resource "aws_security_group" "search_elb" {
   }
 }
 
+resource "aws_security_group_rule" "search-api_ingress_elb_external_http" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.search.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.search-api_external_elb.id}"
+}
+
 # TODO: Audit
 resource "aws_security_group_rule" "search-elb_ingress_management_https" {
   type      = "ingress"


### PR DESCRIPTION
This PR removes the search-api internal service name, that should more properly be a CNAME pointing to the "search" hostname, as search-api lives on the app-search machines (just like rummager).

It also adds an ALB so that Carrenza IPs can talk to search-api over the public internet, which is needed for:

1. Traffic replay from rummager to search-api while we have both running in parallel
2. Direct communication from search-admin and whitehall when rummager is switched off

govuk-aws-data PR: https://github.com/alphagov/govuk-aws-data/pull/339

---

[Trello card](https://trello.com/c/YU9bS9jR/76-get-search-api-running-in-aws-staging)