### PR TITLE
Remove disallowed . from the aws_db_parameter_group name_prefix

### DIFF
--- a/terraform/projects/app-content-data-api-postgresql/main.tf
+++ b/terraform/projects/app-content-data-api-postgresql/main.tf
@@ -64,7 +64,7 @@ provider "aws" {
 }
 
 resource "aws_db_parameter_group" "content_data_api" {
-  name_prefix = "govuk.content-data-api"
+  name_prefix = "govuk-content-data-api"
   family      = "postgres9.6"
 
   # DBInstanceClassMemory is in bytes, divide by 1024 * 16 to convert


### PR DESCRIPTION
Terraform/AWS doesn't like this:

  Error: aws_db_parameter_group.content_data_api: only lowercase
  alphanumeric characters and hyphens allowed in parameter group
  "name_prefix"