### PR TITLE
Configure apps datasource in Puppetmaster bootstrap script

### DIFF
--- a/tools/govuk-puppetmaster-integration-bootstrap.sh
+++ b/tools/govuk-puppetmaster-integration-bootstrap.sh
@@ -89,6 +89,11 @@ then
   then
     cp ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/${GOVUK_STACKNAME}/${GOVUK_ENVIRONMENT}_credentials.yaml ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/${GOVUK_STACKNAME}/production_credentials.yaml
   fi
+
+  if [[ -f "${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/apps/${GOVUK_ENVIRONMENT}_credentials.yaml" ]]
+  then
+    cp ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/apps/${GOVUK_ENVIRONMENT}_credentials.yaml ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/apps/production_credentials.yaml
+  fi
 fi
 
 # Move puppet release to the expected location

--- a/tools/govuk-puppetmaster-production-bootstrap.sh
+++ b/tools/govuk-puppetmaster-production-bootstrap.sh
@@ -89,6 +89,11 @@ then
   then
     cp ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/${GOVUK_STACKNAME}/${GOVUK_ENVIRONMENT}_credentials.yaml ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/${GOVUK_STACKNAME}/production_credentials.yaml
   fi
+
+  if [[ -f "${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/apps/${GOVUK_ENVIRONMENT}_credentials.yaml" ]]
+  then
+    cp ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/apps/${GOVUK_ENVIRONMENT}_credentials.yaml ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/apps/production_credentials.yaml
+  fi
 fi
 
 # Move puppet release to the expected location

--- a/tools/govuk-puppetmaster-staging-bootstrap.sh
+++ b/tools/govuk-puppetmaster-staging-bootstrap.sh
@@ -89,6 +89,11 @@ then
   then
     cp ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/${GOVUK_STACKNAME}/${GOVUK_ENVIRONMENT}_credentials.yaml ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/${GOVUK_STACKNAME}/production_credentials.yaml
   fi
+
+  if [[ -f "${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/apps/${GOVUK_ENVIRONMENT}_credentials.yaml" ]]
+  then
+    cp ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/apps/${GOVUK_ENVIRONMENT}_credentials.yaml ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/apps/production_credentials.yaml
+  fi
 fi
 
 # Move puppet release to the expected location

--- a/tools/govuk-puppetmaster-training-bootstrap.sh
+++ b/tools/govuk-puppetmaster-training-bootstrap.sh
@@ -84,6 +84,10 @@ then
   cp ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/${GOVUK_ENVIRONMENT}.yaml ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/production.yaml
   cp ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/${GOVUK_ENVIRONMENT}_credentials.yaml ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/production_credentials.yaml
 
+  if [[ -f "${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/apps/${GOVUK_ENVIRONMENT}_credentials.yaml" ]]
+  then
+    cp ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/apps/${GOVUK_ENVIRONMENT}_credentials.yaml ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/apps/production_credentials.yaml
+  fi
 fi
 
 # Move puppet release to the expected location


### PR DESCRIPTION
In the Puppetmaster bootstrap we need to override the `apps/production_credentials.yaml`
datasource with the equivalent environment file. Otherwise, Puppet tries to decrypt
the production file with the wrong key.

This process is already implemented in the Puppet deployments:
https://github.com/alphagov/govuk-secrets/blob/master/puppet_aws/config/deploy.rb#L45-L47