### PR TITLE
Set the host for proxied services

### DIFF
--- a/terraform/projects/fastly-datagovuk/main.tf
+++ b/terraform/projects/fastly-datagovuk/main.tf
@@ -106,11 +106,20 @@ resource "fastly_service_v1" "datagovuk" {
   }
 
   header {
-    name              = "education_standards"
+    name              = "education_standards_url"
     action            = "set"
     type              = "request"
     destination       = "url"
     source            = "regsub(req.url, \"^/education-standards\", \"\")"
+    request_condition = "education_standards"
+  }
+
+  header {
+    name              = "education_standards_host"
+    action            = "set"
+    type              = "request"
+    destination       = "http.host"
+    source            = "\"dfe-app1.codeenigma.net\""
     request_condition = "education_standards"
   }
 
@@ -126,6 +135,15 @@ resource "fastly_service_v1" "datagovuk" {
     type              = "request"
     destination       = "url"
     source            = "regsub(req.url, \"^/data/contracts-finder-archive\", \"\")"
+    request_condition = "contracts_finder_archive"
+  }
+
+  header {
+    name              = "contracts_finder_archive_host"
+    action            = "set"
+    type              = "request"
+    destination       = "http.host"
+    source            = "\"34.249.103.20\""
     request_condition = "contracts_finder_archive"
   }
 


### PR DESCRIPTION
Fastly uses a cache key of 'req.url, req.http.host' when deciding which key to store a cache under. So we should set the host when proxying to services other than the main data.gov.uk service so that they don't get cached over data.gov.uk. This happens because we rewrite the URLs to remove the prefix part of the URL for the proxy service. Setting the host doesn't change the host of the backend origin service we're connecting to, it just changes the value of the header sent to the origin service.

[Trello Card](https://trello.com/c/T1aZMkTy/933-make-contracts-archive-accessible-on-former-url)