### PR TITLE
Add Jenkins production SSH key

### DIFF
--- a/terraform/projects/infra-govuk-repo-mirror/README.md
+++ b/terraform/projects/infra-govuk-repo-mirror/README.md
@@ -12,7 +12,8 @@ Deploy_App job and the role is used by the Concourse mirroring job)
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | concourse_role_arn | The role ARN of the role that Concourse uses to assume the govuk_concourse_codecommit_role role | string | - | yes |
-| jenkins_ssh_public_key | The SSH public key of the Jenkins instance for the relevant environment | string | - | yes |
+| jenkins_carrenza_production_ssh_public_key | The SSH public key of the Jenkins instance in the Carrenza production environment | string | - | yes |
+| jenkins_carrenza_staging_ssh_public_key | The SSH public key of the Jenkins instance in the Carrenza staging environment | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/infra-govuk-repo-mirror/main.tf
+++ b/terraform/projects/infra-govuk-repo-mirror/main.tf
@@ -21,9 +21,14 @@ variable "stackname" {
   description = "Stackname"
 }
 
-variable "jenkins_ssh_public_key" {
+variable "jenkins_carrenza_staging_ssh_public_key" {
   type        = "string"
-  description = "The SSH public key of the Jenkins instance for the relevant environment"
+  description = "The SSH public key of the Jenkins instance in the Carrenza staging environment"
+}
+
+variable "jenkins_carrenza_production_ssh_public_key" {
+  type        = "string"
+  description = "The SSH public key of the Jenkins instance in the Carrenza production environment"
 }
 
 variable "concourse_role_arn" {
@@ -50,10 +55,16 @@ resource "aws_iam_user_policy_attachment" "govuk_codecommit_user_policy_attachme
   policy_arn = "arn:aws:iam::aws:policy/AWSCodeCommitPowerUser"
 }
 
-resource "aws_iam_user_ssh_key" "govuk_codecommit_user_jenkins_ssh_key" {
+resource "aws_iam_user_ssh_key" "govuk_codecommit_user_jenkins_staging_ssh_key" {
   username   = "${aws_iam_user.govuk_codecommit_user.name}"
   encoding   = "SSH"
-  public_key = "${var.jenkins_ssh_public_key}"
+  public_key = "${var.jenkins_carrenza_staging_ssh_public_key}"
+}
+
+resource "aws_iam_user_ssh_key" "govuk_codecommit_user_jenkins_production_ssh_key" {
+  username   = "${aws_iam_user.govuk_codecommit_user.name}"
+  encoding   = "SSH"
+  public_key = "${var.jenkins_carrenza_production_ssh_public_key}"
 }
 
 resource "aws_iam_user" "govuk_concourse_codecommit_user" {
@@ -65,10 +76,16 @@ resource "aws_iam_user_policy_attachment" "govuk_concourse_codecommit_user_polic
   policy_arn = "arn:aws:iam::aws:policy/AWSCodeCommitPowerUser"
 }
 
-resource "aws_iam_user_ssh_key" "govuk_concourse_codecommit_user_ssh_key" {
+resource "aws_iam_user_ssh_key" "govuk_concourse_codecommit_staging_user_ssh_key" {
   username   = "${aws_iam_user.govuk_concourse_codecommit_user.name}"
   encoding   = "SSH"
-  public_key = "${var.jenkins_ssh_public_key}"
+  public_key = "${var.jenkins_carrenza_staging_ssh_public_key}"
+}
+
+resource "aws_iam_user_ssh_key" "govuk_concourse_codecommit_production_user_ssh_key" {
+  username   = "${aws_iam_user.govuk_concourse_codecommit_user.name}"
+  encoding   = "SSH"
+  public_key = "${var.jenkins_carrenza_production_ssh_public_key}"
 }
 
 resource "aws_iam_role" "govuk_concourse_codecommit_role" {


### PR DESCRIPTION
This commit adds the SSH key for Jenkins production to be used for repo mirroring and deploying from CodeCommit.