### PR TITLE
Make Jumpbox external ELB optional for Training

### DIFF
--- a/terraform/projects/app-jumpbox/README.md
+++ b/terraform/projects/app-jumpbox/README.md
@@ -9,6 +9,7 @@ Jumpbox node
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| create_external_elb | Create the external ELB | string | `true` | no |
 | external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -35,6 +35,11 @@ variable "external_domain_name" {
   description = "The domain name of the external DNS records, it could be different from the zone name"
 }
 
+variable "create_external_elb" {
+  description = "Create the external ELB"
+  default     = true
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -53,6 +58,8 @@ data "aws_route53_zone" "external" {
 }
 
 resource "aws_elb" "jumpbox_external_elb" {
+  count = "${var.create_external_elb}"
+
   name            = "${var.stackname}-jumpbox"
   subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_offsite_ssh_id}"]
@@ -88,6 +95,8 @@ resource "aws_elb" "jumpbox_external_elb" {
 }
 
 resource "aws_route53_record" "service_record" {
+  count = "${var.create_external_elb}"
+
   zone_id = "${data.aws_route53_zone.external.zone_id}"
   name    = "jumpbox.${var.external_domain_name}"
   type    = "A"
@@ -99,6 +108,11 @@ resource "aws_route53_record" "service_record" {
   }
 }
 
+locals {
+  instance_elb_ids_length = "${var.create_external_elb ? 1 : 0}"
+  instance_elb_ids        = "${compact(list(join("", aws_elb.jumpbox_external_elb.*.id)))}"
+}
+
 module "jumpbox" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-jumpbox"
@@ -108,35 +122,40 @@ module "jumpbox" {
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_jumpbox_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "t2.micro"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
-  instance_elb_ids              = ["${aws_elb.jumpbox_external_elb.id}"]
-  instance_elb_ids_length       = "1"
+  instance_elb_ids              = ["${local.instance_elb_ids}"]
+  instance_elb_ids_length       = "${local.instance_elb_ids_length}"
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
   root_block_device_volume_size = "64"
+}
+
+locals {
+  surgequeuelength_threshold = "${var.create_external_elb ? 200 : 0}"
+  healthyhostcount_threshold = "${var.create_external_elb ? 1 : 0}"
 }
 
 module "alarms-elb-jumpbox-internal" {
   source                         = "../../modules/aws/alarms/elb"
   name_prefix                    = "${var.stackname}-jumpbox-external"
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  elb_name                       = "${aws_elb.jumpbox_external_elb.name}"
+  elb_name                       = "${join("", aws_elb.jumpbox_external_elb.*.name)}"
   httpcode_backend_4xx_threshold = "0"
   httpcode_backend_5xx_threshold = "0"
   httpcode_elb_4xx_threshold     = "0"
   httpcode_elb_5xx_threshold     = "0"
-  surgequeuelength_threshold     = "200"
-  healthyhostcount_threshold     = "1"
+  surgequeuelength_threshold     = "${local.surgequeuelength_threshold}"
+  healthyhostcount_threshold     = "${local.healthyhostcount_threshold}"
 }
 
 # Outputs
 # --------------------------------------------------------------
 
 output "jumpbox_elb_address" {
-  value       = "${aws_elb.jumpbox_external_elb.dns_name}"
+  value       = "${join("", aws_elb.jumpbox_external_elb.*.dns_name)}"
   description = "AWS' internal DNS name for the jumpbox ELB"
 }
 
 output "service_dns_name" {
-  value       = "${aws_route53_record.service_record.name}"
+  value       = "${join("", aws_route53_record.service_record.*.name)}"
   description = "DNS name to access the node service"
 }

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1510,7 +1510,7 @@ data "aws_autoscaling_groups" "jumpbox" {
 
   filter {
     name   = "value"
-    values = ["blue-jumpbox"]
+    values = ["${var.app_stackname}-jumpbox"]
   }
 }
 
@@ -1518,6 +1518,19 @@ resource "aws_autoscaling_attachment" "jumpbox_asg_attachment_elb" {
   count                  = "${length(data.aws_autoscaling_groups.jumpbox.names) > 0 ? 1 : 0}"
   autoscaling_group_name = "${element(data.aws_autoscaling_groups.jumpbox.names, 0)}"
   elb                    = "${aws_elb.jumpbox_public_elb.id}"
+}
+
+module "alarms-elb-jumpbox-public" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-jumpbox"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  elb_name                       = "${aws_elb.jumpbox_public_elb.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "0"
+  httpcode_elb_4xx_threshold     = "0"
+  httpcode_elb_5xx_threshold     = "0"
+  surgequeuelength_threshold     = "200"
+  healthyhostcount_threshold     = "1"
 }
 
 #


### PR DESCRIPTION
We want to make the creation of the external ELB in the `app-jumpbox`
project optional. The `infra-public-services` project didn't have
any alarms for this same Jumpbox ELB , so that needs to be added too.