### PR TITLE
Fix resources list for ES5 manual snapshots S3 bucket policy

### DIFF
--- a/terraform/projects/app-elasticsearch5/main.tf
+++ b/terraform/projects/app-elasticsearch5/main.tf
@@ -342,8 +342,8 @@ data "aws_iam_policy_document" "manual_snapshots_cross_account_access" {
     ]
 
     resources = [
-      "${aws_s3_bucket.manual_snapshots.id}",
-      "${aws_s3_bucket.manual_snapshots.id}/*",
+      "arn:aws:s3:::${aws_s3_bucket.manual_snapshots.id}",
+      "arn:aws:s3:::${aws_s3_bucket.manual_snapshots.id}/*",
     ]
   }
 }


### PR DESCRIPTION
The ARN was not being specified in full, so creating the policy failed

Trello card: https://trello.com/c/QQHOpt56/75-update-data-sync-for-elasticsearch-5