### PR TITLE
Update app-deploy for Training and non-blued support

### DIFF
--- a/terraform/projects/app-deploy/README.md
+++ b/terraform/projects/app-deploy/README.md
@@ -11,9 +11,14 @@ Deploy node
 | aws_region | AWS region | string | `eu-west-1` | no |
 | deploy_subnet | Name of the subnet to place the apt instance 1 and EBS volume | string | - | yes |
 | ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
-| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| elb_external_certname | The ACM cert domain name to find the ARN of | list | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| enable_public_alb | Enable the use of ALBs for public access or use original ELB resources instead | string | `false` | no |
+| external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
+| external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_artefact_bucket_key_stack | Override infra_artefact_bucket remote state path | string | `` | no |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
@@ -29,5 +34,6 @@ Deploy node
 
 | Name | Description |
 |------|-------------|
+| deploy_alb_dns_name | DNS name to access the deploy service |
 | deploy_elb_dns_name | DNS name to access the deploy service |
 

--- a/terraform/projects/app-deploy/training.govuk.backend
+++ b/terraform/projects/app-deploy/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-deploy.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Update the app-deploy project to support non-blued infrastructure in
the new Training environment:
- we need to retrieve Route53 zones from variables instead of remote state files
- we need to bring the public ALB logic from infra-public-services to this module. This
needs to be optional. The default behaviour is to keep the original external ELB. If
we configure the variable `enable_public_alb` to true, the module does not create the
external ELB and creates a public ALB with same settings as originally implemented in
`infra-public-services`

We choose not to continue using the `lb` module because the code is complicated and
we are using LB resources in a simple way. We can investigate later if we can/need to
manage something in modules. For now we extracted the CloudWatch metrics to its own
module, same as other AWS resources.