### PR TITLE
More oversight in copy-paste

### DIFF
--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -782,7 +782,7 @@ data "aws_autoscaling_groups" "calendars" {
 
   filter {
     name   = "value"
-    values = ["blue-calendars"]
+    values = ["blue-calculators-frontend"]
   }
 }
 

--- a/terraform/projects/infra-security-groups/calculators-frontend.tf
+++ b/terraform/projects/infra-security-groups/calculators-frontend.tf
@@ -21,6 +21,16 @@ resource "aws_security_group" "calculators-frontend" {
   }
 }
 
+resource "aws_security_group" "calendars" {
+  name        = "${var.stackname}_calendars_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access to the calendars host from its ELB"
+
+  tags {
+    Name = "${var.stackname}_calendars_access"
+  }
+}
+
 resource "aws_security_group_rule" "calculators-frontend_ingress_calculators-frontend-elb_http" {
   type      = "ingress"
   from_port = 80


### PR DESCRIPTION
- A security group for calendars has to be explicitly in place
- The autoscaling group target for the calendars has to be calculators
frontend
- I got both the wrong way around

solo: @schmie