### PR TITLE
Use aws_region variable in remote_state

### DIFF
--- a/terraform/projects/infra-security-groups/remote_state.tf
+++ b/terraform/projects/infra-security-groups/remote_state.tf
@@ -13,6 +13,6 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }


### PR DESCRIPTION
The new Training environment is provisioned in a different region. We need to use
the `aws_region` variable to configure the networking remote_state file, or Terraform
fails.