### PR TITLE
Update app-monitoring for Training environment

### DIFF
--- a/terraform/projects/app-monitoring/README.md
+++ b/terraform/projects/app-monitoring/README.md
@@ -12,7 +12,11 @@ Monitoring node
 | ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
+| external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | monitoring_subnet | Name of the subnet to place the monitoring instance and the EBS volume | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-monitoring/training.govuk.backend
+++ b/terraform/projects/app-monitoring/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-monitoring.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add backend to build app-monitoring in the Training environment.

Add parameters to select which domain to use with the DNS records (Training
does not use the stack domain). app-monitoring doesn't have external ELB/DNS record