### PR TITLE
Updated infra-security-group terraform files

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -9,7 +9,7 @@ Manage the security groups for the entire infrastructure
 |------|-------------|:----:|:-----:|:-----:|
 | aws_region | AWS region | string | `eu-west-1` | no |
 | carrenza_draft_frontend_ips | An array of CIDR blocks for the current environment that will allow access to draft-content-store from Carrenza. | list | `<list>` | no |
-| carrenza_env_ips | An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox. | list | - | yes |
+| carrenza_env_ips | An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox. | list | `<list>` | no |
 | carrenza_integration_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_production_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_staging_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |

--- a/terraform/projects/infra-security-groups/calculators-frontend.tf
+++ b/terraform/projects/infra-security-groups/calculators-frontend.tf
@@ -113,6 +113,7 @@ resource "aws_security_group" "calendars_carrenza_alb" {
 }
 
 resource "aws_security_group_rule" "calendars-carrenza-alb_ingress_443_carrenza" {
+  count     = "${length(var.carrenza_env_ips) > 0 ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443

--- a/terraform/projects/infra-security-groups/content-store.tf
+++ b/terraform/projects/infra-security-groups/content-store.tf
@@ -89,6 +89,7 @@ resource "aws_security_group" "content-store_external_elb" {
 
 # TODO: Audit
 resource "aws_security_group_rule" "content-store-external-elb_ingress_public_https" {
+  count     = "${length(var.carrenza_env_ips) > 0 ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443

--- a/terraform/projects/infra-security-groups/frontend.tf
+++ b/terraform/projects/infra-security-groups/frontend.tf
@@ -113,6 +113,7 @@ resource "aws_security_group" "static_carrenza_alb" {
 }
 
 resource "aws_security_group_rule" "static-carrenza-alb_ingress_443_carrenza" {
+  count     = "${length(var.carrenza_env_ips) > 0 ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443

--- a/terraform/projects/infra-security-groups/mapit.tf
+++ b/terraform/projects/infra-security-groups/mapit.tf
@@ -88,6 +88,7 @@ resource "aws_security_group" "mapit_carrenza_alb" {
 }
 
 resource "aws_security_group_rule" "mapit-carrenza-alb_ingress_443_carrenza" {
+  count     = "${length(var.carrenza_env_ips) > 0 ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -47,6 +47,7 @@ variable "carrenza_production_ips" {
 variable "carrenza_env_ips" {
   type        = "list"
   description = "An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox."
+  default     = []
 }
 
 variable "carrenza_draft_frontend_ips" {


### PR DESCRIPTION
We have made entering the Carrenza IPs optional.
These can now be blank if they are not needed in your
particular environment