### PR TITLE
Ignore malformed JSON on fastly logs tables

### DIFF
--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -216,7 +216,8 @@ resource "aws_glue_catalog_table" "govuk_www" {
       name = "ser_de_name"
 
       parameters {
-        paths = "client_ip,request_received,request_received_offset,method,url,status,request_time,time_to_generate_response,bytes,content_type,user_agent,fastly_backend,data_centre,cache_hit,tls_client_protocol,tls_client_cipher"
+        paths                 = "client_ip,request_received,request_received_offset,method,url,status,request_time,time_to_generate_response,bytes,content_type,user_agent,fastly_backend,data_centre,cache_hit,tls_client_protocol,tls_client_cipher"
+        ignore.malformed.json = "true"
       }
 
       serialization_library = "org.openx.data.jsonserde.JsonSerDe"
@@ -396,7 +397,8 @@ resource "aws_glue_catalog_table" "govuk_assets" {
       name = "ser_de_name"
 
       parameters {
-        paths = "client_ip,request_received,request_received_offset,method,url,status,request_time,time_to_generate_response,bytes,content_type,user_agent,fastly_backend,data_centre,cache_hit,tls_client_protocol,tls_client_cipher"
+        paths                 = "client_ip,request_received,request_received_offset,method,url,status,request_time,time_to_generate_response,bytes,content_type,user_agent,fastly_backend,data_centre,cache_hit,tls_client_protocol,tls_client_cipher"
+        ignore.malformed.json = "true"
       }
 
       serialization_library = "org.openx.data.jsonserde.JsonSerDe"
@@ -576,7 +578,8 @@ resource "aws_glue_catalog_table" "bouncer" {
       name = "ser_de_name"
 
       parameters {
-        paths = "client_ip,request_received,request_received_offset,method,url,status,request_time,time_to_generate_response,content_type,user_agent,data_centre,cache_hit"
+        paths                 = "client_ip,request_received,request_received_offset,method,url,status,request_time,time_to_generate_response,content_type,user_agent,data_centre,cache_hit"
+        ignore.malformed.json = "true"
       }
 
       serialization_library = "org.openx.data.jsonserde.JsonSerDe"


### PR DESCRIPTION
We were still seeing errors of "HIVE_CURSOR_ERROR: Row is not a valid
JSON Object - JSONException: Unterminated string at 227 [character 228
line 1]" when querying athena. Some tracing indicates that this occurs
when a log entry terminates early, therfore outputting invalid JSON.

In OpenX JSON SerDe there is an option to ignore malformed JSON [1],
this commit applies this to our tables so these erroneous results can be
ignored.

[1]: https://docs.aws.amazon.com/athena/latest/ug/json.html#openxjson

Runs of [plan](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1137/) and [apply](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1138/) to test environment. Note the fails for apply are due to s3 user already existing, terraform and IAM don't play super nice.