### PR TITLE
Increase the Elasticsearch data nodes from 3 to 6

### DIFF
--- a/terraform/projects/app-elasticsearch5/README.md
+++ b/terraform/projects/app-elasticsearch5/README.md
@@ -33,7 +33,7 @@ doesn't support:
 | elasticsearch5_ebs_encrypt | Whether to encrypt the EBS volume at rest | string | - | yes |
 | elasticsearch5_ebs_size | The amount of EBS storage to attach | string | `32` | no |
 | elasticsearch5_ebs_type | The type of EBS storage to attach | string | `gp2` | no |
-| elasticsearch5_instance_count | The number of ElasticSearch nodes | string | `3` | no |
+| elasticsearch5_instance_count | The number of ElasticSearch nodes | string | `6` | no |
 | elasticsearch5_instance_type | The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported | string | `r4.large.elasticsearch` | no |
 | elasticsearch5_manual_snapshot_bucket_arns | Bucket ARNs this domain can read/write for manual snapshots | list | `<list>` | no |
 | elasticsearch5_master_instance_count | Number of dedicated master nodes in the cluster | string | `3` | no |

--- a/terraform/projects/app-elasticsearch5/main.tf
+++ b/terraform/projects/app-elasticsearch5/main.tf
@@ -47,7 +47,7 @@ variable "elasticsearch5_instance_type" {
 variable "elasticsearch5_instance_count" {
   type        = "string"
   description = "The number of ElasticSearch nodes"
-  default     = "3"
+  default     = "6"
 }
 
 variable "elasticsearch5_dedicated_master_enabled" {


### PR DESCRIPTION
Add an additional data node in each availability zone.

This reduces the query queue length and CPU utilisation.

Trello card: https://trello.com/c/Ywbe0luG/117-spike-es-data-instances-have-enough-resource