### PR TITLE
Module to create s3 buckets with expiration lifecycle rules

### DIFF
--- a/terraform/modules/aws/s3_bucket_lifecycle/README.md
+++ b/terraform/modules/aws/s3_bucket_lifecycle/README.md
@@ -1,0 +1,19 @@
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| bucket_name | Name of bucket to create | string | - | yes |
+| current_expiration_days | Number of days to keep current versions | string | `5` | no |
+| enable_current_expiration | Enables current object lifecycle rule | string | `false` | no |
+| enable_noncurrent_expiration | Enables this lifecycle rule | string | `false` | no |
+| noncurrent_expiration_days | Number of days to keep noncurrent versions | string | `5` | no |
+| target_bucketid_for_logs | ID for logging bucket | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| bucket_id |  |
+

--- a/terraform/modules/aws/s3_bucket_lifecycle/main.tf
+++ b/terraform/modules/aws/s3_bucket_lifecycle/main.tf
@@ -1,0 +1,102 @@
+/*
+* ## Module: s3-bucket-lifecycle
+*
+* This module creates s3 buckets with predefined lifecycle rules
+*/
+
+# Variables
+#--------------------------------------------------------------
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+variable "bucket_name" {
+  type        = "string"
+  description = "Name of bucket to create"
+}
+
+variable "target_bucketid_for_logs" {
+  type        = "string"
+  description = "ID for logging bucket"
+}
+
+# lifecycle rule 1 vars
+variable "enable_current_expiration" {
+  type        = "string"
+  description = "Enables current object lifecycle rule"
+  default     = "false"
+}
+
+variable "current_expiration_days" {
+  type        = "string"
+  description = "Number of days to keep current versions"
+  default     = "5"
+}
+
+# lifecycle rule 2 vars
+variable "enable_noncurrent_expiration" {
+  type        = "string"
+  description = "Enables this lifecycle rule"
+  default     = "false"
+}
+
+variable "noncurrent_expiration_days" {
+  type        = "string"
+  description = "Number of days to keep noncurrent versions"
+  default     = "5"
+}
+
+# Resources
+#--------------------------------------------------------------
+
+resource "aws_s3_bucket" "s3_bucket" {
+  bucket = "${var.bucket_name}"
+
+  tags {
+    aws_environment = "${var.aws_environment}"
+    Name            = "${var.bucket_name}"
+    SourceCode      = "alphagov/govuk-aws/terraform/modules/aws/s3_bucket_lifecycle" #hardcoded path to this code, TODO: make this dynamic.
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    target_bucket = "${var.target_bucketid_for_logs}"
+    target_prefix = "log/"
+  }
+
+  lifecycle_rule {
+    id      = "Clean_up_incomplete_multipart_uploads_after_5_days" # lifecycle rule 0
+    enabled = "true"
+
+    abort_incomplete_multipart_upload_days = 5
+  }
+
+  lifecycle_rule {
+    id      = "expire_current_objects"           # lifecycle rule 1
+    enabled = "${var.enable_current_expiration}"
+
+    expiration {
+      days = "${var.current_expiration_days}"
+    }
+  }
+
+  lifecycle_rule {
+    id      = "expire_noncurrent_objects"           # lifecycle rule 2
+    enabled = "${var.enable_noncurrent_expiration}"
+
+    noncurrent_version_expiration {
+      days = "${var.noncurrent_expiration_days}"
+    }
+  }
+}
+
+# Outputs
+#--------------------------------------------------------------
+
+output "bucket_id" {
+  value = "${aws_s3_bucket.s3_bucket.id}"
+}


### PR DESCRIPTION
Context
We have different environments (Integration, Staging and Production) with
different lifecycle requirements yet these are created with the same code. This
means that all lifecycle rules will be the same for any buckets created with
the same code. Lifecycle rules have to be defined inline and cannot be attached
to existing buckets.

Decision
Create a module to allow for basic expiration of objects, namely expiration of
current and noncurrent objects. This commmit creates a module that allows
enable/disable of a current object expiration rule and the enable/disable of a
noncurrent object expiration rule. It also allows an override of the default 5
days for both these rules.