### PR TITLE
Update references to the Content Data * apps

### DIFF
--- a/doc/guides/redeploying-applications-on-rebuild.md
+++ b/doc/guides/redeploying-applications-on-rebuild.md
@@ -26,7 +26,8 @@ This will trigger all the apps to redeploy. It assumes that each app will be rel
 asset-manager
 collections-publisher
 contacts
-content-performance-manager
+content-data-admin
+content-data-api
 content-tagger
 email-alert-api
 email-alert-service

--- a/tools/migration-hosts.sh
+++ b/tools/migration-hosts.sh
@@ -8,7 +8,8 @@ backend
 bouncer
 collections-publisher
 contacts-admin
-content-performance-manager
+content-data-admin
+content-data-api
 content-tagger
 deploy
 draft-origin


### PR DESCRIPTION
The Content Performance Manager has been renamed to the Content Data
API.

Also add the Content Data Admin in to these lists, as that seems
sensible.