### PR TITLE
Update app-db-admin for Training environment

### DIFF
--- a/terraform/projects/app-db-admin/README.md
+++ b/terraform/projects/app-db-admin/README.md
@@ -12,6 +12,8 @@ These nodes connect to RDS instances and administer them.
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_database_backups_bucket_key_stack | Override stackname path to infra_database_backups_bucket remote state | string | `` | no |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-db-admin/training.govuk.backend
+++ b/terraform/projects/app-db-admin/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-db-admin.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add backend to build app-apt in the Training environment.

Add parameters to select which domain to use with the DNS records (Training
does not use the stack domain). app-db-admin doesn't have external ELB/DNS record.