### PR TITLE
terraform code for google mirror and monitoring bucket

### DIFF
--- a/terraform/policies/s3_govuk_mirror_read_policy.tpl
+++ b/terraform/policies/s3_govuk_mirror_read_policy.tpl
@@ -1,0 +1,22 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${govuk_mirror_arn}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "${govuk_mirror_arn}/*"
+    }
+  ]
+}

--- a/terraform/projects/infra-google-mirror-bucket/README.md
+++ b/terraform/projects/infra-google-mirror-bucket/README.md
@@ -1,0 +1,21 @@
+## Project: infra-google-mirror-bucket
+
+This project creates a multi-region EU bucket in google cloud, i.e. gcs.
+
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| google_environment | Google environment, which is govuk environment. e.g: staging | string | `` | no |
+| google_project_id | Google project ID | string | `eu-west2` | no |
+| google_region | Google region the provider | string | `eu-west2` | no |
+| govuk_mirror_google_reader_aws_access_key_id | AWS access key ID used by google transfer service to access s3 govuk mirror bucket | string | - | yes |
+| govuk_mirror_google_reader_aws_secret_access_key | AWS secret access key used by google transfer service to access s3 govuk mirror bucket | string | - | yes |
+| location | location where to put the gcs bucket | string | `eu` | no |
+| remote_state_bucket | GCS bucket we store our terraform state in | string | - | yes |
+| remote_state_infra_google_monitoring_prefix | GCS bucket prefix where the infra-google-monitoring state files are stored | string | - | yes |
+| storage_class | the type of storage used for the gcs bucket | string | `multi_regional` | no |
+

--- a/terraform/projects/infra-google-mirror-bucket/main.tf
+++ b/terraform/projects/infra-google-mirror-bucket/main.tf
@@ -1,0 +1,170 @@
+/**
+* ## Project: infra-google-mirror-bucket
+*
+* This project creates a multi-region EU bucket in google cloud, i.e. gcs.
+*
+*
+*/
+
+variable "google_project_id" {
+  type        = "string"
+  description = "Google project ID"
+  default     = "eu-west2"
+}
+
+variable "google_region" {
+  type        = "string"
+  description = "Google region the provider"
+  default     = "eu-west2"
+}
+
+variable "google_environment" {
+  type        = "string"
+  description = "Google environment, which is govuk environment. e.g: staging"
+  default     = ""
+}
+
+variable "location" {
+  type        = "string"
+  description = "location where to put the gcs bucket"
+  default     = "eu"
+}
+
+variable "storage_class" {
+  type        = "string"
+  description = "the type of storage used for the gcs bucket"
+  default     = "multi_regional"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "GCS bucket we store our terraform state in"
+}
+
+variable "remote_state_infra_google_monitoring_prefix" {
+  type        = "string"
+  description = "GCS bucket prefix where the infra-google-monitoring state files are stored"
+}
+
+variable "govuk_mirror_google_reader_aws_access_key_id" {
+  type        = "string"
+  description = "AWS access key ID used by google transfer service to access s3 govuk mirror bucket"
+}
+
+variable "govuk_mirror_google_reader_aws_secret_access_key" {
+  type        = "string"
+  description = "AWS secret access key used by google transfer service to access s3 govuk mirror bucket"
+}
+
+# Resources
+# --------------------------------------------------------------
+
+terraform {
+  backend          "gcs"            {}
+  required_version = "= 0.11.7"
+}
+
+provider "google" {
+  region  = "${var.google_region}"
+  version = "= 2.4.1"
+  project = "${var.google_project_id}"
+}
+
+data "terraform_remote_state" "infra_google_monitoring" {
+  backend = "gcs"
+
+  config {
+    bucket  = "${var.remote_state_bucket}"
+    prefix  = "${var.remote_state_infra_google_monitoring_prefix}"
+    project = "${var.google_project_id}"
+  }
+}
+
+data "google_storage_transfer_project_service_account" "default" {
+  project = "${var.google_project_id}"
+}
+
+resource "google_storage_bucket" "govuk-mirror" {
+  name          = "govuk-${var.google_environment}-mirror"
+  location      = "${var.location}"
+  storage_class = "${var.storage_class}"
+  project       = "${var.google_project_id}"
+
+  logging {
+    log_bucket = "${data.terraform_remote_state.infra_google_monitoring.google_logging_bucket_id}"
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age        = 8
+      with_state = "ARCHIVED"
+    }
+  }
+}
+
+resource "google_storage_bucket_iam_member" "s3-sync-bucket" {
+  bucket = "govuk-${var.google_environment}-mirror"
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${data.google_storage_transfer_project_service_account.default.email}"
+
+  depends_on = [
+    "google_storage_bucket.govuk-mirror",
+  ]
+}
+
+resource "google_storage_transfer_job" "s3-bucket-daily-sync" {
+  description = "daily sync of the primary govuk-${var.google_environment}-mirror S3 bucket"
+  project     = "${var.google_project_id}"
+
+  transfer_spec {
+    transfer_options {
+      delete_objects_unique_in_sink = true
+    }
+
+    aws_s3_data_source {
+      bucket_name = "govuk-${var.google_environment}-mirror"
+
+      aws_access_key {
+        access_key_id     = "${var.govuk_mirror_google_reader_aws_access_key_id}"
+        secret_access_key = "${var.govuk_mirror_google_reader_aws_secret_access_key}"
+      }
+    }
+
+    gcs_data_sink {
+      bucket_name = "govuk-${var.google_environment}-mirror"
+    }
+  }
+
+  schedule {
+    schedule_start_date {
+      year  = 2019
+      month = 5
+      day   = 20
+    }
+
+    schedule_end_date {
+      year  = 9999
+      month = 12
+      day   = 31
+    }
+
+    start_time_of_day {
+      hours   = 11
+      minutes = 00
+      seconds = 0
+      nanos   = 0
+    }
+  }
+
+  depends_on = [
+    "google_storage_bucket_iam_member.s3-sync-bucket",
+  ]
+}

--- a/terraform/projects/infra-google-mirror-bucket/staging.govuk.backend
+++ b/terraform/projects/infra-google-mirror-bucket/staging.govuk.backend
@@ -1,0 +1,3 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+project = "govuk-staging-160211"
+prefix  = "govuk/infra-google-mirror-bucket"

--- a/terraform/projects/infra-google-monitoring/README.md
+++ b/terraform/projects/infra-google-monitoring/README.md
@@ -1,0 +1,23 @@
+## Project: infra-google-mirror-bucket
+
+This project creates a multi-region EU bucket in google cloud, i.e. gcs.
+
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| google_environment | Google environment, which is govuk environment. e.g: staging | string | `` | no |
+| google_project_id | Google project ID | string | `eu-west2` | no |
+| google_region | Google region the provider | string | `eu-west2` | no |
+| location | location where to put the gcs bucket | string | `eu` | no |
+| storage_class | the type of storage used for the gcs bucket | string | `multi_regional` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| google_logging_bucket_id | Name of the Google logging bucket |
+

--- a/terraform/projects/infra-google-monitoring/main.tf
+++ b/terraform/projects/infra-google-monitoring/main.tf
@@ -1,0 +1,88 @@
+/**
+* ## Project: infra-google-mirror-bucket
+*
+* This project creates a multi-region EU bucket in google cloud, i.e. gcs.
+*
+*
+*/
+
+variable "google_project_id" {
+  type        = "string"
+  description = "Google project ID"
+  default     = "eu-west2"
+}
+
+variable "google_region" {
+  type        = "string"
+  description = "Google region the provider"
+  default     = "eu-west2"
+}
+
+variable "google_environment" {
+  type        = "string"
+  description = "Google environment, which is govuk environment. e.g: staging"
+  default     = ""
+}
+
+variable "location" {
+  type        = "string"
+  description = "location where to put the gcs bucket"
+  default     = "eu"
+}
+
+variable "storage_class" {
+  type        = "string"
+  description = "the type of storage used for the gcs bucket"
+  default     = "multi_regional"
+}
+
+# Resources
+# --------------------------------------------------------------
+
+terraform {
+  backend          "gcs"            {}
+  required_version = "= 0.11.7"
+}
+
+provider "google" {
+  region  = "${var.google_region}"
+  version = "= 2.4.1"
+  project = "${var.google_project_id}"
+}
+
+resource "google_storage_bucket" "google-logging" {
+  name          = "govuk-${var.google_environment}-gcp-logging"
+  location      = "${var.location}"
+  storage_class = "${var.storage_class}"
+  project       = "${var.google_project_id}"
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age = 30
+    }
+  }
+}
+
+resource "google_storage_bucket_acl" "google-logging-acl" {
+  bucket = "${google_storage_bucket.google-logging.name}"
+
+  role_entity = [
+    "WRITER:group-cloud-storage-analytics@google.com",
+  ]
+}
+
+# Outputs
+# --------------------------------------------------------------
+
+output "google_logging_bucket_id" {
+  value       = "${google_storage_bucket.google-logging.id}"
+  description = "Name of the Google logging bucket"
+}

--- a/terraform/projects/infra-google-monitoring/staging.govuk.backend
+++ b/terraform/projects/infra-google-monitoring/staging.govuk.backend
@@ -1,0 +1,3 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+project = "govuk-staging-160211"
+prefix  = "govuk/infra-google-monitoring"

--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -198,3 +198,27 @@ resource "aws_iam_policy_attachment" "govuk_mirror_replication_policy_attachment
   roles      = ["${aws_iam_role.govuk_mirror_replication_role.name}"]
   policy_arn = "${aws_iam_policy.govuk_mirror_replication_policy.arn}"
 }
+
+data "template_file" "s3_govuk_mirror_read_policy_template" {
+  template = "${file("${path.module}/../../policies/s3_govuk_mirror_read_policy.tpl")}"
+
+  vars {
+    govuk_mirror_arn = "${aws_s3_bucket.govuk-mirror.arn}"
+  }
+}
+
+resource "aws_iam_policy" "govuk_mirror_read_policy" {
+  name        = "govuk-${var.aws_environment}-mirror-read-policy"
+  policy      = "${data.template_file.s3_govuk_mirror_read_policy_template.rendered}"
+  description = "Allow the listing and reading of the primary govuk mirror bucket"
+}
+
+resource "aws_iam_user" "govuk_mirror_google_reader" {
+  name = "govuk_mirror_google_reader"
+}
+
+resource "aws_iam_policy_attachment" "govuk_mirror_read_policy_attachment" {
+  name       = "s3-govuk-mirror-read-policy-attachment"
+  users      = ["${aws_iam_user.govuk_mirror_google_reader.name}"]
+  policy_arn = "${aws_iam_policy.govuk_mirror_read_policy.arn}"
+}


### PR DESCRIPTION
# Context

As part of the govuk mirror redesign project, there was a decision to have a 3rd bucket in another provider GCP as a second provider backup to AWS in case that AWS goes down.

# Decisions
1. create terraform code to create a multi-regional EU Google/GCS mirror bucket that
will sync with its master govuk-{environment}-mirror bucket in AWS S3.
2. Since the GCS mirror bucket needs a logging bucket where it can store its log,
a GCS monitoring bucket must be created too
3. configure the google transfer tool to sync on a daily basis
the GCS bucket with its AWS S3 bucket source.
4. create a AWS restricted user to give to google transfer tool in order to access the AWS S3 bucket to be sync from.

The data counterpart for this PR is in: https://github.com/alphagov/govuk-aws-data/pull/432