### PR TITLE
Fix json in IAM policy for Content Data

### DIFF
--- a/terraform/policies/content_data_admin_s3_writer_policy.tpl
+++ b/terraform/policies/content_data_admin_s3_writer_policy.tpl
@@ -4,7 +4,7 @@
         {
             "Effect": "Allow",
             "Action": [
-                "s3:ListBucket",
+                "s3:ListBucket"
              ],
             "Resource": [
                 "arn:aws:s3:::${bucket}"
@@ -14,7 +14,7 @@
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject",
-                "s3:PutObject",
+                "s3:PutObject"
             ],
             "Resource": [
                 "arn:aws:s3:::${bucket}/*"


### PR DESCRIPTION
Fixed the JSON formatting for the IAM policy which prevented the IAM user from being created for Content Data to access S3.