### PR TITLE
Start using s3 module for infra-s3-mirrors project

### DIFF
--- a/terraform/projects/infra-s3-mirrors/mirror-crawler-write-policy.tf
+++ b/terraform/projects/infra-s3-mirrors/mirror-crawler-write-policy.tf
@@ -17,14 +17,14 @@ data "aws_iam_policy_document" "s3_mirror_crawler_writer_policy_doc" {
     actions = ["s3:*"]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}",
-      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}/*",
+      "arn:aws:s3:::${module.govuk_mirror.bucket_id}",
+      "arn:aws:s3:::${module.govuk_mirror.bucket_id}/*",
     ]
   }
 }
 
 resource "aws_iam_policy" "s3_mirror_writer_policy" {
-  name   = "s3_mirror_writer_policy_for_${aws_s3_bucket.govuk_mirror.id}"
+  name   = "s3_mirror_writer_policy_for_${module.govuk_mirror.bucket_id}"
   policy = "${data.aws_iam_policy_document.s3_mirror_crawler_writer_policy_doc.json}"
 }
 

--- a/terraform/projects/infra-s3-mirrors/mirror-read-policy.tf
+++ b/terraform/projects/infra-s3-mirrors/mirror-read-policy.tf
@@ -15,8 +15,8 @@ data "aws_iam_policy_document" "s3_mirror_read_policy_doc" {
     actions = ["s3:GetObject"]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}",
-      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}/*",
+      "arn:aws:s3:::${module.govuk_mirror.bucket_id}",
+      "arn:aws:s3:::${module.govuk_mirror.bucket_id}/*",
     ]
 
     condition {
@@ -36,8 +36,8 @@ data "aws_iam_policy_document" "s3_mirror_read_policy_doc" {
     actions = ["s3:GetObject"]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}",
-      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}/*",
+      "arn:aws:s3:::${module.govuk_mirror.bucket_id}",
+      "arn:aws:s3:::${module.govuk_mirror.bucket_id}/*",
     ]
 
     condition {


### PR DESCRIPTION
Context
We have a module that will improve the consistency of lifecycle rules across s3
buckets. The infra-s3-mirrors project is one of several that would benefit.

Decision
Use the module and it's defaults to ensure versioned objects are deleted for
this project. Do this while ensuring data isn't deleted and that key
infrastructure is not destroyed. This requires both code and implementation
steps.

The following approach was used to implement this across aws envs:

1. Run a plan with `./tools/build-terraform-project.sh` for the project.
2. Confirm what would be destroyed and confirm other changes.
3. Change directory to the project to run `terraform state` and rename the
entries to keep in the state file. This will also create a local backup of the
state file.  e.g. `terraform state mv old_name new_name`
4. Run a plan with `build-terraform-project.sh`, confirm expectations.
HINT: There should be `0 to destroy`.
5. Run an apply with `build-terraform-project.sh` to implement the changes.
6. Submit PR and get changes merged to master.