### PR TITLE
Add fix for training infra-artefact-bucket SNS subscription

### DIFF
--- a/terraform/projects/infra-artefact-bucket/README.md
+++ b/terraform/projects/infra-artefact-bucket/README.md
@@ -32,6 +32,7 @@ This module creates the following.
 | aws_s3_access_account | Here we define the account that will have access to the Artefact S3 bucket. | list | - | yes |
 | aws_secondary_region | Secondary region for cross-replication | string | `eu-west-2` | no |
 | aws_subscription_account_id | The AWS Account ID that will appear on the subscription | string | - | yes |
+| aws_subscription_account_region | AWS region of the SNS topic | string | `eu-west-1` | no |
 | create_sns_subscription | Indicates whether to create an SNS subscription | string | `false` | no |
 | create_sns_topic | Indicates whether to create an SNS Topic | string | `false` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/infra-artefact-bucket/main.tf
+++ b/terraform/projects/infra-artefact-bucket/main.tf
@@ -56,6 +56,12 @@ variable "create_sns_subscription" {
   description = "Indicates whether to create an SNS subscription"
 }
 
+variable "aws_subscription_account_region" {
+  type        = "string"
+  default     = "eu-west-1"
+  description = "AWS region of the SNS topic"
+}
+
 variable "artefact_source" {
   type        = "string"
   description = "Identifies the source artefact environment"
@@ -97,6 +103,12 @@ provider "aws" {
 provider "aws" {
   alias   = "secondary"
   region  = "${var.aws_secondary_region}"
+  version = "1.40.0"
+}
+
+provider "aws" {
+  alias   = "subscription"
+  region  = "${var.aws_subscription_account_region}"
   version = "1.40.0"
 }
 
@@ -260,7 +272,8 @@ resource "aws_s3_bucket_notification" "artefact_bucket_notification" {
 # AWS SNS Subscription
 resource "aws_sns_topic_subscription" "artefact_topic_subscription" {
   count     = "${var.create_sns_subscription ? 1 : 0}"
-  topic_arn = "arn:aws:sns:${var.aws_region}:${var.aws_subscription_account_id}:govuk-${var.artefact_source}-artefact"
+  provider  = "aws.subscription"
+  topic_arn = "arn:aws:sns:${var.aws_subscription_account_region}:${var.aws_subscription_account_id}:govuk-${var.artefact_source}-artefact"
   protocol  = "lambda"
   endpoint  = "arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.current.account_id}:function:govuk-${var.aws_environment}-artefact"
 }


### PR DESCRIPTION
The SNS suscription is region specific. We have added a new
provider block to the main.tf file to solve a permissions
error.