### PR TITLE
Update app-apt for Training environment

### DIFF
--- a/terraform/projects/app-apt/README.md
+++ b/terraform/projects/app-apt/README.md
@@ -13,7 +13,11 @@ Apt node
 | ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
+| external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-apt/training.govuk.backend
+++ b/terraform/projects/app-apt/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-apt.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add backend to build app-apt in the Training environment.

Add parameters to select which domain to use with the DNS records (Training
does not use the stack domain).

This project doesn't have a second public ALB in `infra-public-services`, because
the apt service in Production is common to all the infrastructure and it hasn't
been migrated to AWS yet.