### PR TITLE
Update app-deploy for Training and make external ELB optional

### DIFF
--- a/terraform/projects/app-deploy/README.md
+++ b/terraform/projects/app-deploy/README.md
@@ -9,11 +9,16 @@ Deploy node
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| create_external_elb | Create the external ELB | string | `true` | no |
 | deploy_subnet | Name of the subnet to place the apt instance 1 and EBS volume | string | - | yes |
 | ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
+| external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_artefact_bucket_key_stack | Override infra_artefact_bucket remote state path | string | `` | no |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-deploy/training.govuk.backend
+++ b/terraform/projects/app-deploy/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-deploy.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Update the app-deploy project to support non-blued infrastructure in
the new Training environment:
- We need to retrieve Route53 zones from variables instead of remote state files
- Make the creation of the external ELB optional. By default the external ELB is
created, this is the expected behaviour in the existing environments. In Training,
we can choose not to create this ELB.