### PR TITLE
Update the AWS Terraform provider version to 1.60.0

### DIFF
--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -74,7 +74,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "external" {

--- a/terraform/projects/app-asset-master/main.tf
+++ b/terraform/projects/app-asset-master/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_efs_file_system" "assets-efs-fs" {

--- a/terraform/projects/app-backend-redis/main.tf
+++ b/terraform/projects/app-backend-redis/main.tf
@@ -44,7 +44,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -56,7 +56,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -56,7 +56,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -63,7 +63,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/app-ckan/main.tf
+++ b/terraform/projects/app-ckan/main.tf
@@ -60,7 +60,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-content-data-api-db-admin/main.tf
+++ b/terraform/projects/app-content-data-api-db-admin/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 module "content-data-api-db-admin" {

--- a/terraform/projects/app-content-data-api-postgresql/main.tf
+++ b/terraform/projects/app-content-data-api-postgresql/main.tf
@@ -60,7 +60,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_db_parameter_group" "content_data_api" {

--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-data-science/main.tf
+++ b/terraform/projects/app-data-science/main.tf
@@ -41,7 +41,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_security_group" "data-science" {

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -52,7 +52,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -97,7 +97,7 @@ data "terraform_remote_state" "artefact_bucket" {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "external" {

--- a/terraform/projects/app-docker-management/main.tf
+++ b/terraform/projects/app-docker-management/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_elb" "docker_management_etcd_elb" {

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -56,7 +56,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -51,7 +51,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/app-elasticsearch5/main.tf
+++ b/terraform/projects/app-elasticsearch5/main.tf
@@ -125,7 +125,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_region" "current" {}

--- a/terraform/projects/app-email-alert-api-db-admin/main.tf
+++ b/terraform/projects/app-email-alert-api-db-admin/main.tf
@@ -42,7 +42,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_elb" "email-alert-api-db-admin_elb" {

--- a/terraform/projects/app-email-alert-api-postgresql/main.tf
+++ b/terraform/projects/app-email-alert-api-postgresql/main.tf
@@ -60,7 +60,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 module "email-alert-api-postgresql-primary_rds_instance" {

--- a/terraform/projects/app-email-alert-api/main.tf
+++ b/terraform/projects/app-email-alert-api/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -63,7 +63,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -85,7 +85,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "external" {

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -44,7 +44,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "external" {

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -60,7 +60,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 module "mirrorer" {

--- a/terraform/projects/app-mongo-api/main.tf
+++ b/terraform/projects/app-mongo-api/main.tf
@@ -90,7 +90,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 # Instance 1

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -100,7 +100,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -74,7 +74,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -70,7 +70,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -70,7 +70,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-prometheus/main.tf
+++ b/terraform/projects/app-prometheus/main.tf
@@ -41,7 +41,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.60.0"
 }
 
 module "prometheus-1" {

--- a/terraform/projects/app-publishing-api-db-admin/main.tf
+++ b/terraform/projects/app-publishing-api-db-admin/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_elb" "publishing-api-db-admin_elb" {

--- a/terraform/projects/app-publishing-api-postgresql/main.tf
+++ b/terraform/projects/app-publishing-api-postgresql/main.tf
@@ -60,7 +60,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 module "publishing-api-postgresql-primary_rds_instance" {

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -61,7 +61,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-rabbitmq/main.tf
+++ b/terraform/projects/app-rabbitmq/main.tf
@@ -44,7 +44,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -100,7 +100,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -63,7 +63,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -44,7 +44,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -70,7 +70,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-ubuntu-test/main.tf
+++ b/terraform/projects/app-ubuntu-test/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_elb" "ubuntutest_external_elb" {

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -56,7 +56,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -45,7 +45,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/infra-artefact-bucket/main.tf
+++ b/terraform/projects/infra-artefact-bucket/main.tf
@@ -97,19 +97,19 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 provider "aws" {
   alias   = "secondary"
   region  = "${var.aws_secondary_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 provider "aws" {
   alias   = "subscription"
   region  = "${var.aws_subscription_account_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/projects/infra-assets/main.tf
+++ b/terraform/projects/infra-assets/main.tf
@@ -35,7 +35,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_s3_bucket" "assets" {

--- a/terraform/projects/infra-carrenza-vpn/main.tf
+++ b/terraform/projects/infra-carrenza-vpn/main.tf
@@ -63,7 +63,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "terraform_remote_state" "infra_networking" {

--- a/terraform/projects/infra-certificates/main.tf
+++ b/terraform/projects/infra-certificates/main.tf
@@ -55,7 +55,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "terraform_remote_state" "infra_root_dns_zones" {

--- a/terraform/projects/infra-content-data-admin/main.tf
+++ b/terraform/projects/infra-content-data-admin/main.tf
@@ -29,7 +29,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_s3_bucket" "content_data_csvs" {

--- a/terraform/projects/infra-content-publisher/main.tf
+++ b/terraform/projects/infra-content-publisher/main.tf
@@ -29,7 +29,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_s3_bucket" "activestorage" {

--- a/terraform/projects/infra-csw/main.tf
+++ b/terraform/projects/infra-csw/main.tf
@@ -25,7 +25,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 module "csw_inspector_role" {

--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -54,13 +54,13 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 provider "aws" {
   alias   = "eu-london"
   region  = "${var.aws_backup_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {

--- a/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
@@ -47,7 +47,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.14.0"
+  version = "1.60.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {

--- a/terraform/projects/infra-datagovuk-static-bucket/main.tf
+++ b/terraform/projects/infra-datagovuk-static-bucket/main.tf
@@ -47,7 +47,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {

--- a/terraform/projects/infra-email-alert-api-archive/main.tf
+++ b/terraform/projects/infra-email-alert-api-archive/main.tf
@@ -30,7 +30,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_s3_bucket" "email_alert_api_archive" {

--- a/terraform/projects/infra-env-sync-and-backup/main.tf
+++ b/terraform/projects/infra-env-sync-and-backup/main.tf
@@ -29,7 +29,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_iam_user" "env_sync_and_backup" {

--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -28,7 +28,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_s3_bucket" "fastly_logs" {

--- a/terraform/projects/infra-govuk-cdn-logs-monitor-bucket/main.tf
+++ b/terraform/projects/infra-govuk-cdn-logs-monitor-bucket/main.tf
@@ -33,7 +33,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_s3_bucket" "cdn_logs_monitor" {

--- a/terraform/projects/infra-govuk-csp-forwarder/main.tf
+++ b/terraform/projects/infra-govuk-csp-forwarder/main.tf
@@ -22,7 +22,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_lambda_function" "govuk_csp_forwarder_lambda_function" {

--- a/terraform/projects/infra-govuk-repo-mirror/main.tf
+++ b/terraform/projects/infra-govuk-repo-mirror/main.tf
@@ -43,7 +43,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_iam_user" "govuk_codecommit_user" {

--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -57,13 +57,13 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 provider "aws" {
   region  = "${var.aws_replica_region}"
   alias   = "aws_replica"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/projects/infra-monitoring/main.tf
+++ b/terraform/projects/infra-monitoring/main.tf
@@ -38,7 +38,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_elb_service_account" "main" {}

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -118,7 +118,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "terraform_remote_state" "infra_vpc" {

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -449,7 +449,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 #

--- a/terraform/projects/infra-root-dns-zones/main.tf
+++ b/terraform/projects/infra-root-dns-zones/main.tf
@@ -64,7 +64,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "terraform_remote_state" "infra_vpc" {

--- a/terraform/projects/infra-root-dns-zones/main.tf
+++ b/terraform/projects/infra-root-dns-zones/main.tf
@@ -78,9 +78,12 @@ data "terraform_remote_state" "infra_vpc" {
 }
 
 resource "aws_route53_zone" "internal_zone" {
-  count  = "${var.create_internal_zone}"
-  name   = "${var.root_domain_internal_name}"
-  vpc_id = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  count = "${var.create_internal_zone}"
+  name  = "${var.root_domain_internal_name}"
+
+  vpc {
+    vpc_id = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  }
 
   tags {
     Project = "infra-root-dns-zones"

--- a/terraform/projects/infra-s3-mirrors/main.tf
+++ b/terraform/projects/infra-s3-mirrors/main.tf
@@ -30,7 +30,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_s3_bucket" "govuk_mirror_access_logs" {

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -11,7 +11,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 # used by the fastly ip ranges provider.

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -102,7 +102,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/projects/infra-splunk/main.tf
+++ b/terraform/projects/infra-splunk/main.tf
@@ -19,7 +19,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_iam_role" "splunk_aws_ro_role" {

--- a/terraform/projects/infra-stack-dns-zones/main.tf
+++ b/terraform/projects/infra-stack-dns-zones/main.tf
@@ -64,7 +64,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "terraform_remote_state" "infra_vpc" {

--- a/terraform/projects/infra-support-api/main.tf
+++ b/terraform/projects/infra-support-api/main.tf
@@ -29,7 +29,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 resource "aws_s3_bucket" "support_api_csvs" {

--- a/terraform/projects/infra-vpc/main.tf
+++ b/terraform/projects/infra-vpc/main.tf
@@ -59,7 +59,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {


### PR DESCRIPTION
This is the latest minor version before major version 2.

From 1.40.0 in most cases, apart from app-prometheus and
infra-datagovuk-organogram-bucket which were on 1.14.0.