### PR TITLE
Fix the Content Data API DB Admin reader to allow ListObjects

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -615,11 +615,22 @@ resource "aws_iam_policy" "production_content_data_api_dbadmin_database_backups_
 
 data "aws_iam_policy_document" "production_content_data_api_dbadmin_database_backups_reader" {
   statement {
-    sid = "ContentDataAPIDBAdminReadBucket"
+    sid = "ContentDataAPIDBAdminListBucket"
 
     actions = [
-      "s3:Get*",
-      "s3:List*",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::govuk-production-database-backups",
+    ]
+  }
+
+  statement {
+    sid = "ContentDataAPIDBAdminGetObject"
+
+    actions = [
+      "s3:GetObject",
     ]
 
     resources = [


### PR DESCRIPTION
Through the ListBucket permission. Previously "s3:List*" was being
specified as an action, but this seems not to apply to resources that
specify files within a bucket, it must apply to the whole bucket.

This kinda makes sense, I was getting confused by the combination of
the resources and actions in the other policies.

This commit splits the actions across two statements, the first
statement applying to the bucket itself, and removes the wildcards
from the actions being specific about what's actually intended.