### PR TITLE
Add support for ALB routing with specific application health checks - Option2

### DIFF
--- a/terraform/modules/aws/lb_listener_rules/README.md
+++ b/terraform/modules/aws/lb_listener_rules/README.md
@@ -3,54 +3,32 @@
 This module creates Load Balancer listener rules and target groups for
 an existing listener resource.
 
-You can specify rules based on host header with the `rules_host` variable,
-path pattern with the `rules_path` variable, or both with the `rules_host_and_path`
-variable. Rules from the three variables are merged and prioritised in the order
-`rules_host_and_path`, `rules_host` and `rules_path`.
-
-The three variables are map types. The values of the maps define the target group
-port and protocol where requests are routed when they meet the rule condition, with
-the format TARGET_GROUP_PROTOCOL:TARGET_GROUP_PORT.
-
-The keys of `rules_host` are evaluated against the Host header of the request. The
-keys of `rules_path` are evaluated against the path of the request. If the
-`rules_host_and_path` variable is provided, the key has the format FIELD:VALUE.
-FIELD must be one of 'path-pattern' for path based routing or 'host-header' for host
-based routing.
-
-```
-rules_host {
-  "www.example1.com" = "HTTP:8080"
-  "www.example2.com" = "HTTPS:9091"
-  "www.example3.*"   = "HTTP:8080"
-}
-
-rules_host_and_path {
- "host-header:www.example1.com" = "HTTP:8080"
- "host-header:www.example2.com" = "HTTPS:9091"
- "path-pattern:/example3"       = "HTTPS:9091"
-}
-```
-
 Limitations:
  - The target group deregistration_delay, health_check_interval and health_check_timeout
 values can be configured with variables, but will be the same for all the target groups
  - With Terraform we can't provide a 'count' or list for listener_rule condition blocks,
 so at the moment only one condition can be specified per rule
+ - At the moment this module only implements Host Header based rules
 
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| autoscaling_group_name | Name of ASG to associate with the target group. | string | - | yes |
+| default_tags | Additional resource tags | map | `<map>` | no |
 | listener_arn | ARN of the listener. | string | - | yes |
-| name | Prefix of the target group names. The final name is name-PROTOCOL-PORT. | string | - | yes |
-| rules_host | A map with the value of a host-header rule condition and the target group associated. | map | `<map>` | no |
-| rules_host_and_path | A map with the value of a rule with the format FIELD:VALUE and the target group associated. FIELD can be one of 'host-header' or 'path-pattern' | map | `<map>` | no |
-| rules_path | A map with the value of a path-pattern rule condition and the target group associated | map | `<map>` | no |
+| name | Prefix of the target group names. The final name is name-rulename. | string | - | yes |
+| priority_offset | first priority number assigned to the rules managed by the module. | string | `1` | no |
+| rules_host | A list with the values to create Host-header based listener rules and target groups. | list | `<list>` | no |
+| rules_host_domain | Host header domain to append to the hosts in rules_host. | string | `*` | no |
 | target_group_deregistration_delay | The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. | string | `300` | no |
 | target_group_health_check_interval | The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. | string | `30` | no |
+| target_group_health_check_matcher | The HTTP codes to use when checking for a successful response from a target. | string | `200-399` | no |
+| target_group_health_check_path_prefix | The prefix destination for the health check request. | string | `/_healthcheck-` | no |
 | target_group_health_check_timeout | The amount of time, in seconds, during which no response means a failed health check. | string | `5` | no |
+| target_group_port | The port on which targets receive traffic. | string | `80` | no |
+| target_group_protocol | The protocol to use for routing traffic to the targets. | string | `HTTP` | no |
 | vpc_id | The ID of the VPC in which the default target groups are created. | string | - | yes |
 
 ## Outputs

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -58,6 +58,7 @@ This project adds global resources for app components:
 | elb_public_secondary_certname | The ACM secondary cert domain name to find the ARN of | string | - | yes |
 | email_alert_api_internal_service_names |  | list | `<list>` | no |
 | email_alert_api_public_service_names |  | list | `<list>` | no |
+| enable_lb_app_healthchecks | Use application specific target groups and healthchecks based on the list of services in the cname variable. | string | `false` | no |
 | feedback_public_service_names |  | list | `<list>` | no |
 | frontend_internal_service_cnames |  | list | `<list>` | no |
 | frontend_internal_service_names |  | list | `<list>` | no |


### PR DESCRIPTION
Update the original `lb_listener_rules` module, that hasn't been used so far,
to support a more specific case, where we want to add a target group and listener
rule for that target based on host headers. Each target group has its own health
check, so we can ensure traffic is only routing when the application is up and
healthy.

We are testing this module with the backend LB. We can choose when to use the
application healthchecks and target groups with the `enable_lb_app_healthchecks`
variable. By default the LBs continue using the default target group. When
we set `enable_lb_app_healthchecks` to true, we are creating the LB forward rules
from the service cnames variable.

This expression:
```
rules_host = ["${compact(split(",", var.enable_lb_app_healthchecks ? join(",", var.backend_public_service_cnames) : ""))}"]
```

is required because we can't use a conditional with list variables:
hashicorp/terraform#12453

This is fixed in Terraform 0.12, until then we need to implement a workaround.