### PR TITLE
Added training environment option

### DIFF
--- a/tools/govukcli
+++ b/tools/govukcli
@@ -9,7 +9,7 @@ set -e
 ### Global settings
 CONFIG_DIR=~/.govukcli
 CONTEXT_FILE=$CONFIG_DIR/current-context
-CONTEXTS='ci test tools integration staging production staging-aws production-aws'
+CONTEXTS='ci test tools integration staging production training staging-aws production-aws'
 
 ### Help output
 function usage {


### PR DESCRIPTION
Added training item to CONTEXTS array, gdscli aws
command can now be used with the new training environment,
ssh training option will need to be updated after we have set up
the jumpbox.