### PR TITLE
Give search machines a 600s warmup period

### DIFF
--- a/terraform/modules/aws/node_group/README.md
+++ b/terraform/modules/aws/node_group/README.md
@@ -22,6 +22,7 @@ to use with Application Load Balancers with the `instance_target_group_arns` var
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | asg_desired_capacity | The autoscaling groups desired capacity | string | `1` | no |
+| asg_health_check_grace_period | The time to wait after creation before checking the status of the instance | string | `60` | no |
 | asg_max_size | The autoscaling groups max_size | string | `1` | no |
 | asg_min_size | The autoscaling groups max_size | string | `1` | no |
 | asg_notification_topic_arn | The Topic ARN for Autoscaling Group notifications to be sent to | string | `` | no |

--- a/terraform/modules/aws/node_group/main.tf
+++ b/terraform/modules/aws/node_group/main.tf
@@ -115,6 +115,12 @@ variable "instance_target_group_arns_length" {
   default     = 0
 }
 
+variable "asg_health_check_grace_period" {
+  type        = "string"
+  description = "The time to wait after creation before checking the status of the instance"
+  default     = "60"
+}
+
 variable "asg_desired_capacity" {
   type        = "string"
   description = "The autoscaling groups desired capacity"
@@ -267,7 +273,7 @@ resource "aws_autoscaling_group" "node_autoscaling_group" {
   desired_capacity          = "${var.asg_desired_capacity}"
   min_size                  = "${var.asg_min_size}"
   max_size                  = "${var.asg_max_size}"
-  health_check_grace_period = "60"
+  health_check_grace_period = "${var.asg_health_check_grace_period}"
   health_check_type         = "EC2"
   force_delete              = false
   wait_for_capacity_timeout = 0

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -146,6 +146,7 @@ module "search" {
   asg_min_size                  = "${var.asg_min_size}"
   asg_desired_capacity          = "${var.asg_desired_capacity}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  asg_health_check_grace_period = "600"
 }
 
 module "alarms-elb-search-internal" {


### PR DESCRIPTION
The healthcheck only checks nginx is running, not that the app is running.  We've seen this cause occasional problems elsewhere, so just set it to a large value for the search machines, given that we're planning to grow the ASG to 3 nodes.