### PR TITLE
increase the size of the monitoring box

### DIFF
--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -224,6 +224,7 @@ module "monitoring" {
   instance_elb_ids              = ["${aws_elb.monitoring_external_elb.id}", "${aws_elb.monitoring_internal_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "40"
 }
 
 resource "aws_ebs_volume" "monitoring" {


### PR DESCRIPTION
# Context

The size of the root partition of the monitoring box should be increased to take into account the logs.

# Decisions
1. increase the root partition size from 20gb to 40gb