### PR TITLE
Remove CSW target account ID

### DIFF
--- a/terraform/projects/infra-csw/README.md
+++ b/terraform/projects/infra-csw/README.md
@@ -10,5 +10,4 @@ Role and policy for CSW
 | aws_region | AWS region | string | `eu-west-1` | no |
 | csw_agent_account_id |  | string | - | yes |
 | csw_prefix |  | string | `csw-prod` | no |
-| csw_target_account_id |  | string | - | yes |
 

--- a/terraform/projects/infra-csw/main.tf
+++ b/terraform/projects/infra-csw/main.tf
@@ -15,7 +15,6 @@ variable "aws_region" {
 }
 
 variable "csw_agent_account_id" {}
-variable "csw_target_account_id" {}
 
 # Resources
 # --------------------------------------------------------------
@@ -30,9 +29,8 @@ provider "aws" {
 }
 
 module "csw_inspector_role" {
-  source                = "git::https://github.com/alphagov/csw-client-role.git"
-  region                = "${var.aws_region}"
-  csw_prefix            = "${var.csw_prefix}"
-  csw_agent_account_id  = "${var.csw_agent_account_id}"
-  csw_target_account_id = "${var.csw_target_account_id}"
+  source               = "git::https://github.com/alphagov/csw-client-role.git"
+  region               = "${var.aws_region}"
+  csw_prefix           = "${var.csw_prefix}"
+  csw_agent_account_id = "${var.csw_agent_account_id}"
 }


### PR DESCRIPTION
The latest version of CSW will not need target account ID.

Related PRs:

- https://github.com/alphagov/csw-client-role/pull/14
- https://github.com/alphagov/govuk-aws-data/pull/358