### PR TITLE
Revert "allow carrenza dashboard to access the graphite service in AWS"

### DIFF
--- a/terraform/projects/infra-security-groups/graphite.tf
+++ b/terraform/projects/infra-security-groups/graphite.tf
@@ -108,16 +108,6 @@ resource "aws_security_group_rule" "graphite-external-elb_ingress_office_https" 
   cidr_blocks       = ["${var.office_ips}"]
 }
 
-resource "aws_security_group_rule" "graphite-external-elb_ingress_carrenza_https" {
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  security_group_id = "${aws_security_group.graphite_external_elb.id}"
-  cidr_blocks       = ["${var.carrenza_env_ips}"]
-}
-
 # TODO: Audit
 resource "aws_security_group_rule" "graphite-external-elb_ingress_management_https" {
   type      = "ingress"


### PR DESCRIPTION
Reverts alphagov/govuk-aws#837 because second line will use the Grafana in AWS now rather than the Carrenza one.