### PR TITLE
Added infra-artefacts-bucket project to training environment

### DIFF
--- a/terraform/projects/infra-artefact-bucket/README.md
+++ b/terraform/projects/infra-artefact-bucket/README.md
@@ -27,15 +27,13 @@ This module creates the following.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | artefact_source | Identifies the source artefact environment | string | - | yes |
-| aws_account_id | The AWS Account ID | string | - | yes |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
-| aws_s3_access_account | Here we define the account that will have access to the Artefact S3 bucket. | string | - | yes |
+| aws_s3_access_account | Here we define the account that will have access to the Artefact S3 bucket. | list | - | yes |
 | aws_secondary_region | Secondary region for cross-replication | string | `eu-west-2` | no |
 | aws_subscription_account_id | The AWS Account ID that will appear on the subscription | string | - | yes |
 | create_sns_subscription | Indicates whether to create an SNS subscription | string | `false` | no |
 | create_sns_topic | Indicates whether to create an SNS Topic | string | `false` | no |
-| deployer_role | Define the role name used by the Jenkins deployer | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | stackname | Stackname | string | - | yes |

--- a/terraform/projects/infra-artefact-bucket/training.govuk.backend
+++ b/terraform/projects/infra-artefact-bucket/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/infra-artefact-bucket.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
We changed the bucket policy from inline to a terraform data
object, this way it's easier to implement empty variables.
We also changed the aws_s3_access_account variable to
a list to make it more flexible, because the integration environment
needs access from more than a single aws account.

We also removed a variable that was no longer in use "deployer_role".
Finally we added the terraform backend file.

Co-authored-by: @afda16