### PR TITLE
Add Carrenza facing ALB for the static app

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -93,6 +93,7 @@ This project adds global resources for app components:
 | search_internal_service_cnames |  | list | `<list>` | no |
 | search_internal_service_names |  | list | `<list>` | no |
 | stackname | Stackname | string | - | yes |
+| static_public_service_names |  | list | `<list>` | no |
 | support_api_public_service_names |  | list | `<list>` | no |
 | transition_db_admin_internal_service_names |  | list | `<list>` | no |
 | transition_postgresql_internal_service_names |  | list | `<list>` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -157,6 +157,11 @@ variable "monitoring_public_service_names" {
   default = []
 }
 
+variable "static_public_service_names" {
+  type    = "list"
+  default = []
+}
+
 variable "support_api_public_service_names" {
   type    = "list"
   default = []
@@ -1939,6 +1944,62 @@ resource "aws_autoscaling_attachment" "search_api_backend_asg_attachment_alb" {
   count                  = "${length(data.aws_autoscaling_groups.search.names) > 0 ? 1 : 0}"
   autoscaling_group_name = "${element(data.aws_autoscaling_groups.search.names, 0)}"
   alb_target_group_arn   = "${element(module.search_api_public_lb.target_group_arns, 0)}"
+}
+
+#
+# Static
+#
+
+module "static_public_lb" {
+  source                                     = "../../modules/aws/lb"
+  name                                       = "${var.stackname}-static-public"
+  internal                                   = false
+  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix                  = "elb/${var.stackname}-static-public-elb"
+  listener_certificate_domain_name           = "${var.elb_public_certname}"
+  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
+
+  listener_action = {
+    "HTTPS:443" = "HTTP:80"
+  }
+
+  target_group_health_check_path = "/_healthcheck"
+  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_static_carrenza_alb_id}"]
+  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  default_tags                   = "${map("Project", var.stackname, "aws_migration", "static", "aws_environment", var.aws_environment)}"
+}
+
+resource "aws_route53_record" "static_public_service_names" {
+  count   = "${length(var.static_public_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.static_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${module.static_public_lb.lb_dns_name}"
+    zone_id                = "${module.static_public_lb.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+data "aws_autoscaling_groups" "static" {
+  filter {
+    name   = "key"
+    values = ["Name"]
+  }
+
+  filter {
+    name   = "value"
+    values = ["blue-frontend"]
+  }
+}
+
+resource "aws_autoscaling_attachment" "static_asg_attachment_alb" {
+  count                  = "${length(data.aws_autoscaling_groups.static.names) > 0 ? 1 : 0}"
+  autoscaling_group_name = "${element(data.aws_autoscaling_groups.static.names, 0)}"
+  alb_target_group_arn   = "${element(module.static_public_lb.target_group_arns, 0)}"
 }
 
 # support-api

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -117,6 +117,7 @@ Manage the security groups for the entire infrastructure
 | sg_search-api_external_elb_id |  |
 | sg_search_elb_id |  |
 | sg_search_id |  |
+| sg_static_carrenza_alb_id |  |
 | sg_support-api_external_elb_id |  |
 | sg_transition-db-admin_elb_id |  |
 | sg_transition-db-admin_id |  |

--- a/terraform/projects/infra-security-groups/frontend.tf
+++ b/terraform/projects/infra-security-groups/frontend.tf
@@ -63,3 +63,70 @@ resource "aws_security_group_rule" "frontend-elb_egress_any_any" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.frontend_elb.id}"
 }
+
+resource "aws_security_group" "static" {
+  name        = "${var.stackname}_static_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access to static host from its ELB"
+
+  tags {
+    Name = "${var.stackname}_static_access"
+  }
+}
+
+resource "aws_security_group_rule" "frontend_ingress_static-carrenza-alb_http" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.frontend.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.static_carrenza_alb.id}"
+}
+
+resource "aws_security_group_rule" "static_ingress_static-carrenza-alb_http" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.static.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.static_carrenza_alb.id}"
+}
+
+# Security resources for ALB set up for Carrenza access to AWS calendars
+
+resource "aws_security_group" "static_carrenza_alb" {
+  name        = "${var.stackname}_static_carrenza_alb"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access static Carrenza ALB "
+
+  tags {
+    Name = "${var.stackname}_static_carrenza_alb_access"
+  }
+}
+
+resource "aws_security_group_rule" "static-carrenza-alb_ingress_443_carrenza" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  cidr_blocks       = ["${var.carrenza_env_ips}"]
+  security_group_id = "${aws_security_group.static_carrenza_alb.id}"
+}
+
+resource "aws_security_group_rule" "static-carrenza-alb_egress_any_any" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.static_carrenza_alb.id}"
+}

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -342,6 +342,10 @@ output "sg_search_id" {
   value = "${aws_security_group.search.id}"
 }
 
+output "sg_static_carrenza_alb_id" {
+  value = "${aws_security_group.static_carrenza_alb.id}"
+}
+
 output "sg_transition-db-admin_elb_id" {
   value = "${aws_security_group.transition-db-admin_elb.id}"
 }


### PR DESCRIPTION
  Following the migration of static on AWS:
Whitehall in carrenza need a way to talk to static on AWS
This new ALB needs to be locked down to the carrenza CIDR