### PR TITLE
Fix the jenkins.sh script for a persistent workspace

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -38,6 +38,8 @@ if [[ $TERRAFORM_VERSION != '' ]]; then
   echo "Terraform binary: $(which terraform)"
 fi
 
+rm -rf govuk-aws-data
+
 echo "Cloning govuk-aws-data"
 git clone git@github.com:alphagov/govuk-aws-data.git
 


### PR DESCRIPTION
Now that the Jenkins job definition has been changed in govuk-puppet
to not wipe the workspace, this directory needs deleting so that it
can be cloned.

It's probably possible to do this more efficiently, but this is a
simple way of making it work again.