### PR TITLE
Set up a location for elasticsearch 5 backups in s3

### DIFF
--- a/terraform/projects/app-search/README.md
+++ b/terraform/projects/app-search/README.md
@@ -16,6 +16,7 @@ Search application servers
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_database_backups_bucket_key_stack | Override stackname path to infra_database_backups_bucket remote state | string | `` | no |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
 | remote_state_infra_root_dns_zones_key_stack | Override stackname path to infra_root_dns_zones remote state | string | `` | no |

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -54,6 +54,12 @@ variable "app_service_records" {
   default     = []
 }
 
+variable "remote_state_infra_database_backups_bucket_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_database_backups_bucket remote state"
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -159,6 +165,33 @@ module "alarms-elb-search-internal" {
   httpcode_elb_5xx_threshold     = "100"
   surgequeuelength_threshold     = "0"
   healthyhostcount_threshold     = "0"
+}
+
+data "terraform_remote_state" "infra_database_backups_bucket" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_database_backups_bucket_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "write_search_database_backups_iam_role_policy_attachment" {
+  role       = "${module.search.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.elasticsearch5_write_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "integration_read_search_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "integration" ? 1 : 0}"
+  role       = "${module.search.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.integration_elasticsearch5_read_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "staging_read_search_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "staging" ? 1 : 0}"
+  role       = "${module.search.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.staging_elasticsearch5_read_database_backups_bucket_policy_arn}"
 }
 
 # Outputs

--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -23,10 +23,12 @@ database-backups: The bucket that will hold database backups
 | Name | Description |
 |------|-------------|
 | dbadmin_write_database_backups_bucket_policy_arn | ARN of the DBAdmin write database_backups-bucket policy |
+| elasticsearch5_write_database_backups_bucket_policy_arn | ARN of the elasticsearch5 write database_backups-bucket policy |
 | elasticsearch_write_database_backups_bucket_policy_arn | ARN of the elasticsearch write database_backups-bucket policy |
 | email-alert-api_dbadmin_write_database_backups_bucket_policy_arn | ARN of the EmailAlertAPIDBAdmin write database_backups-bucket policy |
 | graphite_write_database_backups_bucket_policy_arn | ARN of the Graphite write database_backups-bucket policy |
 | integration_dbadmin_read_database_backups_bucket_policy_arn | ARN of the integration read DBAdmin database_backups-bucket policy |
+| integration_elasticsearch5_read_database_backups_bucket_policy_arn | ARN of the integration read elasticsearch5 database_backups-bucket policy |
 | integration_elasticsearch_read_database_backups_bucket_policy_arn | ARN of the integration read elasticsearch database_backups-bucket policy |
 | integration_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the integration read EmailAlertAPUDBAdmin database_backups-bucket policy |
 | integration_graphite_read_database_backups_bucket_policy_arn | ARN of the integration read Graphite database_backups-bucket policy |
@@ -40,6 +42,7 @@ database-backups: The bucket that will hold database backups
 | mongo_router_write_database_backups_bucket_policy_arn | ARN of the router_backend write database_backups-bucket policy |
 | mongodb_write_database_backups_bucket_policy_arn | ARN of the mongodb write database_backups-bucket policy |
 | production_dbadmin_read_database_backups_bucket_policy_arn | ARN of the production read DBAdmin database_backups-bucket policy |
+| production_elasticsearch5_read_database_backups_bucket_policy_arn | ARN of the production read elasticsearch5 database_backups-bucket policy |
 | production_elasticsearch_read_database_backups_bucket_policy_arn | ARN of the production read elasticsearch database_backups-bucket policy |
 | production_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the production read EmailAlertAPUDBAdmin database_backups-bucket policy |
 | production_graphite_read_database_backups_bucket_policy_arn | ARN of the production read Graphite database_backups-bucket policy |
@@ -51,6 +54,7 @@ database-backups: The bucket that will hold database backups
 | production_warehouse_dbadmin_read_database_backups_bucket_policy_arn | ARN of the production read WarehouseDBAdmin database_backups-bucket policy |
 | publishing-api_dbadmin_write_database_backups_bucket_policy_arn | ARN of the publishing-apiDBAdmin write database_backups-bucket policy |
 | staging_dbadmin_read_database_backups_bucket_policy_arn | ARN of the staging read DBAdmin database_backups-bucket policy |
+| staging_elasticsearch5_read_database_backups_bucket_policy_arn | ARN of the staging read elasticsearch5 database_backups-bucket policy |
 | staging_elasticsearch_read_database_backups_bucket_policy_arn | ARN of the staging read elasticsearch database_backups-bucket policy |
 | staging_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the staging read EmailAlertAPUDBAdmin database_backups-bucket policy |
 | staging_graphite_read_database_backups_bucket_policy_arn | ARN of the staging read Graphite database_backups-bucket policy |

--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -154,6 +154,15 @@ resource "aws_s3_bucket" "database_backups" {
   }
 
   lifecycle_rule {
+    prefix  = "elasticsearch5/"
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+  }
+
+  lifecycle_rule {
     prefix  = "whisper/"
     enabled = true
 

--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -110,6 +110,31 @@ data "aws_iam_policy_document" "integration_elasticsearch_database_backups_reade
   }
 }
 
+resource "aws_iam_policy" "integration_elasticsearch5_database_backups_reader" {
+  name        = "govuk-integration-elasticsearch5_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.integration_elasticsearch5_database_backups_reader.json}"
+  description = "Allows reading the elasticsearch5 database_backups bucket"
+}
+
+data "aws_iam_policy_document" "integration_elasticsearch5_database_backups_reader" {
+  statement {
+    sid = "Elasticsearch5ReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-integration-database-backups",
+      "arn:aws:s3:::govuk-integration-database-backups/*elasticsearch5*",
+      "arn:aws:s3:::govuk-staging-database-backups",
+      "arn:aws:s3:::govuk-staging-database-backups/*elasticsearch5*",
+    ]
+  }
+}
+
 resource "aws_iam_policy" "integration_dbadmin_database_backups_reader" {
   name        = "govuk-integration-dbadmin_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.integration_dbadmin_database_backups_reader.json}"
@@ -351,6 +376,29 @@ data "aws_iam_policy_document" "staging_elasticsearch_database_backups_reader" {
   }
 }
 
+resource "aws_iam_policy" "staging_elasticsearch5_database_backups_reader" {
+  name        = "govuk-staging-elasticsearch5_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.staging_elasticsearch5_database_backups_reader.json}"
+  description = "Allows reading the elasticsearch5 database_backups bucket"
+}
+
+data "aws_iam_policy_document" "staging_elasticsearch5_database_backups_reader" {
+  statement {
+    sid = "Elasticsearch5ReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-staging-database-backups",
+      "arn:aws:s3:::govuk-staging-database-backups/*elasticsearch5*",
+    ]
+  }
+}
+
 resource "aws_iam_policy" "staging_dbadmin_database_backups_reader" {
   name        = "govuk-staging-dbadmin_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.staging_dbadmin_database_backups_reader.json}"
@@ -583,6 +631,29 @@ data "aws_iam_policy_document" "production_elasticsearch_database_backups_reader
   }
 }
 
+resource "aws_iam_policy" "production_elasticsearch5_database_backups_reader" {
+  name        = "govuk-production-elasticsearch5_database_backups-reader-policy"
+  policy      = "${data.aws_iam_policy_document.production_elasticsearch5_database_backups_reader.json}"
+  description = "Allows reading the elasticsearch5 database_backups bucket"
+}
+
+data "aws_iam_policy_document" "production_elasticsearch5_database_backups_reader" {
+  statement {
+    sid = "Elasticsearch5ReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-production-database-backups",
+      "arn:aws:s3:::govuk-production-database-backups/*elasticsearch5*",
+    ]
+  }
+}
+
 resource "aws_iam_policy" "production_dbadmin_database_backups_reader" {
   name        = "govuk-production-dbadmin_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.production_dbadmin_database_backups_reader.json}"
@@ -742,6 +813,11 @@ output "integration_elasticsearch_read_database_backups_bucket_policy_arn" {
   description = "ARN of the integration read elasticsearch database_backups-bucket policy"
 }
 
+output "integration_elasticsearch5_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.integration_elasticsearch5_database_backups_reader.arn}"
+  description = "ARN of the integration read elasticsearch5 database_backups-bucket policy"
+}
+
 output "integration_dbadmin_read_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.integration_dbadmin_database_backups_reader.arn}"
   description = "ARN of the integration read DBAdmin database_backups-bucket policy"
@@ -792,6 +868,11 @@ output "staging_elasticsearch_read_database_backups_bucket_policy_arn" {
   description = "ARN of the staging read elasticsearch database_backups-bucket policy"
 }
 
+output "staging_elasticsearch5_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.staging_elasticsearch5_database_backups_reader.arn}"
+  description = "ARN of the staging read elasticsearch5 database_backups-bucket policy"
+}
+
 output "staging_dbadmin_read_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.staging_dbadmin_database_backups_reader.arn}"
   description = "ARN of the staging read DBAdmin database_backups-bucket policy"
@@ -840,6 +921,11 @@ output "production_mongodb_read_database_backups_bucket_policy_arn" {
 output "production_elasticsearch_read_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.production_elasticsearch_database_backups_reader.arn}"
   description = "ARN of the production read elasticsearch database_backups-bucket policy"
+}
+
+output "production_elasticsearch5_read_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.production_elasticsearch5_database_backups_reader.arn}"
+  description = "ARN of the production read elasticsearch5 database_backups-bucket policy"
 }
 
 output "production_dbadmin_read_database_backups_bucket_policy_arn" {

--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -233,6 +233,62 @@ data "aws_iam_policy_document" "elasticsearch_database_backups_writer" {
   }
 }
 
+resource "aws_iam_policy" "elasticsearch5_database_backups_writer" {
+  name        = "govuk-${var.aws_environment}-elasticsearch5_database_backups-writer-policy"
+  policy      = "${data.aws_iam_policy_document.elasticsearch5_database_backups_writer.json}"
+  description = "Allows writing of the elasticsearch5 database_backups bucket"
+}
+
+data "aws_iam_policy_document" "elasticsearch5_database_backups_writer" {
+  statement {
+    sid = "ReadListOfBuckets"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "Elasticsearch5ReadBucketLists"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+
+    # The top level access is required.
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
+    ]
+
+    # We can now apply restictions on what can be accessed.
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "search",
+      ]
+    }
+  }
+
+  statement {
+    sid = "Elasticsearch5WriteGovukDatabaseBackups"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*elasticsearch5*",
+    ]
+  }
+}
+
 resource "aws_iam_policy" "dbadmin_database_backups_writer" {
   name        = "govuk-${var.aws_environment}-dbadmin_database_backups-writer-policy"
   policy      = "${data.aws_iam_policy_document.dbadmin_database_backups_writer.json}"
@@ -596,6 +652,11 @@ output "mongodb_write_database_backups_bucket_policy_arn" {
 output "elasticsearch_write_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.elasticsearch_database_backups_writer.arn}"
   description = "ARN of the elasticsearch write database_backups-bucket policy"
+}
+
+output "elasticsearch5_write_database_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.elasticsearch5_database_backups_writer.arn}"
+  description = "ARN of the elasticsearch5 write database_backups-bucket policy"
 }
 
 output "dbadmin_write_database_backups_bucket_policy_arn" {


### PR DESCRIPTION
This will be used by the env sync script in puppet.

---

[Trello card](https://trello.com/c/QQHOpt56/75-update-data-sync-for-elasticsearch-5)