### PR TITLE
Set up a bucket and policy for manual elasticsearch snapshots

### DIFF
--- a/terraform/projects/app-elasticsearch5/README.md
+++ b/terraform/projects/app-elasticsearch5/README.md
@@ -2,6 +2,25 @@
 
 Managed Elasticsearch 5 cluster
 
+This project has two gotchas, where we work around things terraform
+doesn't support:
+
+- Deploying the cluster across 3 availability zones: terraform has
+  some built-in validation which rejects using 3 master nodes and 3
+  data nodes across 3 availability zones.  To provision a new
+  cluster, only use two of everything, then bump the numbers in the
+  AWS console and in the terraform variables - it won't complain
+  when you next plan.
+
+  https://github.com/terraform-providers/terraform-provider-aws/issues/7504
+
+- Configuring a snapshot repository: terraform doesn't support this,
+  and as far as I can tell doesn't have any plans to.  There's a
+  Python script in the AWS documentation which sets things up.
+
+  https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-snapshots.html
+
+
 
 ## Inputs
 

--- a/terraform/projects/app-elasticsearch5/README.md
+++ b/terraform/projects/app-elasticsearch5/README.md
@@ -33,6 +33,7 @@ Managed Elasticsearch 5 cluster
 
 | Name | Description |
 |------|-------------|
+| domain_configuration_policy_arn | ARN of the policy used to configure the elasticsearch domain |
 | service_dns_name | DNS name to access the Elasticsearch internal service |
 | service_endpoint | Endpoint to submit index, search, and upload requests |
 | service_role_id | Unique identifier for the service-linked role |

--- a/terraform/projects/app-elasticsearch5/main.tf
+++ b/terraform/projects/app-elasticsearch5/main.tf
@@ -2,6 +2,25 @@
 * ## Project: app-elasticsearch5
 *
 * Managed Elasticsearch 5 cluster
+*
+* This project has two gotchas, where we work around things terraform
+* doesn't support:
+*
+* - Deploying the cluster across 3 availability zones: terraform has
+*   some built-in validation which rejects using 3 master nodes and 3
+*   data nodes across 3 availability zones.  To provision a new
+*   cluster, only use two of everything, then bump the numbers in the
+*   AWS console and in the terraform variables - it won't complain
+*   when you next plan.
+*
+*   https://github.com/terraform-providers/terraform-provider-aws/issues/7504
+*
+* - Configuring a snapshot repository: terraform doesn't support this,
+*   and as far as I can tell doesn't have any plans to.  There's a
+*   Python script in the AWS documentation which sets things up.
+*
+*   https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-snapshots.html
+*
 */
 variable "aws_environment" {
   type        = "string"


### PR DESCRIPTION
We're going to use snapshots for the data sync, as the current
dump/export script we use doesn't support elasticsearch 5, and it's
always better to use built-in functionality if you can.

The cluster is configured to take an automatic snapshot every day, but
these snapshots are stored in a bucket we don't have access to.  So we
need to take manual snapshots, which are written to a custom location.

*However*, terraform doesn't support configuring manual snapshots.
This has to be done by hand.  This is what the
`manual_snapshot_domain_configuration_policy` is for: it will be added
to the list of policies administrators and powerusers have, and
someone will be able to configure the elasticsearch cluster using that
policy.

The details of this all are in the AWS documentation:
https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-snapshots.html

---

[Trello card](https://trello.com/c/QQHOpt56/75-update-data-sync-for-elasticsearch-5)