### PR TITLE
Update app-backend-redis for training environment

### DIFF
--- a/terraform/projects/app-backend-redis/README.md
+++ b/terraform/projects/app-backend-redis/README.md
@@ -10,6 +10,8 @@ Backend VDC Redis Elasticache cluster
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | enable_clustering | Enable clustering | string | `false` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-backend-redis/training.govuk.backend
+++ b/terraform/projects/app-backend-redis/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-backend-redis.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add new terraform backend file for app-backend-redis

Add parameters to select which domain to use with the DNS records (Training
does not use the stack domain).