### PR TITLE
Make data.gov.uk Fastly backend domain configurable

### DIFF
--- a/terraform/projects/fastly-datagovuk/README.md
+++ b/terraform/projects/fastly-datagovuk/README.md
@@ -8,6 +8,7 @@ Manages the Fastly service for data.gov.uk
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
+| backend_domain | The domain of the data.gov.uk PaaS instance to forward requests to | string | - | yes |
 | domain | The domain of the data.gov.uk service to manage | string | - | yes |
 | fastly_api_key | API key to authenticate with Fastly | string | - | yes |
 | logging_aws_access_key_id | IAM key ID with access to put logs into the S3 bucket | string | - | yes |

--- a/terraform/projects/fastly-datagovuk/main.tf
+++ b/terraform/projects/fastly-datagovuk/main.tf
@@ -34,6 +34,11 @@ variable "domain" {
   description = "The domain of the data.gov.uk service to manage"
 }
 
+variable "backend_domain" {
+  type        = "string"
+  description = "The domain of the data.gov.uk PaaS instance to forward requests to"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -57,8 +62,8 @@ resource "fastly_service_v1" "datagovuk" {
   }
 
   backend {
-    name               = "cname find-data-beta.cloudapps.digital"
-    address            = "find-data-beta.cloudapps.digital"
+    name               = "cname ${var.backend_domain}"
+    address            = "${var.backend_domain}"
     port               = "443"
     use_ssl            = true
     auto_loadbalance   = false


### PR DESCRIPTION
This allows us to set up a different staging configuration that points to the staging data.gov.uk PaaS instance.

[Trello Card](https://trello.com/c/MomTjKnV/910-ensure-only-whitelisted-ips-can-purge-dgu-cache)