### PR TITLE
Bump the search-api instance size from t2 to c5

### DIFF
--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -137,7 +137,7 @@ module "search" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "search", "aws_hostname", "search-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_search_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "c5.large"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "1"
   instance_elb_ids              = ["${aws_elb.search_elb.id}"]


### PR DESCRIPTION
- We have been seeing search-api instances run out of CPU credits. At
the moment they are manually set to be "unlimited".
- Using c5 removes CPU credits. As we seem to be using burst mode 30-40
percent of the time, this change should not increase cost.

solo: @schmie