### PR TITLE
Remove expiration rule from elasticsearch manual snapshot bucket

### DIFF
--- a/terraform/projects/app-elasticsearch5/main.tf
+++ b/terraform/projects/app-elasticsearch5/main.tf
@@ -300,14 +300,6 @@ resource "aws_s3_bucket" "manual_snapshots" {
     target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
     target_prefix = "s3/govuk-${var.aws_environment}-elasticsearch5-manual-snapshots/"
   }
-
-  lifecycle_rule {
-    enabled = true
-
-    expiration {
-      days = 7
-    }
-  }
 }
 
 resource "aws_s3_bucket_policy" "manual_snapshots_cross_account_access" {


### PR DESCRIPTION
Elasticsearch doesn't just look at the files in the bucket to know
what snapshots there are, it maintains a metadata file.  Expiring old
files results in this metadata file getting out of sync, which results
in a 500 error when trying to do anything other than take a new
snapshot.

There doesn't seem to be a way to regenerate the metadata based on the
real data, so automatic expiration has to go.  Perhaps we could have a
daily task on the search machines which deletes the oldest snapshot or
something.

To fix the bad state I'll need to unregister the buckets from elasticsearch, delete their contents, and re-register them.

---

[Trello card](https://trello.com/c/rsePSAB9/90-fix-the-flakey-data-sync)