### PR TITLE
Add code for s3-mirrors

### DIFF
--- a/terraform/projects/infra-s3-mirrors/README.md
+++ b/terraform/projects/infra-s3-mirrors/README.md
@@ -1,0 +1,18 @@
+## Project: infra-s3-mirrors
+
+This creates two s3 buckets
+
+govuk-mirror-{env}-access-logs: The bucket that will hold the access logs
+govuk-mirror-{env}: The bucket that will hold the mirror content
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| stackname | Stackname | string | - | yes |
+

--- a/terraform/projects/infra-s3-mirrors/integration.govuk.backend
+++ b/terraform/projects/infra-s3-mirrors/integration.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "govuk/infra-s3-mirrors.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-s3-mirrors/main.tf
+++ b/terraform/projects/infra-s3-mirrors/main.tf
@@ -1,0 +1,72 @@
+/**
+* ## Project: infra-s3-mirrors
+*
+* This creates two s3 buckets
+*
+* govuk-mirror-{env}-access-logs: The bucket that will hold the access logs
+* govuk-mirror-{env}: The bucket that will hold the mirror content
+*
+*/
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "S3 bucket we store our terraform state in"
+}
+
+# Resources
+# --------------------------------------------------------------
+
+# Set up the backend & provider for each region
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.40.0"
+}
+
+resource "aws_s3_bucket" "govuk_mirror_access_logs" {
+  bucket = "govuk-mirror-${var.aws_environment}-access-logs"
+  acl    = "log-delivery-write"
+}
+
+resource "aws_s3_bucket" "govuk_mirror" {
+  bucket = "govuk-mirror-${var.aws_environment}"
+
+  tags {
+    aws_environment = "${var.aws_environment}"
+    Name            = "govuk-mirror-${var.aws_environment}"
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    target_bucket = "${aws_s3_bucket.govuk_mirror_access_logs.id}"
+    target_prefix = "log/"
+  }
+}
+
+resource "aws_s3_bucket_policy" "govuk_mirror_read_policy" {
+  bucket = "${aws_s3_bucket.govuk_mirror.id}"
+  policy = "${data.aws_iam_policy_document.s3_mirror_read_policy_doc.json}"
+}

--- a/terraform/projects/infra-s3-mirrors/mirror-crawler-write-policy.tf
+++ b/terraform/projects/infra-s3-mirrors/mirror-crawler-write-policy.tf
@@ -1,0 +1,39 @@
+data "aws_iam_policy_document" "s3_mirror_crawler_writer_policy_doc" {
+  statement {
+    sid = "S3SyncReadLists"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    sid     = "S3SyncReadWriteBucket"
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "s3_mirror_writer_policy" {
+  name   = "s3_mirror_writer_policy_for_${aws_s3_bucket.govuk_mirror.id}"
+  policy = "${data.aws_iam_policy_document.s3_mirror_crawler_writer_policy_doc.json}"
+}
+
+resource "aws_iam_user" "s3_mirror_writer_user" {
+  name = "s3_mirror_writer"
+}
+
+resource "aws_iam_policy_attachment" "s3_mirror_writer_user_policy" {
+  name       = "s3_mirror_writer_user_policy_attachement"
+  users      = ["${aws_iam_user.s3_mirror_writer_user.name}"]
+  policy_arn = "${aws_iam_policy.s3_mirror_writer_policy.arn}"
+}

--- a/terraform/projects/infra-s3-mirrors/mirror-read-policy.tf
+++ b/terraform/projects/infra-s3-mirrors/mirror-read-policy.tf
@@ -1,0 +1,54 @@
+provider "fastly" {
+  # We only want to use fastly's data API
+  api_key = "test"
+}
+
+data "fastly_ip_ranges" "fastly" {}
+
+data "external" "pingdom" {
+  program = ["/bin/bash", "${path.module}/pingdom_probe_ips.sh"]
+}
+
+data "aws_iam_policy_document" "s3_mirror_read_policy_doc" {
+  statement {
+    sid     = "S3FastlyReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}/*",
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["${data.fastly_ip_ranges.fastly.cidr_blocks}"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+
+  statement {
+    sid     = "S3PingdomReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}/*",
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["${split(",",data.external.pingdom.result.pingdom_probe_ips)}"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}

--- a/terraform/projects/infra-s3-mirrors/pingdom_probe_ips.sh
+++ b/terraform/projects/infra-s3-mirrors/pingdom_probe_ips.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# This script pulls Pingdom probe IPs from the feed page and prints a sorted
+# list of CIDR blocks to the standard output in JSON format.
+#
+# Pingdom probe IPs information:
+# https://help.pingdom.com/hc/en-us/articles/203682601-Pingdom-probe-servers-IP-addresses
+#
+# The JSON output needs to meet Terraform external data sources requirements
+# and limitations (at the moment Terraform only supports string data types)
+# https://www.terraform.io/docs/providers/external/data_source.html
+# https://github.com/hashicorp/terraform/issues/12256
+
+curl -s https://my.pingdom.com/probes/feed | grep "pingdom:ip" | sed -e 's|</.*||' -e 's|.*>||' | sort -n -t . -k 1,1 -k 2,2 -k 3,3 -k 4,4 | grep -v ":" | awk '
+BEGIN { ORS = ""; print " { \"pingdom_probe_ips\": \""}
+{ if (NR == 1) { print $1"/32" } else { print ","$1"/32" } }
+END { print "\" }" }
+'
+

--- a/terraform/projects/infra-s3-mirrors/production.govuk.backend
+++ b/terraform/projects/infra-s3-mirrors/production.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "govuk/infra-s3-mirrors.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-s3-mirrors/staging.govuk.backend
+++ b/terraform/projects/infra-s3-mirrors/staging.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+key     = "govuk/infra-s3-mirrors.tfstate"
+encrypt = true
+region  = "eu-west-1"


### PR DESCRIPTION
# Context
Mirrors were created using the older terraform code base,
repo:`govuk-terraform-provisioning`. In order to modify the buckets we need to
have this under an active code base.

# Decision
- Write code to provision the infrastructure (this commit)
- Import the existing resources to the new state file, example for integration
  is written below.

To manually run terraform from `govuk-aws` root
`/tools/build-terraform-project.sh -c apply -p infra-s3-mirrors -d
../govuk-aws-data/data -e integration -s govuk`

```
terraform import aws_s3_bucket.govuk_mirror_access_logs
govuk-mirror-integration-access-logs

terraform import aws_s3_bucket.govuk_mirror govuk-mirror-integration

terraform import aws_iam_user.s3_mirror_writer_user s3_mirror_writer

terraform import aws_iam_policy.s3_mirror_writer_policy
s3_mirror_writer_policy_for_govuk-mirror-integration

terraform import aws_iam_policy.s3_mirror_writer_policy
arn:aws:iam::210287912431:policy/s3_mirror_writer_policy_for_govuk-mirror-integration
```

Co-authored-by: Conor Glynn <conor.glynn@digital.cabinet-office.gov.uk>