### PR TITLE
Bump search grace period to 1200s

### DIFF
--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -146,7 +146,7 @@ module "search" {
   asg_min_size                  = "${var.asg_min_size}"
   asg_desired_capacity          = "${var.asg_desired_capacity}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
-  asg_health_check_grace_period = "600"
+  asg_health_check_grace_period = "1200"
 }
 
 module "alarms-elb-search-internal" {


### PR DESCRIPTION
It took a little over 10 minutes on staging for search-api to be
deployed to the new machine, so the 600s period is not enough.