### PR TITLE
Add missing S3 permissions for Content Data Admin

### DIFF
--- a/terraform/policies/content_data_admin_s3_writer_policy.tpl
+++ b/terraform/policies/content_data_admin_s3_writer_policy.tpl
@@ -15,6 +15,7 @@
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject",
+                "s3:GetObjectAcl",
                 "s3:PutObject",
                 "s3:PutObjectAcl"
             ],


### PR DESCRIPTION
This adds a missing GetObjectAcl permissions needed for Content Data Admin to fetch an object's public url.