### PR TITLE
Open integration draft-cache to the world

### DIFF
--- a/terraform/projects/infra-security-groups/draft-cache.tf
+++ b/terraform/projects/infra-security-groups/draft-cache.tf
@@ -103,7 +103,7 @@ resource "aws_security_group_rule" "draft-cache-external-elb_ingress_public_http
   from_port         = 443
   protocol          = "tcp"
   security_group_id = "${aws_security_group.draft-cache_external_elb.id}"
-  cidr_blocks       = ["${data.fastly_ip_ranges.fastly.cidr_blocks}", "${var.office_ips}"]
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 # This is required to commit routes using router-api at the end of the data sync


### PR DESCRIPTION
Context
We need access to draft-origin and subsequently draft-cache for training
sessions run on the integration environment. Access to
draft-origin.integration.publishing.service.gov.uk being restricted to the list
of fastly and office ips means that anyone on GovWiFi (for example) will be
unable to do their training. Access is further restricted by signon.

Decision
Modify the draft-cache security group to allow access to everyone. They
will still need a signon account.
