### PR TITLE
Add Carrenza facing ALB for calendars app

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -30,6 +30,7 @@ This project adds global resources for app components:
 | cache_public_service_names |  | list | `<list>` | no |
 | calculators_frontend_internal_service_cnames |  | list | `<list>` | no |
 | calculators_frontend_internal_service_names |  | list | `<list>` | no |
+| calendars_public_service_names |  | list | `<list>` | no |
 | ckan_internal_service_cnames |  | list | `<list>` | no |
 | ckan_internal_service_names |  | list | `<list>` | no |
 | ckan_public_service_cnames |  | list | `<list>` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -72,6 +72,11 @@ variable "cache_public_service_cnames" {
   default = []
 }
 
+variable "calendars_public_service_names" {
+  type    = "list"
+  default = []
+}
+
 variable "ckan_public_service_names" {
   type    = "list"
   default = []
@@ -729,6 +734,62 @@ resource "aws_route53_record" "cache_internal_service_cnames" {
   type    = "CNAME"
   records = ["${element(var.cache_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
   ttl     = "300"
+}
+
+#
+# Calendars
+#
+
+module "calendars_public_lb" {
+  source                                     = "../../modules/aws/lb"
+  name                                       = "${var.stackname}-calendars-public"
+  internal                                   = false
+  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix                  = "elb/${var.stackname}-calendars-public-elb"
+  listener_certificate_domain_name           = "${var.elb_public_certname}"
+  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
+
+  listener_action = {
+    "HTTPS:443" = "HTTP:80"
+  }
+
+  target_group_health_check_path = "/_healthcheck"
+  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_calendars_external_elb_id}"]
+  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  default_tags                   = "${map("Project", var.stackname, "aws_migration", "calendars", "aws_environment", var.aws_environment)}"
+}
+
+resource "aws_route53_record" "calendars_public_service_names" {
+  count   = "${length(var.calendars_public_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.calendars_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${module.calendars_public_lb.lb_dns_name}"
+    zone_id                = "${module.calendars_public_lb.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+data "aws_autoscaling_groups" "calendars" {
+  filter {
+    name   = "key"
+    values = ["Name"]
+  }
+
+  filter {
+    name   = "value"
+    values = ["blue-calendars"]
+  }
+}
+
+resource "aws_autoscaling_attachment" "calendars_asg_attachment_alb" {
+  count                  = "${length(data.aws_autoscaling_groups.calendars.names) > 0 ? 1 : 0}"
+  autoscaling_group_name = "${element(data.aws_autoscaling_groups.calendars.names, 0)}"
+  alb_target_group_arn   = "${element(module.calendars_public_lb.target_group_arns, 0)}"
 }
 
 # Calculators-frontend

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -43,6 +43,7 @@ Manage the security groups for the entire infrastructure
 | sg_cache_id |  |
 | sg_calculators-frontend_elb_id |  |
 | sg_calculators-frontend_id |  |
+| sg_calendars_carrenza_alb_id |  |
 | sg_ckan_elb_external_id |  |
 | sg_ckan_elb_internal_id |  |
 | sg_ckan_id |  |

--- a/terraform/projects/infra-security-groups/calculators-frontend.tf
+++ b/terraform/projects/infra-security-groups/calculators-frontend.tf
@@ -63,3 +63,47 @@ resource "aws_security_group_rule" "calculators-frontends-elb_egress_any_any" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.calculators-frontend_elb.id}"
 }
+
+resource "aws_security_group_rule" "calendars_ingress_calendars-carrenza-alb_http" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.calendars.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.calendars_carrenza_alb.id}"
+}
+
+# Security resources for ALB set up for Carrenza access to AWS calendars
+
+resource "aws_security_group" "calendars_carrenza_alb" {
+  name        = "${var.stackname}_calendars_carrenza_alb"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access the calendars Carrenza ALB "
+
+  tags {
+    Name = "${var.stackname}_calendars_carrenza_alb_access"
+  }
+}
+
+resource "aws_security_group_rule" "calendars-carrenza-alb_ingress_443_carrenza" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  cidr_blocks       = ["${var.carrenza_env_ips}"]
+  security_group_id = "${aws_security_group.calendars_carrenza_alb.id}"
+}
+
+resource "aws_security_group_rule" "calendars-carrenza-alb_egress_any_any" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.calendars_carrenza_alb.id}"
+}

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -66,6 +66,10 @@ output "sg_cache_id" {
   value = "${aws_security_group.cache.id}"
 }
 
+output "sg_calendars_carrenza_alb_id" {
+  value = "${aws_security_group.calendars_carrenza_alb.id}"
+}
+
 output "sg_calculators-frontend_elb_id" {
   value = "${aws_security_group.calculators-frontend_elb.id}"
 }


### PR DESCRIPTION
- For some reason the publisher requires to talk to the calendars
frontend app
- This load balancer will be locked down to the Carrenza CIDR and allow
publisher to access the app over the internet
- We have used this approach in the past for mapit and content-store

Requires: https://github.com/alphagov/govuk-aws-data/pull/347

solo: @schmie