### PR TITLE
Fix to app-puppet master module ELB list

### DIFF
--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -201,7 +201,7 @@ module "puppetmaster" {
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_puppetmaster_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "${var.puppetmaster_instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
-  instance_elb_ids              = ["${aws_elb.puppetmaster_bootstrap_elb.*.id}", "${aws_elb.puppetmaster_internal_elb.id}"]
+  instance_elb_ids              = ["${aws_elb.puppetmaster_internal_elb.id}", "${aws_elb.puppetmaster_bootstrap_elb.*.id}"]
   instance_elb_ids_length       = "${var.enable_bootstrap > 0 ? 2 : 1}"
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"


### PR DESCRIPTION
To avoid the internal loadbalancer being destroyed and recreated
we have swapped the resource's position in the "instance_elb_ids" list. Please
see below for an in-depth explanation on why this was necessary.

When setting up a new environment, we run the app-puppet master project
twice. The first time we run the project the "enable_bootstrap" variable
needs to be set to true. This will create a bootstrap ELB that will allow
us to access the puppetmaster instance and check that everything is
configured correctly. An internal ELB will also be created by default.

When we are happy that the puppet master instance is set up
and working, we then run the app-puppetmaster terraform project
again, this time with the "enable_bootstrap" variable set to false. This will
remove the bootstrap ELB as it is no longer needed and leave only the
internal ELB. However, the way terraform works with resources in lists
is to destroy a resource at it's current index and recreate it at a new
index. For example, if you wanted to remove element b from the list below:
[a, b, c]
terraform would destroy b AND c, then recreate the element c at index 1
eventually giving you:
[a,c]
It will NOT simply move c and delete b...To avoid the unnecessarily destroying
and recreating the internal load balancer we've swapped it's place in the list.