### PR TITLE
Add CORS config for s3 mirrors

### DIFF
--- a/terraform/projects/infra-s3-mirrors/main.tf
+++ b/terraform/projects/infra-s3-mirrors/main.tf
@@ -51,6 +51,11 @@ resource "aws_s3_bucket" "govuk_mirror_access_logs" {
 resource "aws_s3_bucket" "govuk_mirror" {
   bucket = "govuk-mirror-${var.aws_environment}"
 
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_origins = ["https://assets.staging.publishing.service.gov.uk", "https://assets.publishing.service.gov.uk"]
+  }
+
   tags {
     aws_environment = "${var.aws_environment}"
     Name            = "govuk-mirror-${var.aws_environment}"


### PR DESCRIPTION
Context
We are seeing CORS errors when the s3 mirrors are in use, i.e. when fastly
health checks fail and traffic is redirected to the s3 bucket we see
Cross-Origin Resource Sharing errors in the browser.

Decision
Add the allowed origins to the s3 bucket config.