### PR TITLE
Create govuk-csp-forwarder lambda in eu-west-1 and add API Gateway

### DIFF
--- a/terraform/projects/infra-govuk-csp-forwarder/README.md
+++ b/terraform/projects/infra-govuk-csp-forwarder/README.md
@@ -19,3 +19,9 @@ reports, filter them and forward them to Sentry.
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
 | stackname | Stackname | string | - | yes |
 
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| govuk_csp_forwarder_report_url |  |
+

--- a/terraform/projects/infra-govuk-csp-forwarder/README.md
+++ b/terraform/projects/infra-govuk-csp-forwarder/README.md
@@ -9,7 +9,7 @@ reports, filter them and forward them to Sentry.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
-| aws_region | AWS region | string | `eu-west-1` | no |
+| aws_region | AWS region | string | `eu-west-2` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/infra-govuk-csp-forwarder/main.tf
+++ b/terraform/projects/infra-govuk-csp-forwarder/main.tf
@@ -65,3 +65,75 @@ resource "aws_iam_role" "govuk_csp_forwarder_lambda_role" {
 }
 EOF
 }
+
+# API Gateway setup to make the lambda function available over HTTP
+resource "aws_api_gateway_rest_api" "govuk_csp_forwarder_api_gateway" {
+  name        = "GovukCspForwarder"
+  description = "API gateway for GOV.UK CSP Forwarder"
+}
+
+resource "aws_api_gateway_resource" "proxy" {
+  rest_api_id = "${aws_api_gateway_rest_api.govuk_csp_forwarder_api_gateway.id}"
+  parent_id   = "${aws_api_gateway_rest_api.govuk_csp_forwarder_api_gateway.root_resource_id}"
+  path_part   = "{proxy+}"
+}
+
+resource "aws_api_gateway_method" "proxy" {
+  rest_api_id   = "${aws_api_gateway_rest_api.govuk_csp_forwarder_api_gateway.id}"
+  resource_id   = "${aws_api_gateway_resource.proxy.id}"
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "lambda" {
+  rest_api_id = "${aws_api_gateway_rest_api.govuk_csp_forwarder_api_gateway.id}"
+  resource_id = "${aws_api_gateway_method.proxy.resource_id}"
+  http_method = "${aws_api_gateway_method.proxy.http_method}"
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = "${aws_lambda_function.govuk_csp_forwarder_lambda_function.invoke_arn}"
+}
+
+resource "aws_api_gateway_method" "proxy_root" {
+  rest_api_id   = "${aws_api_gateway_rest_api.govuk_csp_forwarder_api_gateway.id}"
+  resource_id   = "${aws_api_gateway_rest_api.govuk_csp_forwarder_api_gateway.root_resource_id}"
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "lambda_root" {
+  rest_api_id = "${aws_api_gateway_rest_api.govuk_csp_forwarder_api_gateway.id}"
+  resource_id = "${aws_api_gateway_method.proxy_root.resource_id}"
+  http_method = "${aws_api_gateway_method.proxy_root.http_method}"
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = "${aws_lambda_function.govuk_csp_forwarder_lambda_function.invoke_arn}"
+}
+
+resource "aws_api_gateway_deployment" "govuk_csp_forwarder_api_gateway_deployment" {
+  depends_on = [
+    "aws_api_gateway_integration.lambda",
+    "aws_api_gateway_integration.lambda_root",
+  ]
+
+  rest_api_id = "${aws_api_gateway_rest_api.govuk_csp_forwarder_api_gateway.id}"
+  stage_name  = "production"
+}
+
+resource "aws_lambda_permission" "govuk_csp_forwarder_api_gateway_invoke_permission" {
+  provider      = "aws.eu-west-1-region"
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.govuk_csp_forwarder_lambda_function.arn}"
+  principal     = "apigateway.amazonaws.com"
+
+  # The /*/* portion grants access from any method on any resource
+  # within the API Gateway "REST API".
+  source_arn = "${aws_api_gateway_deployment.govuk_csp_forwarder_api_gateway_deployment.execution_arn}/*/*"
+}
+
+output "govuk_csp_forwarder_report_url" {
+  value = "${aws_api_gateway_deployment.govuk_csp_forwarder_api_gateway_deployment.invoke_url}"
+}

--- a/terraform/projects/infra-govuk-csp-forwarder/main.tf
+++ b/terraform/projects/infra-govuk-csp-forwarder/main.tf
@@ -7,7 +7,7 @@
 variable "aws_region" {
   type        = "string"
   description = "AWS region"
-  default     = "eu-west-1"
+  default     = "eu-west-2"
 }
 
 variable "aws_environment" {
@@ -30,9 +30,16 @@ provider "aws" {
   version = "1.40.0"
 }
 
+provider "aws" {
+  region  = "eu-west-1"
+  version = "1.40.0"
+  alias   = "eu-west-1-region"
+}
+
 resource "aws_lambda_function" "govuk_csp_forwarder_lambda_function" {
+  provider      = "aws.eu-west-1-region"
   s3_bucket     = "govuk-integration-artefact"
-  s3_key        = "govuk-csp-forwarder/release/csp_forwarder"
+  s3_key        = "govuk-csp-forwarder/release/csp_forwarder.zip"
   function_name = "govuk-csp-forwarder"
   role          = "${aws_iam_role.govuk_csp_forwarder_lambda_role.arn}"
   handler       = "csp_forwarder"

--- a/terraform/projects/infra-govuk-csp-forwarder/tools.govuk.backend
+++ b/terraform/projects/infra-govuk-csp-forwarder/tools.govuk.backend
@@ -1,4 +1,4 @@
 bucket  = "govuk-terraform-steppingstone-tools"
 key     = "govuk/infra-govuk-csp-forwarder.tfstate"
 encrypt = true
-region  = "eu-west-1"
+region  = "eu-west-2"


### PR DESCRIPTION
This PR does two things:

* Moves the creation of the `govuk-csp-forwarder` lambda function to eu-west-1 since this is the region the deployed lambda artefact exists in
* Adds an API gateway endpoint to allow HTTP POST requests to reach the lambda function