### PR TITLE
Manage environment certificates with Terraform

### DIFF
--- a/doc/guides/certificate-validation.md
+++ b/doc/guides/certificate-validation.md
@@ -1,5 +1,10 @@
 # Certificate Validation
 
+*DEPRECATED*
+New environments should manage certificate validation with DNS via `infra-certificates` project.
+
+*Remove after importing all the certificates from existing environments into `infra-certificates`*
+
 If a certificate is registered through Amazon, then a few steps will be required to enable validation of the certificate.
 
 ## DNS

--- a/doc/guides/environment-provisioning.md
+++ b/doc/guides/environment-provisioning.md
@@ -117,12 +117,13 @@ The projects that need to be initially run in this way are:
 4. `infra-networking`
 5. `infra-root-dns-zones`
 6. `infra-stack-dns-zones`
-7. `infra-security-groups`
-8. `infra-database-backups-bucket`
-9. `infra-artefact-bucket`
-10. `infra-mirror-bucket`
-11. `infra-wal-e-warehouse-bucket`
-12. `infra-public-services`
+7. `infra-certificates`
+8. `infra-security-groups`
+9. `infra-database-backups-bucket`
+10. `infra-artefact-bucket`
+11. `infra-mirror-bucket`
+12. `infra-wal-e-warehouse-bucket`
+13. `infra-public-services`
 
 ### Update the NS records (if rebuilding infra-root-dns-zones in staging or integration)
 

--- a/terraform/projects/infra-certificates/README.md
+++ b/terraform/projects/infra-certificates/README.md
@@ -1,0 +1,25 @@
+## Project: infra-certificates
+
+This module creates the environment certificates
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_region | AWS region | string | - | yes |
+| certificate_external_domain_name | Domain name for which the external certificate should be issued | string | - | yes |
+| certificate_external_subject_alternative_names | List of domains that should be SANs in the external issued certificate | list | `<list>` | no |
+| certificate_internal_domain_name | Domain name for which the internal certificate should be issued | string | - | yes |
+| certificate_internal_subject_alternative_names | List of domains that should be SANs in the internal issued certificate | list | `<list>` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_root_dns_zones_key_stack | Override stackname path to infra_root_dns_zones remote state | string | `` | no |
+| stackname | Stackname | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| external_certificate_arn | ARN of the external certificate |
+| internal_certificate_arn | ARN of the internal certificate |
+

--- a/terraform/projects/infra-certificates/main.tf
+++ b/terraform/projects/infra-certificates/main.tf
@@ -75,16 +75,18 @@ resource "aws_acm_certificate" "certificate_external" {
 }
 
 resource "aws_route53_record" "certificate_external_validation" {
-  name    = "${aws_acm_certificate.certificate_external.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.certificate_external.domain_validation_options.0.resource_record_type}"
+  count = "${length(aws_acm_certificate.certificate_external.domain_validation_options)}"
+
+  name    = "${lookup(aws_acm_certificate.certificate_external.domain_validation_options[count.index], "resource_record_name")}"
+  type    = "${lookup(aws_acm_certificate.certificate_external.domain_validation_options[count.index], "resource_record_type")}"
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
-  records = ["${aws_acm_certificate.certificate_external.domain_validation_options.0.resource_record_value}"]
+  records = ["${lookup(aws_acm_certificate.certificate_external.domain_validation_options[count.index], "resource_record_value")}"]
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "certificate_external" {
   certificate_arn         = "${aws_acm_certificate.certificate_external.arn}"
-  validation_record_fqdns = ["${aws_route53_record.certificate_external_validation.fqdn}"]
+  validation_record_fqdns = ["${aws_route53_record.certificate_external_validation.*.fqdn}"]
 }
 
 resource "aws_acm_certificate" "certificate_internal" {
@@ -94,16 +96,18 @@ resource "aws_acm_certificate" "certificate_internal" {
 }
 
 resource "aws_route53_record" "certificate_internal_validation" {
-  name    = "${aws_acm_certificate.certificate_internal.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.certificate_internal.domain_validation_options.0.resource_record_type}"
+  count = "${length(aws_acm_certificate.certificate_internal.domain_validation_options)}"
+
+  name    = "${lookup(aws_acm_certificate.certificate_internal.domain_validation_options[count.index], "resource_record_name")}"
+  type    = "${lookup(aws_acm_certificate.certificate_internal.domain_validation_options[count.index], "resource_record_type")}"
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_dns_validation_zone_id}"
-  records = ["${aws_acm_certificate.certificate_internal.domain_validation_options.0.resource_record_value}"]
+  records = ["${lookup(aws_acm_certificate.certificate_internal.domain_validation_options[count.index], "resource_record_value")}"]
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "certificate_internal" {
   certificate_arn         = "${aws_acm_certificate.certificate_internal.arn}"
-  validation_record_fqdns = ["${aws_route53_record.certificate_internal_validation.fqdn}"]
+  validation_record_fqdns = ["${aws_route53_record.certificate_internal_validation.*.fqdn}"]
 }
 
 # Outputs

--- a/terraform/projects/infra-certificates/main.tf
+++ b/terraform/projects/infra-certificates/main.tf
@@ -1,0 +1,120 @@
+/**
+* ## Project: infra-certificates
+*
+* This module creates the environment certificates
+*/
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "S3 bucket we store our terraform state in"
+}
+
+variable "remote_state_infra_root_dns_zones_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_root_dns_zones remote state "
+  default     = ""
+}
+
+variable "certificate_external_domain_name" {
+  type        = "string"
+  description = "Domain name for which the external certificate should be issued"
+}
+
+variable "certificate_external_subject_alternative_names" {
+  type        = "list"
+  description = "List of domains that should be SANs in the external issued certificate"
+  default     = []
+}
+
+variable "certificate_internal_domain_name" {
+  type        = "string"
+  description = "Domain name for which the internal certificate should be issued"
+}
+
+variable "certificate_internal_subject_alternative_names" {
+  type        = "list"
+  description = "List of domains that should be SANs in the internal issued certificate"
+  default     = []
+}
+
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+}
+
+# Resources
+# --------------------------------------------------------------
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.40.0"
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
+    region = "${var.aws_region}"
+  }
+}
+
+resource "aws_acm_certificate" "certificate_external" {
+  domain_name               = "${var.certificate_external_domain_name}"
+  subject_alternative_names = ["${var.certificate_external_subject_alternative_names}"]
+  validation_method         = "DNS"
+}
+
+resource "aws_route53_record" "certificate_external_validation" {
+  name    = "${aws_acm_certificate.certificate_external.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.certificate_external.domain_validation_options.0.resource_record_type}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  records = ["${aws_acm_certificate.certificate_external.domain_validation_options.0.resource_record_value}"]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "certificate_external" {
+  certificate_arn         = "${aws_acm_certificate.certificate_external.arn}"
+  validation_record_fqdns = ["${aws_route53_record.certificate_external_validation.fqdn}"]
+}
+
+resource "aws_acm_certificate" "certificate_internal" {
+  domain_name               = "${var.certificate_internal_domain_name}"
+  subject_alternative_names = ["${var.certificate_internal_subject_alternative_names}"]
+  validation_method         = "DNS"
+}
+
+resource "aws_route53_record" "certificate_internal_validation" {
+  name    = "${aws_acm_certificate.certificate_internal.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.certificate_internal.domain_validation_options.0.resource_record_type}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_dns_validation_zone_id}"
+  records = ["${aws_acm_certificate.certificate_internal.domain_validation_options.0.resource_record_value}"]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "certificate_internal" {
+  certificate_arn         = "${aws_acm_certificate.certificate_internal.arn}"
+  validation_record_fqdns = ["${aws_route53_record.certificate_internal_validation.fqdn}"]
+}
+
+# Outputs
+# --------------------------------------------------------------
+
+output "external_certificate_arn" {
+  value       = "${aws_acm_certificate_validation.certificate_external.certificate_arn}"
+  description = "ARN of the external certificate"
+}
+
+output "internal_certificate_arn" {
+  value       = "${aws_acm_certificate_validation.certificate_internal.certificate_arn}"
+  description = "ARN of the internal certificate"
+}

--- a/terraform/projects/infra-certificates/training.govuk.backend
+++ b/terraform/projects/infra-certificates/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/infra-certificates.tfstate"
+encrypt = true
+region  = "eu-west-2"

--- a/terraform/projects/infra-root-dns-zones/README.md
+++ b/terraform/projects/infra-root-dns-zones/README.md
@@ -10,6 +10,7 @@ This module creates the internal and external root DNS zones.
 | aws_region | AWS region | string | `eu-west-1` | no |
 | create_external_zone | Create an external DNS zone (default true) | string | `true` | no |
 | create_internal_zone | Create an internal DNS zone (default true) | string | `true` | no |
+| create_internal_zone_dns_validation | Create a public DNS zone to validate the internal domain certificate (default false) | string | `false` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
 | root_domain_external_name | External DNS root domain name. Override default for Integration, Staging, Production if create_external_zone is true | string | `mydomain.external` | no |
@@ -22,6 +23,7 @@ This module creates the internal and external root DNS zones.
 |------|-------------|
 | external_root_domain_name | Route53 External Root Domain Name |
 | external_root_zone_id | Route53 External Root Zone ID |
+| internal_root_dns_validation_zone_id | Route53 Zone ID for DNS certificate validation of the internal domain |
 | internal_root_domain_name | Route53 Internal Root Domain Name |
 | internal_root_zone_id | Route53 Internal Root Zone ID |
 

--- a/terraform/projects/infra-root-dns-zones/main.tf
+++ b/terraform/projects/infra-root-dns-zones/main.tf
@@ -44,6 +44,12 @@ variable "root_domain_external_name" {
   default     = "mydomain.external"
 }
 
+variable "create_internal_zone_dns_validation" {
+  type        = "string"
+  description = "Create a public DNS zone to validate the internal domain certificate (default false)"
+  default     = false
+}
+
 variable "stackname" {
   type        = "string"
   description = "Stackname"
@@ -90,6 +96,15 @@ resource "aws_route53_zone" "external_zone" {
   }
 }
 
+resource "aws_route53_zone" "internal_zone_dns_validation" {
+  count = "${var.create_internal_zone_dns_validation}"
+  name  = "${var.root_domain_internal_name}"
+
+  tags {
+    Project = "infra-root-dns-zones"
+  }
+}
+
 # Outputs
 # --------------------------------------------------------------
 
@@ -111,4 +126,9 @@ output "external_root_zone_id" {
 output "external_root_domain_name" {
   value       = "${join("", aws_route53_zone.external_zone.*.name)}"
   description = "Route53 External Root Domain Name"
+}
+
+output "internal_root_dns_validation_zone_id" {
+  value       = "${join("", aws_route53_zone.internal_zone_dns_validation.*.zone_id)}"
+  description = "Route53 Zone ID for DNS certificate validation of the internal domain"
 }


### PR DESCRIPTION
The environment certificates have so far been created manually in AWS and
validated with Email: https://github.com/alphagov/govuk-aws/blob/master/doc/guides/certificate-validation.md

Now we want to manage these certificates with Terraform and use DNS validation (originally this
was not an option).

We need to create a public Route53 zone for the private domain to be able to validate the
certificate. The certificates will be managed in a new project called `infra-certificates` that
requires `infra-root-dns-zones` outputs.

`infra-certificates` contains outputs resources that ensure the certificate has been successfully validated:
https://www.terraform.io/docs/providers/aws/r/acm_certificate_validation.html

These outputs could be used by other projects to get the certificate ARN instead of data resources.

Pair: @afda16 @camdesgov