### PR TITLE
Update app-transition-postgresql for Training

### DIFF
--- a/terraform/projects/app-transition-postgresql/README.md
+++ b/terraform/projects/app-transition-postgresql/README.md
@@ -11,6 +11,8 @@ RDS Transition PostgreSQL Primary instance
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
 | instance_name | The RDS Instance Name. | string | `` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | multi_az | Enable multi-az. | string | `true` | no |
 | password | DB password | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -57,6 +57,16 @@ variable "snapshot_identifier" {
   default     = ""
 }
 
+variable "internal_zone_name" {
+  type        = "string"
+  description = "The name of the Route53 zone that contains internal records"
+}
+
+variable "internal_domain_name" {
+  type        = "string"
+  description = "The domain name of the internal DNS records, it could be different from the zone name"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -67,6 +77,11 @@ terraform {
 provider "aws" {
   region  = "${var.aws_region}"
   version = "1.40.0"
+}
+
+data "aws_route53_zone" "internal" {
+  name         = "${var.internal_zone_name}"
+  private_zone = true
 }
 
 module "transition-postgresql-primary_rds_instance" {
@@ -90,8 +105,8 @@ module "transition-postgresql-primary_rds_instance" {
 }
 
 resource "aws_route53_record" "service_record" {
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
-  name    = "transition-postgresql-primary.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
+  zone_id = "${data.aws_route53_zone.internal.zone_id}"
+  name    = "transition-postgresql-primary.${var.internal_domain_name}"
   type    = "CNAME"
   ttl     = 300
   records = ["${module.transition-postgresql-primary_rds_instance.rds_instance_address}"]
@@ -112,8 +127,8 @@ module "transition-postgresql-standby_rds_instance" {
 }
 
 resource "aws_route53_record" "replica_service_record" {
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
-  name    = "transition-postgresql-standby.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
+  zone_id = "${data.aws_route53_zone.internal.zone_id}"
+  name    = "transition-postgresql-standby.${var.internal_domain_name}"
   type    = "CNAME"
   ttl     = 300
   records = ["${module.transition-postgresql-standby_rds_instance.rds_replica_address}"]

--- a/terraform/projects/app-transition-postgresql/training.govuk.backend
+++ b/terraform/projects/app-transition-postgresql/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-transition-postgresql.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add backend to build app-transition-postgresql in the Training environment.

Add parameters to select which domain to use with the DNS records (Training
does not use the stack domain).