### PR TITLE
Fix missing permissions in S3 policy

### DIFF
--- a/terraform/policies/content_data_admin_s3_writer_policy.tpl
+++ b/terraform/policies/content_data_admin_s3_writer_policy.tpl
@@ -4,7 +4,8 @@
         {
             "Effect": "Allow",
             "Action": [
-                "s3:ListBucket"
+                "s3:ListBucket",
+                "s3:GetBucketLocation"
              ],
             "Resource": [
                 "arn:aws:s3:::${bucket}"
@@ -14,7 +15,8 @@
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject",
-                "s3:PutObject"
+                "s3:PutObject",
+                "s3:PutObjectAcl"
             ],
             "Resource": [
                 "arn:aws:s3:::${bucket}/*"


### PR DESCRIPTION
Adding `GetBucketLocation` and `PutObjectAcl` permissions as needed to HEAD buckets and PUT object with public access.