### PR TITLE
Manage SOPS KMS key

### DIFF
--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -6,6 +6,7 @@ Infrastructure security settings:
  - Default IAM password policy
  - Default SSH key
  - CloudTrail settings and alarms
+ - SOPS KMS key
 
 
 ## Inputs
@@ -24,4 +25,10 @@ Infrastructure security settings:
 | role_user_user_arns | List of ARNs of external users that can assume the role | list | `<list>` | no |
 | ssh_public_key | The public part of an SSH keypair | string | - | yes |
 | stackname | Stackname | string | `` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| sops_kms_key_arn | The ARN of the Sops KMS key |
 


### PR DESCRIPTION
The SOPS KMS key has been created manually in the past. We want to add this resource
to `infra-security` to remove manual steps from an environment bootstrap.

We'll need to import the KMS resources into the existing environments