### PR TITLE
Add another calculators_frontend machine

### DIFF
--- a/terraform/projects/app-calculators-frontend/README.md
+++ b/terraform/projects/app-calculators-frontend/README.md
@@ -8,7 +8,7 @@ Calculators Frontend application servers
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| asg_size | The autoscaling groups desired/max/min capacity | string | `3` | no |
+| asg_size | The autoscaling groups desired/max/min capacity | string | `5` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -33,7 +33,7 @@ variable "elb_internal_certname" {
 variable "asg_size" {
   type        = "string"
   description = "The autoscaling groups desired/max/min capacity"
-  default     = "3"
+  default     = "5"
 }
 
 variable "app_service_records" {


### PR DESCRIPTION
We will be redirecting extra traffic to finder-frontend from whitehall finders over the next few days/weeks.  

Elasticsearch / search-api should behave similarly to before, as they were both in the whitehall finder dependency tree, so it should just be finder-frontend that needs to increase spec.

Note that the current asg size in live is `4` not `3` as this PR would suggest.  This is because of last week's remedial work.

https://trello.com/c/NMLcme88/110-add-additional-calculators-search-api-boxes-to-create-additional-capacity