### PR TITLE
Add custom data.gov.uk VCL to limit purge requests

### DIFF
--- a/terraform/projects/fastly-datagovuk/datagovuk.vcl
+++ b/terraform/projects/fastly-datagovuk/datagovuk.vcl
@@ -1,0 +1,110 @@
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+  "31.210.245.70";    # Carrenza Staging
+  "18.202.183.143";   # AWS NAT GW1 Staging
+  "18.203.90.80";     # AWS NAT GW2 Staging
+  "18.203.108.248";   # AWS NAT GW3 Staging
+  "31.210.245.86";    # Carrenza Production
+  "34.246.209.74";    # AWS NAT GW1 Production
+  "34.253.57.8";      # AWS NAT GW2 Production
+  "18.202.136.43";    # AWS NAT GW3 Production
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+sub vcl_recv {
+#FASTLY recv
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE" && !(client.ip ~ purge_ip_whitelist)) {
+    error 403 "Forbidden";
+  }
+
+  if (req.method != "HEAD" && req.method != "GET" && req.method != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  if ((beresp.status == 500 || beresp.status == 503) && req.restarts < 1 && (req.method == "GET" || req.method == "HEAD")) {
+    restart;
+  }
+
+  if (req.restarts > 0) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Set-Cookie) {
+    set req.http.Fastly-Cachetype = "SETCOOKIE";
+    return(pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return(pass);
+  }
+
+  if (beresp.status == 500 || beresp.status == 503) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return(deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~ "(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 3600s;
+  }
+
+  return(deliver);
+}
+
+sub vcl_hit {
+#FASTLY hit
+
+  if (!obj.cacheable) {
+    return(pass);
+  }
+  return(deliver);
+}
+
+sub vcl_miss {
+#FASTLY miss
+  return(fetch);
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+  return(deliver);
+}
+
+sub vcl_error {
+#FASTLY error
+}
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_log {
+#FASTLY log
+}

--- a/terraform/projects/fastly-datagovuk/main.tf
+++ b/terraform/projects/fastly-datagovuk/main.tf
@@ -82,6 +82,12 @@ resource "fastly_service_v1" "datagovuk" {
     request_condition  = "education_standards"
   }
 
+  vcl {
+    name    = "datagovuk_vcl"
+    content = "${file("datagovuk.vcl")}"
+    main    = true
+  }
+
   condition {
     name      = "education_standards"
     type      = "request"


### PR DESCRIPTION
This means that purge requests to data.gov.uk will be limited to the IPs listed in the VCL.

Tested this deploy to staging:

```
❯ curl -XPURGE https://staging.data.gov.uk/test -k
<?xml version="1.0" encoding="utf-8"?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html>
  <head>
    <title>403 Forbidden</title>
  </head>
  <body>
    <h1>Error 403 Forbidden</h1>
    <p>Forbidden</p>
    <h3>Guru Mediation:</h3>
    <p>Details: cache-ams21026-AMS 1554123729 1861220372</p>
    <hr>
    <p>Varnish cache server</p>
  </body>
</html>

❯ ssh backend-1.production
Last login: Mon Apr  1 13:01:56 2019 from jumpbox-1.management.publishing.service.gov.uk
thomasleese@production-backend-1:~$ curl -XPURGE https://staging.data.gov.uk/test -k
{"status": "ok", "id": "19225-1553318348-5389140"}
```

[Trello Card](https://trello.com/c/MomTjKnV/910-ensure-only-whitelisted-ips-can-purge-dgu-cache)