### PR TITLE
Bump elasticsearch data node size to r4.xlarge

### DIFF
--- a/terraform/projects/app-elasticsearch5/README.md
+++ b/terraform/projects/app-elasticsearch5/README.md
@@ -34,7 +34,7 @@ doesn't support:
 | elasticsearch5_ebs_size | The amount of EBS storage to attach | string | `32` | no |
 | elasticsearch5_ebs_type | The type of EBS storage to attach | string | `gp2` | no |
 | elasticsearch5_instance_count | The number of ElasticSearch nodes | string | `6` | no |
-| elasticsearch5_instance_type | The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported | string | `r4.large.elasticsearch` | no |
+| elasticsearch5_instance_type | The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported | string | `r4.xlarge.elasticsearch` | no |
 | elasticsearch5_manual_snapshot_bucket_arns | Bucket ARNs this domain can read/write for manual snapshots | list | `<list>` | no |
 | elasticsearch5_master_instance_count | Number of dedicated master nodes in the cluster | string | `3` | no |
 | elasticsearch5_master_instance_type | Instance type of the dedicated master nodes in the cluster | string | `c4.large.elasticsearch` | no |

--- a/terraform/projects/app-elasticsearch5/main.tf
+++ b/terraform/projects/app-elasticsearch5/main.tf
@@ -41,7 +41,7 @@ variable "stackname" {
 variable "elasticsearch5_instance_type" {
   type        = "string"
   description = "The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported"
-  default     = "r4.large.elasticsearch"
+  default     = "r4.xlarge.elasticsearch"
 }
 
 variable "elasticsearch5_instance_count" {


### PR DESCRIPTION
- We were still seeing performance issues with the cluster
- AWS recommends to keep the cluster size under 10

solo: @schmie