### PR TITLE
Add CORS rules for datagovuk-organogram S3 bucket

### DIFF
--- a/terraform/projects/infra-datagovuk-organogram-bucket/README.md
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/README.md
@@ -12,6 +12,7 @@ datagovuk-organogram-bucket: A bucket to hold data.gov.uk organogram files
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| domain | The domain of the data.gov.uk service to manage | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | stackname | Stackname | string | - | yes |

--- a/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
@@ -18,6 +18,11 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
+variable "domain" {
+  type        = "string"
+  description = "The domain of the data.gov.uk service to manage"
+}
+
 variable "stackname" {
   type        = "string"
   description = "Stackname"
@@ -57,6 +62,11 @@ data "terraform_remote_state" "infra_monitoring" {
 
 resource "aws_s3_bucket" "datagovuk-organogram" {
   bucket = "datagovuk-${var.aws_environment}-ckan-organogram"
+
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_origins = ["${var.domain}"]
+  }
 
   tags {
     Name            = "datagovuk-${var.aws_environment}-ckan-organogram"


### PR DESCRIPTION
We currently have an issue where organograms are not showing for
data links. Adding CORS rules to allow data.gov.uk fixes this.

Paired with @AlanGabbianelli 

Trello card: https://trello.com/c/wh8pUMOm/982-fix-display-of-organogram-visualisations-on-datagovuk