### PR TITLE
Update app-router-backend for Training

### DIFF
--- a/terraform/projects/app-router-backend/README.md
+++ b/terraform/projects/app-router-backend/README.md
@@ -11,6 +11,8 @@ Router backend hosts both Mongo and router-api
 | aws_region | AWS region | string | `eu-west-1` | no |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_database_backups_bucket_key_stack | Override stackname path to infra_database_backups_bucket remote state | string | `` | no |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-router-backend/training.govuk.backend
+++ b/terraform/projects/app-router-backend/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-router-backend.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add backend to build app-router-backend in the Training environment.

Add parameters to select which domain to use with the DNS records (Training
does not use the stack domain).