### PR TITLE
Add Training to infra-public-services

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -10,6 +10,7 @@ This project adds global resources for app components:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| app_stackname | Stackname of the app projects in this environment | string | `blue` | no |
 | apt_internal_service_names |  | list | `<list>` | no |
 | apt_public_service_cnames |  | list | `<list>` | no |
 | apt_public_service_names |  | list | `<list>` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -32,6 +32,12 @@ variable "elb_public_secondary_certname" {
   description = "The ACM secondary cert domain name to find the ARN of"
 }
 
+variable "app_stackname" {
+  type        = "string"
+  description = "Stackname of the app projects in this environment"
+  default     = "blue"
+}
+
 variable "apt_public_service_names" {
   type    = "list"
   default = []
@@ -1024,7 +1030,7 @@ data "aws_autoscaling_groups" "deploy" {
 
   filter {
     name   = "value"
-    values = ["blue-deploy"]
+    values = ["${var.app_stackname}-deploy"]
   }
 }
 


### PR DESCRIPTION
We need a new variable to select the value of the app stackname on
each environment. Defaults to previous static value, there should be
no changes in the existing environments.