### PR TITLE
add the fastly listeners to monitoring box elb

### DIFF
--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -88,6 +88,33 @@ resource "aws_elb" "monitoring_external_elb" {
     ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
   }
 
+  listener {
+    instance_port     = 6514
+    instance_protocol = "tcp"
+    lb_port           = 6514
+    lb_protocol       = "ssl"
+
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
+  }
+
+  listener {
+    instance_port     = 6515
+    instance_protocol = "tcp"
+    lb_port           = 6515
+    lb_protocol       = "ssl"
+
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
+  }
+
+  listener {
+    instance_port     = 6516
+    instance_protocol = "tcp"
+    lb_port           = 6516
+    lb_protocol       = "ssl"
+
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
+  }
+
   health_check {
     healthy_threshold   = 2
     unhealthy_threshold = 2

--- a/terraform/projects/infra-security-groups/monitoring.tf
+++ b/terraform/projects/infra-security-groups/monitoring.tf
@@ -152,6 +152,7 @@ resource "aws_security_group_rule" "monitoring-internal-elb_egress_any_any" {
   security_group_id = "${aws_security_group.monitoring_internal_elb.id}"
 }
 
+# Allows access to the monitoring machine from its ELB on specified ports
 resource "aws_security_group_rule" "monitoring_ingress_monitoring-elb_syslog-tls" {
   type      = "ingress"
   from_port = 6514
@@ -165,10 +166,11 @@ resource "aws_security_group_rule" "monitoring_ingress_monitoring-elb_syslog-tls
   source_security_group_id = "${aws_security_group.monitoring_external_elb.id}"
 }
 
+# Allows access to the monitoring ELB from fastly IPs on specified ports
 resource "aws_security_group_rule" "monitoring-elb_ingress_fastly_syslog-tls" {
   type              = "ingress"
-  to_port           = 6516
   from_port         = 6514
+  to_port           = 6516
   protocol          = "tcp"
   security_group_id = "${aws_security_group.monitoring_external_elb.id}"
   cidr_blocks       = ["${data.fastly_ip_ranges.fastly.cidr_blocks}"]


### PR DESCRIPTION
# Context

For the CDN logs migration to AWS, we need to add the listeners to the ELB of the monitoring box so that fastly can reach these boxes.

# Decisions
1. add listeners for fastly to monitoring elb