### PR TITLE
Parameterise elasticsearch by what manual snapshot buckets exist

### DIFF
--- a/terraform/projects/app-elasticsearch5/README.md
+++ b/terraform/projects/app-elasticsearch5/README.md
@@ -35,6 +35,7 @@ doesn't support:
 | elasticsearch5_ebs_type | The type of EBS storage to attach | string | `gp2` | no |
 | elasticsearch5_instance_count | The number of ElasticSearch nodes | string | `3` | no |
 | elasticsearch5_instance_type | The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported | string | `r4.large.elasticsearch` | no |
+| elasticsearch5_manual_snapshot_bucket_arns | Bucket ARNs this domain can read/write for manual snapshots | list | `<list>` | no |
 | elasticsearch5_master_instance_count | Number of dedicated master nodes in the cluster | string | `3` | no |
 | elasticsearch5_master_instance_type | Instance type of the dedicated master nodes in the cluster | string | `c4.large.elasticsearch` | no |
 | elasticsearch5_snapshot_start_hour | The hour in which the daily snapshot is taken | string | `1` | no |

--- a/terraform/projects/app-elasticsearch5/main.tf
+++ b/terraform/projects/app-elasticsearch5/main.tf
@@ -102,6 +102,12 @@ variable "cloudwatch_log_retention" {
   default     = 90
 }
 
+variable "elasticsearch5_manual_snapshot_bucket_arns" {
+  type        = "list"
+  description = "Bucket ARNs this domain can read/write for manual snapshots"
+  default     = []
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -325,7 +331,8 @@ POLICY
 }
 
 resource "aws_iam_policy" "manual_snapshot_bucket_policy" {
-  name = "govuk-${var.aws_environment}-elasticsearch5-manual-snapshot-bucket-policy"
+  count = "${length(var.elasticsearch5_manual_snapshot_bucket_arns)}"
+  name  = "govuk-${var.aws_environment}-elasticsearch5-manual-snapshot-bucket-policy-${count.index}"
 
   policy = <<POLICY
 {
@@ -336,7 +343,7 @@ resource "aws_iam_policy" "manual_snapshot_bucket_policy" {
       ],
       "Effect": "Allow",
       "Resource": [
-        "${aws_s3_bucket.manual_snapshots.arn}"
+        "${element(var.elasticsearch5_manual_snapshot_bucket_arns, count.index)}"
       ]
     },
     {
@@ -347,7 +354,7 @@ resource "aws_iam_policy" "manual_snapshot_bucket_policy" {
       ],
       "Effect": "Allow",
       "Resource": [
-        "${aws_s3_bucket.manual_snapshots.arn}/*"
+        "${element(var.elasticsearch5_manual_snapshot_bucket_arns, count.index)}/*"
       ]
     }
   ]


### PR DESCRIPTION
Elasticsearch needs to have access to buckets across environments:

- read from the environment above (eg, pulling production data to
  staging)
- write to the current environment (eg, backing up staging)

We decided to store the bucket ARNs in govuk-aws-data to simplify
this.  There's no risk in doing this, because we only use these
buckets for the data sync.  Giving (eg) staging write access to
production doesn't let ot touch production's atcual backups, only the
ones used for the data sync.

There will be a follow-up change to govuk-aws-data.

---

[Trello card](https://trello.com/c/QQHOpt56/75-update-data-sync-for-elasticsearch-5)