### PR TITLE
Fix the Content Data API database backups bucket prefix

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -330,7 +330,7 @@ data "aws_iam_policy_document" "content_data_api_dbadmin_database_backups_writer
       variable = "s3:prefix"
 
       values = [
-        "postgres",
+        "content-data-api-postgresql",
       ]
     }
   }

--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -346,6 +346,10 @@ data "aws_iam_policy_document" "content_data_api_dbadmin_database_backups_writer
 
     resources = [
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/content-data-api-postgresql/*-content_data_api.gz",
+
+      # The following line can be removed once the Content Data API
+      # database is renamed
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/content-data-api-postgresql/*-content_performance_manager.gz",
     ]
   }
 }

--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -345,11 +345,11 @@ data "aws_iam_policy_document" "content_data_api_dbadmin_database_backups_writer
     ]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/content-data-api-postgresql/*-content_data_api.gz",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/content-data-api-postgresql/*-content_data_api_production.gz",
 
       # The following line can be removed once the Content Data API
       # database is renamed
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/content-data-api-postgresql/*-content_performance_manager.gz",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/content-data-api-postgresql/*-content_performance_manager_production.gz",
     ]
   }
 }


### PR DESCRIPTION
I'm currently seeing the following error. I can't track down what
permissions are required for the CreateMultipartUpload operation, so
maybe it relates to this bit of the policy...

1:
(AccessDenied) when calling the CreateMultipartUpload operation