### PR TITLE
Add app-jumpbox support for non-blued environments and training envir…

### DIFF
--- a/terraform/projects/app-jumpbox/README.md
+++ b/terraform/projects/app-jumpbox/README.md
@@ -9,6 +9,8 @@ Jumpbox node
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
+| external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -25,6 +25,16 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
+variable "external_zone_name" {
+  type        = "string"
+  description = "The name of the Route53 zone that contains external records"
+}
+
+variable "external_domain_name" {
+  type        = "string"
+  description = "The domain name of the external DNS records, it could be different from the zone name"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -35,6 +45,11 @@ terraform {
 provider "aws" {
   region  = "${var.aws_region}"
   version = "1.40.0"
+}
+
+data "aws_route53_zone" "external" {
+  name         = "${var.external_zone_name}"
+  private_zone = false
 }
 
 resource "aws_elb" "jumpbox_external_elb" {
@@ -73,8 +88,8 @@ resource "aws_elb" "jumpbox_external_elb" {
 }
 
 resource "aws_route53_record" "service_record" {
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
-  name    = "jumpbox.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
+  zone_id = "${data.aws_route53_zone.external.zone_id}"
+  name    = "jumpbox.${var.external_domain_name}"
   type    = "A"
 
   alias {

--- a/terraform/projects/app-jumpbox/training.govuk.backend
+++ b/terraform/projects/app-jumpbox/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-jumpbox.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
…onment

Update the app-jumpbox project to read Route53 configuration from variables
instead of remote state files. This allows us to support the non-blued implementation
on the new Training environment.