### PR TITLE
Fix terraform cloudwatch_log_exporter module deprecation warning

### DIFF
--- a/terraform/modules/aws/cloudwatch_log_exporter/main.tf
+++ b/terraform/modules/aws/cloudwatch_log_exporter/main.tf
@@ -53,9 +53,7 @@ variable "lambda_log_retention_in_days" {
 # Resources
 #--------------------------------------------------------------
 
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 


### PR DESCRIPTION
Deleted value in aws_region current block. According to the
documentation "aws_region" now defaults to the current provider
region:

https://www.terraform.io/docs/providers/aws/d/region.html