### PR TITLE
Fix Pingdom probe sh script

### DIFF
--- a/terraform/projects/infra-s3-mirrors/pingdom_probe_ips.sh
+++ b/terraform/projects/infra-s3-mirrors/pingdom_probe_ips.sh
@@ -11,7 +11,7 @@
 # https://www.terraform.io/docs/providers/external/data_source.html
 # https://github.com/hashicorp/terraform/issues/12256
 
-curl -s https://my.pingdom.com/probes/feed | grep "pingdom:ip" | sed -e 's|</.*||' -e 's|.*>||' | sort -n -t . -k 1,1 -k 2,2 -k 3,3 -k 4,4 | grep -v ":" | awk '
+curl -s https://my.pingdom.com/probes/feed | grep "pingdom:ip" | sed -e 's|</.*||' -e 's|.*>||' | sort -n -t . -k 1,1 -k 2,2 -k 3,3 -k 4,4 | grep -oE "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" | awk '
 BEGIN { ORS = ""; print " { \"pingdom_probe_ips\": \""}
 { if (NR == 1) { print $1"/32" } else { print ","$1"/32" } }
 END { print "\" }" }


### PR DESCRIPTION
Context
The probe to determine pingdom ips doesn't filter out "NULL" entries.

Decision
Remove the invert-match ("-v") and add regex specifically for IPv4 addresses.
(regex ref: https://www.shellhacks.com/regex-find-ip-addresses-file-grep/)