### PR TITLE
app-puppetmaster add support for non-blued infrastructure

### DIFF
--- a/terraform/projects/app-puppetmaster/README.md
+++ b/terraform/projects/app-puppetmaster/README.md
@@ -12,6 +12,8 @@ Puppetmaster node
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | enable_bootstrap | Whether to create the ELB which allows a user to SSH to the Puppetmaster from the office | string | `false` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name. | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | puppetmaster_instance_type | Instance type for the mirrorer instance | string | `m5.xlarge` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |


### PR DESCRIPTION
We want to start provisioning the Training environment app projects
without the `blue` or stack-based DNS/LB infrastructure, but the code
has to be able to support the current design in integration/staging/production
and the new one at the same time.

Already, the training doesn't have a stack Route53 zone (`infra-stack-dns-zones`
hasn't been applied), so the remote_state data resource `infra_stack_dns_zones`
can't be used in the code.

This new solution uses the `aws_route53_zone` data resource instead of the remote
state files to make it easier to understand what the code needs to implement. The
variables that determine the domain/zone name are required, which
forces the user to add the correct configuration in the data repository.