### PR TITLE
Update app-content-data-api-db-admin for training environment

### DIFF
--- a/terraform/projects/app-content-data-api-db-admin/main.tf
+++ b/terraform/projects/app-content-data-api-db-admin/main.tf
@@ -77,7 +77,7 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_database_backups_bucket_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 

--- a/terraform/projects/app-content-data-api-db-admin/training.govuk.backend
+++ b/terraform/projects/app-content-data-api-db-admin/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-content-data-api-db-admin.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add terraform backend file for training environment
app-content-data-api-db-admin.

Update the database backups buckets to use the current aws region
automatically.