### PR TITLE
Update Environment Provisioning Doc

### DIFF
--- a/doc/guides/environment-provisioning.md
+++ b/doc/guides/environment-provisioning.md
@@ -259,7 +259,6 @@ Create the following projects (in no particular order):
 `app-db-admin`
 `app-content-data-api-db-admin`
 `app-transition-db-admin`
-`app-warehouse-db-admin`
 `app-graphite`
 `app-monitoring`
 


### PR DESCRIPTION
Remove reference to app-warehouse-db-admin as it is no longer used.
Please see this pull request for more information:
https://github.com/alphagov/govuk-aws/pull/929