### PR TITLE
Allow Gatling to access port 443 on cache machines

### DIFF
--- a/terraform/projects/infra-security-groups/cache.tf
+++ b/terraform/projects/infra-security-groups/cache.tf
@@ -133,6 +133,16 @@ resource "aws_security_group_rule" "cache-external-elb_ingress_public_https" {
   ]
 }
 
+# allow gatling to load test www-origin
+resource "aws_security_group_rule" "cache-external-elb_ingress_gatling_https" {
+  type                     = "ingress"
+  to_port                  = 443
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.cache_external_elb.id}"
+  source_security_group_id = "${aws_security_group.gatling.id}"
+}
+
 resource "aws_security_group_rule" "cache-external-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0


### PR DESCRIPTION
This makes it easier to set up load testing as we don't need to manually configure the IP addresses that Gatling uses (which can change frequently).