### PR TITLE
Configure remote state bucket region with variable

### DIFF
--- a/terraform/projects/app-apt/remote_state.tf
+++ b/terraform/projects/app-apt/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-asset-master/remote_state.tf
+++ b/terraform/projects/app-asset-master/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-backend-redis/remote_state.tf
+++ b/terraform/projects/app-backend-redis/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-backend/remote_state.tf
+++ b/terraform/projects/app-backend/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-bouncer/remote_state.tf
+++ b/terraform/projects/app-bouncer/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-cache/remote_state.tf
+++ b/terraform/projects/app-cache/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-calculators-frontend/remote_state.tf
+++ b/terraform/projects/app-calculators-frontend/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-ckan/remote_state.tf
+++ b/terraform/projects/app-ckan/remote_state.tf
@@ -25,25 +25,25 @@ variable "remote_state_infra_networking_key_stack" {
 
 variable "remote_state_infra_security_groups_key_stack" {
   type        = "string"
-  description = "Override infra_security_groups stackname path to infra_vpc remote state"
+  description = "Override infra_security_groups stackname path to infra_vpc remote state "
   default     = ""
 }
 
 variable "remote_state_infra_root_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_root_dns_zones remote state"
+  description = "Override stackname path to infra_root_dns_zones remote state "
   default     = ""
 }
 
 variable "remote_state_infra_stack_dns_zones_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_stack_dns_zones remote state"
+  description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
 variable "remote_state_infra_monitoring_key_stack" {
   type        = "string"
-  description = "Override stackname path to infra_monitoring remote state"
+  description = "Override stackname path to infra_monitoring remote state "
   default     = ""
 }
 
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-content-data-api-db-admin/remote_state.tf
+++ b/terraform/projects/app-content-data-api-db-admin/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-content-data-api-postgresql/remote_state.tf
+++ b/terraform/projects/app-content-data-api-postgresql/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-content-store/remote_state.tf
+++ b/terraform/projects/app-content-store/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-data-science/remote_state.tf
+++ b/terraform/projects/app-data-science/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-2"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-2"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-2"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-2"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-2"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-2"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-db-admin/remote_state.tf
+++ b/terraform/projects/app-db-admin/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-deploy/remote_state.tf
+++ b/terraform/projects/app-deploy/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-docker-management/remote_state.tf
+++ b/terraform/projects/app-docker-management/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-draft-cache/remote_state.tf
+++ b/terraform/projects/app-draft-cache/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-draft-content-store/remote_state.tf
+++ b/terraform/projects/app-draft-content-store/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-draft-frontend/remote_state.tf
+++ b/terraform/projects/app-draft-frontend/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-elasticsearch5/remote_state.tf
+++ b/terraform/projects/app-elasticsearch5/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-email-alert-api-db-admin/remote_state.tf
+++ b/terraform/projects/app-email-alert-api-db-admin/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-email-alert-api-postgresql/remote_state.tf
+++ b/terraform/projects/app-email-alert-api-postgresql/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-email-alert-api/remote_state.tf
+++ b/terraform/projects/app-email-alert-api/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-frontend/remote_state.tf
+++ b/terraform/projects/app-frontend/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-graphite/remote_state.tf
+++ b/terraform/projects/app-graphite/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-jumpbox/remote_state.tf
+++ b/terraform/projects/app-jumpbox/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-mapit/remote_state.tf
+++ b/terraform/projects/app-mapit/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-mirrorer/remote_state.tf
+++ b/terraform/projects/app-mirrorer/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-mongo-api/remote_state.tf
+++ b/terraform/projects/app-mongo-api/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-mongo/remote_state.tf
+++ b/terraform/projects/app-mongo/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-monitoring/remote_state.tf
+++ b/terraform/projects/app-monitoring/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-mysql/remote_state.tf
+++ b/terraform/projects/app-mysql/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-postgresql/remote_state.tf
+++ b/terraform/projects/app-postgresql/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-publishing-api-db-admin/remote_state.tf
+++ b/terraform/projects/app-publishing-api-db-admin/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-publishing-api-postgresql/remote_state.tf
+++ b/terraform/projects/app-publishing-api-postgresql/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-publishing-api/remote_state.tf
+++ b/terraform/projects/app-publishing-api/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-puppetmaster/remote_state.tf
+++ b/terraform/projects/app-puppetmaster/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-rabbitmq/remote_state.tf
+++ b/terraform/projects/app-rabbitmq/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-router-backend/remote_state.tf
+++ b/terraform/projects/app-router-backend/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-search/remote_state.tf
+++ b/terraform/projects/app-search/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-transition-db-admin/remote_state.tf
+++ b/terraform/projects/app-transition-db-admin/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-transition-postgresql/remote_state.tf
+++ b/terraform/projects/app-transition-postgresql/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-ubuntu-test/remote_state.tf
+++ b/terraform/projects/app-ubuntu-test/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-warehouse-db-admin/remote_state.tf
+++ b/terraform/projects/app-warehouse-db-admin/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-warehouse/remote_state.tf
+++ b/terraform/projects/app-warehouse/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-whitehall-backend/remote_state.tf
+++ b/terraform/projects/app-whitehall-backend/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-whitehall-frontend/remote_state.tf
+++ b/terraform/projects/app-whitehall-frontend/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/fastly-datagovuk/README.md
+++ b/terraform/projects/fastly-datagovuk/README.md
@@ -8,6 +8,7 @@ Manages the Fastly service for data.gov.uk
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
 | backend_domain | The domain of the data.gov.uk PaaS instance to forward requests to | string | - | yes |
 | domain | The domain of the data.gov.uk service to manage | string | - | yes |
 | fastly_api_key | API key to authenticate with Fastly | string | - | yes |

--- a/terraform/projects/fastly-datagovuk/main.tf
+++ b/terraform/projects/fastly-datagovuk/main.tf
@@ -3,6 +3,11 @@
 *
 * Manages the Fastly service for data.gov.uk
 */
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
 
 variable "stackname" {
   type        = "string"

--- a/terraform/projects/fastly-datagovuk/remote_state.tf
+++ b/terraform/projects/fastly-datagovuk/remote_state.tf
@@ -56,7 +56,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -66,7 +66,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -76,7 +76,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -86,7 +86,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -96,7 +96,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -106,6 +106,6 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }

--- a/tools/generate-remote-state-boiler-plate.sh
+++ b/tools/generate-remote-state-boiler-plate.sh
@@ -68,7 +68,7 @@ data "terraform_remote_state" "infra_vpc" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -78,7 +78,7 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -88,7 +88,7 @@ data "terraform_remote_state" "infra_security_groups" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -98,7 +98,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -108,7 +108,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 
@@ -118,7 +118,7 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 EOT


### PR DESCRIPTION
The new Training environment and the Tools environment are deployed in
a different region from the default one (eu-west-1). We need to configure
the remote state bucket location with the global variable `aws_region` to
be able to fetch the remote state file from the right location.

This change needs to be applied to the `generate-remote-state-boiler-plate.sh`
and the generated manifests to avoid being overwritten in the future.