### PR TITLE
Infra mirror setup

### DIFF
--- a/terraform/policies/s3_aws_secondary_logging_write_policy.tpl
+++ b/terraform/policies/s3_aws_secondary_logging_write_policy.tpl
@@ -1,0 +1,18 @@
+{
+  "Id": "Policy",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::govuk-${aws_environment}-aws-secondary-logging/*",
+      "Principal": {
+        "AWS": [
+          "${aws_account_id}"
+        ]
+      }
+    }
+  ]
+}

--- a/terraform/policies/s3_govuk_mirror_replication_policy.tpl
+++ b/terraform/policies/s3_govuk_mirror_replication_policy.tpl
@@ -8,17 +8,18 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "${govuk-mirror-1}"
+        "${govuk_mirror_arn}"
       ]
     },
     {
       "Action": [
         "s3:GetObjectVersion",
-        "s3:GetObjectVersionAcl"
+        "s3:GetObjectVersionAcl",
+        "s3:GetObjectVersionTagging"
       ],
       "Effect": "Allow",
       "Resource": [
-        "${govuk-mirror-1}/*"
+        "${govuk_mirror_arn}/*"
       ]
     },
     {
@@ -27,7 +28,7 @@
         "s3:ReplicateDelete"
       ],
       "Effect": "Allow",
-      "Resource": "${govuk-mirror-2}/*"
+      "Resource": "${govuk_mirror_replica_arn}/*"
     }
   ]
 }

--- a/terraform/policies/s3_govuk_mirror_replication_role.tpl
+++ b/terraform/policies/s3_govuk_mirror_replication_role.tpl
@@ -1,9 +1,9 @@
 {
   "Version": "2012-10-17",
-  "Statement": [ 
+  "Statement": [
     {
     "Action": "sts:AssumeRole",
-    "Principal": { 
+    "Principal": {
       "Service": "s3.amazonaws.com"
     },
     "Effect": "Allow",

--- a/terraform/projects/app-mirrorer/README.md
+++ b/terraform/projects/app-mirrorer/README.md
@@ -23,3 +23,9 @@ Mirrorer node
 | stackname | Stackname | string | - | yes |
 | user_data_snippets | List of user-data snippets | list | - | yes |
 
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| instance_iam_role_name | name of the instance iam role |
+

--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -119,3 +119,7 @@ module "alarms-ec2-mirrorer" {
 # Outputs
 # --------------------------------------------------------------
 
+output "instance_iam_role_name" {
+  value       = "${module.mirrorer.instance_iam_role_name}"
+  description = "name of the instance iam role"
+}

--- a/terraform/projects/infra-mirror-bucket/README.md
+++ b/terraform/projects/infra-mirror-bucket/README.md
@@ -1,8 +1,9 @@
-## Project: database-backups-bucket
+## Project: infra-mirror-bucket
 
-This creates an s3 bucket
+This project creates two s3 buckets: a primary s3 bucket to store the govuk
+mirror files and a replica s3 bucket which tracks the primary s3 bucket.
 
-database-backups: The bucket that will hold database backups
+The primary bucket should be in London and the backup in Ireland.
 
 
 
@@ -10,9 +11,12 @@ database-backups: The bucket that will hold database backups
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| aws_backup_region | AWS region | string | `eu-west-2` | no |
+| app_mirrorer_stackname | Stackname of the app mirrorer | string | - | yes |
 | aws_environment | AWS Environment | string | - | yes |
-| aws_region | AWS region | string | `eu-west-1` | no |
+| aws_region | AWS region where primary s3 bucket is located | string | `eu-west-2` | no |
+| aws_replica_region | AWS region where replica s3 bucket is located | string | `eu-west-1` | no |
+| office_ips | An array of CIDR blocks that will be allowed offsite access. | list | - | yes |
+| remote_state_app_mirrorer_key_stack | stackname path to app_mirrorer remote state | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | stackname | Stackname | string | - | yes |

--- a/terraform/projects/infra-mirror-bucket/integration.govuk.backend
+++ b/terraform/projects/infra-mirror-bucket/integration.govuk.backend
@@ -1,4 +1,4 @@
 bucket  = "govuk-terraform-steppingstone-integration"
-key     = "govuk/infra-database-backups-bucket.tfstate"
+key     = "govuk/infra-mirror-bucket.tfstate"
 encrypt = true
 region  = "eu-west-1"

--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -1,22 +1,23 @@
 /**
-* ## Project: database-backups-bucket
+* ## Project: infra-mirror-bucket
 *
-* This creates an s3 bucket
+* This project creates two s3 buckets: a primary s3 bucket to store the govuk
+* mirror files and a replica s3 bucket which tracks the primary s3 bucket.
 *
-* database-backups: The bucket that will hold database backups
+* The primary bucket should be in London and the backup in Ireland.
 *
 */
 
 variable "aws_region" {
   type        = "string"
-  description = "AWS region"
-  default     = "eu-west-1"
+  description = "AWS region where primary s3 bucket is located"
+  default     = "eu-west-2"
 }
 
-variable "aws_backup_region" {
+variable "aws_replica_region" {
   type        = "string"
-  description = "AWS region"
-  default     = "eu-west-2"
+  description = "AWS region where replica s3 bucket is located"
+  default     = "eu-west-1"
 }
 
 variable "aws_environment" {
@@ -40,6 +41,14 @@ variable "remote_state_infra_monitoring_key_stack" {
   default     = ""
 }
 
+variable "office_ips" {
+  type        = "list"
+  description = "An array of CIDR blocks that will be allowed offsite access."
+}
+
+# Resources
+# --------------------------------------------------------------
+
 # Set up the backend & provider for each region
 terraform {
   backend          "s3"             {}
@@ -52,10 +61,12 @@ provider "aws" {
 }
 
 provider "aws" {
-  region  = "${var.aws_backup_region}"
-  alias   = "aws_secondary"
+  region  = "${var.aws_replica_region}"
+  alias   = "aws_replica"
   version = "1.40.0"
 }
+
+data "aws_caller_identity" "current" {}
 
 data "terraform_remote_state" "infra_monitoring" {
   backend = "s3"
@@ -63,55 +74,78 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
-    region = "${var.aws_region}"
+    region = "${var.aws_replica_region}"
   }
 }
 
-resource "aws_s3_bucket" "govuk-mirror-1" {
-  bucket = "govuk-${var.aws_environment}-mirror-1"
+resource "aws_s3_bucket" "govuk-mirror" {
+  bucket = "govuk-${var.aws_environment}-mirror"
 
   tags {
-    Name            = "govuk-${var.aws_environment}-mirror-1"
+    Name            = "govuk-${var.aws_environment}-mirror"
     aws_environment = "${var.aws_environment}"
   }
 
   logging {
-    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-    target_prefix = "s3/govuk-${var.aws_environment}-mirror-1/"
+    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_secondary_logging_bucket_id}"
+    target_prefix = "s3/govuk-${var.aws_environment}-mirror/"
   }
 
   versioning {
     enabled = true
   }
 
+  lifecycle_rule {
+    id      = "main"
+    enabled = true
+
+    prefix = ""
+
+    noncurrent_version_expiration {
+      days = 5
+    }
+  }
+
+  lifecycle_rule {
+    id      = "government_uploads"
+    enabled = true
+
+    prefix = "www.gov.uk/government/uploads/"
+
+    noncurrent_version_expiration {
+      days = 8
+    }
+  }
+
   replication_configuration {
-    role = "${aws_iam_role.govuk_mirror_1_replication_role.arn}"
+    role = "${aws_iam_role.govuk_mirror_replication_role.arn}"
 
     rules {
+      id     = "govuk-mirror-replication-whole-bucket-rule"
       prefix = ""
       status = "Enabled"
 
       destination {
-        bucket        = "${aws_s3_bucket.govuk-mirror-2.arn}"
+        bucket        = "${aws_s3_bucket.govuk-mirror-replica.arn}"
         storage_class = "STANDARD"
       }
     }
   }
 }
 
-resource "aws_s3_bucket" "govuk-mirror-2" {
-  bucket   = "govuk-${var.aws_environment}-mirror-2"
-  region   = "${var.aws_backup_region}"
-  provider = "aws.aws_secondary"
+resource "aws_s3_bucket" "govuk-mirror-replica" {
+  bucket   = "govuk-${var.aws_environment}-mirror-replica"
+  region   = "${var.aws_replica_region}"
+  provider = "aws.aws_replica"
 
   tags {
-    Name            = "govuk-${var.aws_environment}-mirror-2"
+    Name            = "govuk-${var.aws_environment}-mirror-replica"
     aws_environment = "${var.aws_environment}"
   }
 
   logging {
     target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-    target_prefix = "s3/govuk-${var.aws_environment}-mirror-2/"
+    target_prefix = "s3/govuk-${var.aws_environment}-mirror-replica/"
   }
 
   versioning {
@@ -119,47 +153,48 @@ resource "aws_s3_bucket" "govuk-mirror-2" {
   }
 }
 
-resource "aws_s3_bucket_policy" "govuk_mirror_1_read_policy" {
-  bucket = "${aws_s3_bucket.govuk-mirror-1.id}"
-  policy = "${data.aws_iam_policy_document.s3_mirrors_read_policy_doc.json}"
+resource "aws_s3_bucket_policy" "govuk_mirror_read_policy" {
+  bucket = "${aws_s3_bucket.govuk-mirror.id}"
+  policy = "${data.aws_iam_policy_document.s3_mirror_read_policy_doc.json}"
 }
 
-resource "aws_s3_bucket_policy" "govuk_mirror_2_read_policy" {
-  bucket = "${aws_s3_bucket.govuk-mirror-2.id}"
-  policy = "${data.aws_iam_policy_document.s3_mirrors_read_policy_doc.json}"
+resource "aws_s3_bucket_policy" "govuk_mirror_replica_read_policy" {
+  bucket   = "${aws_s3_bucket.govuk-mirror-replica.id}"
+  policy   = "${data.aws_iam_policy_document.s3_mirror_replica_read_policy_doc.json}"
+  provider = "aws.aws_replica"
 }
 
 # S3 backup replica role configuration
-data "template_file" "s3_govuk_mirror_1_replication_role_template" {
-  template = "${file("${path.module}/../../policies/s3_mirror_replica_role.tpl")}"
+data "template_file" "s3_govuk_mirror_replication_role_template" {
+  template = "${file("${path.module}/../../policies/s3_govuk_mirror_replication_role.tpl")}"
 }
 
 # Adding backup replication role
-resource "aws_iam_role" "govuk_mirror_1_replication_role" {
-  name               = "${var.stackname}-mirror-1-replication-role"
-  assume_role_policy = "${data.template_file.s3_govuk_mirror_1_replication_role_template.rendered}"
+resource "aws_iam_role" "govuk_mirror_replication_role" {
+  name               = "${var.stackname}-mirror-replication-role"
+  assume_role_policy = "${data.template_file.s3_govuk_mirror_replication_role_template.rendered}"
 }
 
-data "template_file" "" s3_govuk_mirror_1_replication_policy_template "" {
-  template = "${file("${path.module}/../../policies/s3_role_replica_policy.tpl")}"
+data "template_file" "s3_govuk_mirror_replication_policy_template" {
+  template = "${file("${path.module}/../../policies/s3_govuk_mirror_replication_policy.tpl")}"
 
   vars {
-    govuk_s3_bucket = "arn:aws:s3:::${govuk-mirror-1}.bucket.arn"
-    govuk_s3_backup = "arn:aws:s3:::${govuk-mirror-2}.bucket.arn"
-    aws_account_id  = "${data.aws_caller_identity.current.account_id}"
+    govuk_mirror_arn         = "${aws_s3_bucket.govuk-mirror.arn}"
+    govuk_mirror_replica_arn = "${aws_s3_bucket.govuk-mirror-replica.arn}"
+    aws_account_id           = "${data.aws_caller_identity.current.account_id}"
   }
 }
 
 # Adding backup replication policy
-resource "aws_iam_policy" "govuk_mirror_1_replication_policy" {
-  name        = "govuk-${var.aws_environment}-backup-bucket-replication-policy"
-  policy      = "${data.template_file.s3_backup_replica_policy_template.rendered}"
-  description = "Allows replication of the backup buckets"
+resource "aws_iam_policy" "govuk_mirror_replication_policy" {
+  name        = "govuk-${var.aws_environment}-mirror-buckets-replication-policy"
+  policy      = "${data.template_file.s3_govuk_mirror_replication_policy_template.rendered}"
+  description = "Allows replication of the mirror buckets"
 }
 
 # Combine the role and policy
-resource "aws_iam_policy_attachment" "govuk_mirror_1_replication_policy_attachment" {
-  name       = "s3-govuk-mirror-1-replication-policy-attachment"
-  roles      = ["${aws_iam_role.govuk-mirror-1-replication-role.name}"]
-  policy_arn = "${aws_iam_policy.govuk-mirror-1-replication-policy.arn}"
+resource "aws_iam_policy_attachment" "govuk_mirror_replication_policy_attachment" {
+  name       = "s3-govuk-mirror-replication-policy-attachment"
+  roles      = ["${aws_iam_role.govuk_mirror_replication_role.name}"]
+  policy_arn = "${aws_iam_policy.govuk_mirror_replication_policy.arn}"
 }

--- a/terraform/projects/infra-mirror-bucket/mirror-crawler-write-policy.tf
+++ b/terraform/projects/infra-mirror-bucket/mirror-crawler-write-policy.tf
@@ -1,3 +1,27 @@
+variable "remote_state_app_mirrorer_key_stack" {
+  type        = "string"
+  description = "stackname path to app_mirrorer remote state "
+  default     = ""
+}
+
+variable "app_mirrorer_stackname" {
+  type        = "string"
+  description = "Stackname of the app mirrorer"
+}
+
+# Resources
+# --------------------------------------------------------------
+
+data "terraform_remote_state" "app_mirrorer" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_app_mirrorer_key_stack, var.app_mirrorer_stackname)}/app-mirrorer.tfstate"
+    region = "${var.aws_replica_region}"
+  }
+}
+
 data "aws_iam_policy_document" "s3_mirrors_crawler_writer_policy_doc" {
   statement {
     sid = "S3SyncReadLists"
@@ -17,23 +41,18 @@ data "aws_iam_policy_document" "s3_mirrors_crawler_writer_policy_doc" {
     actions = ["s3:*"]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-1.id}",
-      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-1.id}/*",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror.id}/*",
     ]
   }
 }
 
 resource "aws_iam_policy" "s3_mirrors_writer_policy" {
-  name   = "s3_mirrors_writer_policy_for_${aws_s3_bucket.govuk-mirror-1.id}"
+  name   = "s3_mirrors_writer_policy_for_${aws_s3_bucket.govuk-mirror.id}"
   policy = "${data.aws_iam_policy_document.s3_mirrors_crawler_writer_policy_doc.json}"
 }
 
-resource "aws_iam_user" "s3_mirrors_writer_user" {
-  name = "s3_mirrors_writer"
-}
-
-resource "aws_iam_policy_attachment" "s3_mirrors_writer_user_policy" {
-  name       = "s3_mirrors_writers_user_policy_attachement"
-  users      = ["${aws_iam_user.s3_mirrors_writers_user.name}"]
+resource "aws_iam_role_policy_attachment" "s3_mirrors_writer_user_policy" {
   policy_arn = "${aws_iam_policy.s3_mirrors_writer_policy.arn}"
+  role       = "${data.terraform_remote_state.app_mirrorer.instance_iam_role_name}"
 }

--- a/terraform/projects/infra-mirror-bucket/mirror-read-policy.tf
+++ b/terraform/projects/infra-mirror-bucket/mirror-read-policy.tf
@@ -9,16 +9,14 @@ data "external" "pingdom" {
   program = ["/bin/bash", "${path.module}/pingdom_probe_ips.sh"]
 }
 
-data "aws_iam_policy_document" "s3_mirrors_read_policy_doc" {
+data "aws_iam_policy_document" "s3_mirror_read_policy_doc" {
   statement {
     sid     = "S3FastlyReadBucket"
     actions = ["s3:GetObject"]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-1.id}",
-      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-1.id}/*",
-      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-2.id}",
-      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-2.id}/*",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror.id}/*",
     ]
 
     condition {
@@ -38,16 +36,100 @@ data "aws_iam_policy_document" "s3_mirrors_read_policy_doc" {
     actions = ["s3:GetObject"]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-1.id}",
-      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-1.id}/*",
-      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-2.id}",
-      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-2.id}/*",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror.id}/*",
     ]
 
     condition {
       test     = "IpAddress"
       variable = "aws:SourceIp"
       values   = ["${split(",",data.external.pingdom.result.pingdom_probe_ips)}"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+
+  statement {
+    sid     = "S3OfficeReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror.id}/*",
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["${var.office_ips}"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "s3_mirror_replica_read_policy_doc" {
+  statement {
+    sid     = "S3FastlyReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-replica.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-replica.id}/*",
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["${data.fastly_ip_ranges.fastly.cidr_blocks}"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+
+  statement {
+    sid     = "S3PingdomReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-replica.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-replica.id}/*",
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["${split(",",data.external.pingdom.result.pingdom_probe_ips)}"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+
+  statement {
+    sid     = "S3OfficeReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-replica.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-replica.id}/*",
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["${var.office_ips}"]
     }
 
     principals {

--- a/terraform/projects/infra-mirror-bucket/production.govuk.backend
+++ b/terraform/projects/infra-mirror-bucket/production.govuk.backend
@@ -1,4 +1,4 @@
 bucket  = "govuk-terraform-steppingstone-production"
-key     = "govuk/infra-database-backups-bucket.tfstate"
+key     = "govuk/infra-mirror-bucket.tfstate"
 encrypt = true
 region  = "eu-west-1"

--- a/terraform/projects/infra-mirror-bucket/staging.govuk.backend
+++ b/terraform/projects/infra-mirror-bucket/staging.govuk.backend
@@ -1,4 +1,4 @@
 bucket  = "govuk-terraform-steppingstone-staging"
-key     = "govuk/infra-database-backups-bucket.tfstate"
+key     = "govuk/infra-mirror-bucket.tfstate"
 encrypt = true
 region  = "eu-west-1"

--- a/terraform/projects/infra-monitoring/README.md
+++ b/terraform/projects/infra-monitoring/README.md
@@ -17,6 +17,7 @@ Create resources to manage infrastructure and app monitoring:
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| aws_secondary_region | Secondary AWS region | string | `eu-west-2` | no |
 | stackname | Stackname | string | `` | no |
 
 ## Outputs
@@ -25,6 +26,7 @@ Create resources to manage infrastructure and app monitoring:
 |------|-------------|
 | aws_logging_bucket_arn | ARN of the AWS logging bucket |
 | aws_logging_bucket_id | Name of the AWS logging bucket |
+| aws_secondary_logging_bucket_id | Name of the AWS logging bucket |
 | firehose_logs_role_arn | ARN of the Kinesis Firehose stream AWS credentials |
 | lambda_logs_role_arn | ARN of the IAM role attached to the Lambda logs Function |
 | lambda_rds_logs_to_s3_role_arn | ARN of the IAM role attached to the Lambda RDS logs to S3 Function |

--- a/terraform/projects/infra-monitoring/secondary.tf
+++ b/terraform/projects/infra-monitoring/secondary.tf
@@ -1,0 +1,62 @@
+/**
+* Creates a logging s3 bucket in the secondary region of gov.uk so that the
+* logs of that region can be stored in
+*
+*/
+
+variable "aws_secondary_region" {
+  type        = "string"
+  description = "Secondary AWS region"
+  default     = "eu-west-2"
+}
+
+# Resources
+# --------------------------------------------------------------
+
+provider "aws" {
+  alias   = "aws_secondary"
+  region  = "${var.aws_secondary_region}"
+  version = "1.40.0"
+}
+
+data "template_file" "s3_aws_secondary_logging_policy_template" {
+  template = "${file("${path.module}/../../policies/s3_aws_secondary_logging_write_policy.tpl")}"
+
+  vars {
+    aws_environment = "${var.aws_environment}"
+    aws_account_id  = "${data.aws_elb_service_account.main.arn}"
+  }
+}
+
+# Create a bucket that allows AWS services to write to it
+resource "aws_s3_bucket" "aws-secondary-logging" {
+  bucket   = "govuk-${var.aws_environment}-aws-secondary-logging"
+  acl      = "log-delivery-write"
+  provider = "aws.aws_secondary"
+
+  tags {
+    Name        = "govuk-${var.aws_environment}-aws-secondary-logging"
+    Environment = "${var.aws_environment}"
+  }
+
+  # Expire everything after 30 days
+  lifecycle_rule {
+    enabled = true
+
+    prefix = "/"
+
+    expiration {
+      days = 30
+    }
+  }
+
+  policy = "${data.template_file.s3_aws_secondary_logging_policy_template.rendered}"
+}
+
+# Outputs
+# --------------------------------------------------------------
+
+output "aws_secondary_logging_bucket_id" {
+  value       = "${aws_s3_bucket.aws-secondary-logging.id}"
+  description = "Name of the AWS logging bucket"
+}


### PR DESCRIPTION
# Context

New mirror project of gov.uk where the mirror buckets are in AWS. 

# key requirements met

1. the main mirror s3 bucket should be in London and the replica in Ireland.
2. s3 buckets should be browsable from the office IPs as well as fastly and
   pingdom
3. infra-monitoring should have a bucket in London to store the logs of
   s3 mirror bucket located in london
4. the bucket write policy should be attached to the mirrorer ec2 instance
   role
5. the retention period for non-current version of whole bucket is set to
   5 days and the www.gov.uk/government/uploads should be set to 8 days