### PR TITLE
Bump CPU and disk of the mirrorer

### DIFF
--- a/terraform/projects/app-mirrorer/README.md
+++ b/terraform/projects/app-mirrorer/README.md
@@ -11,7 +11,7 @@ Mirrorer node
 | aws_region | AWS region | string | `eu-west-1` | no |
 | ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
-| mirrorer_instance_type | Instance type for the mirrorer instance | string | `m5.large` | no |
+| mirrorer_instance_type | Instance type for the mirrorer instance | string | `c5.4xlarge` | no |
 | mirrorer_subnet | Subnet to contain mirrorer and its EBS volume | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -33,7 +33,7 @@ variable "instance_ami_filter_name" {
 variable "mirrorer_instance_type" {
   type        = "string"
   description = "Instance type for the mirrorer instance"
-  default     = "m5.large"
+  default     = "c5.4xlarge"
 }
 
 variable "mirrorer_subnet" {
@@ -75,7 +75,7 @@ module "mirrorer" {
 resource "aws_ebs_volume" "mirrorer" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mirrorer_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = 100
+  size              = 1000
   type              = "gp2"
 
   tags {


### PR DESCRIPTION
- We are testing to include all assets in the mirrorer in order to
provide a complete GOV.UK on a disk
- For testing our paradigm that this is working by simply extending the
scope of the crawler, we are temporarily upping the size of the mirrorer
significantly.
- Subsequently we should be able to significantly optimise the resource
requirements of the project

solo: @schmie