### PR TITLE
Adding require sg for calendar alb

### DIFF
--- a/terraform/projects/infra-security-groups/calculators-frontend.tf
+++ b/terraform/projects/infra-security-groups/calculators-frontend.tf
@@ -44,6 +44,19 @@ resource "aws_security_group_rule" "calculators-frontend_ingress_calculators-fro
   source_security_group_id = "${aws_security_group.calculators-frontend_elb.id}"
 }
 
+resource "aws_security_group_rule" "calculators-frontend_ingress_calendars-carrenza-alb_http" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.calculators-frontend.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.calendars_carrenza_alb.id}"
+}
+
 resource "aws_security_group" "calculators-frontend_elb" {
   name        = "${var.stackname}_calculators-frontend_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"


### PR DESCRIPTION
We need this security group rule to allow access through to the
calculators-frontend host from the calendar alb.

Co-authored-by: Sebastian Schmieschek <sebastian.schmieschek@digital.cabinet-office.gov.uk>