### PR TITLE
Add a govuk-internal-administrators role

### DIFF
--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -17,6 +17,8 @@ Infrastructure security settings:
 | aws_region | AWS region | string | `eu-west-1` | no |
 | role_admin_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |
 | role_admin_user_arns | List of ARNs of external users that can assume the role | list | `<list>` | no |
+| role_internal_admin_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |
+| role_internal_admin_user_arns | List of ARNs of external users that can assume the role | list | `<list>` | no |
 | role_platformhealth_poweruser_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |
 | role_platformhealth_poweruser_user_arns | List of ARNs of external users that can assume the role | list | `<list>` | no |
 | role_poweruser_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -39,6 +39,18 @@ variable "role_admin_policy_arns" {
   default     = []
 }
 
+variable "role_internal_admin_user_arns" {
+  type        = "list"
+  description = "List of ARNs of external users that can assume the role"
+  default     = []
+}
+
+variable "role_internal_admin_policy_arns" {
+  type        = "list"
+  description = "List of ARNs of policies to attach to the role"
+  default     = []
+}
+
 variable "role_platformhealth_poweruser_user_arns" {
   type        = "list"
   description = "List of ARNs of external users that can assume the role"
@@ -100,6 +112,13 @@ module "role_admin" {
   role_name        = "govuk-administrators"
   role_user_arns   = ["${var.role_admin_user_arns}"]
   role_policy_arns = ["${var.role_admin_policy_arns}"]
+}
+
+module "role_internal_admin" {
+  source           = "../../modules/aws/iam/role_user"
+  role_name        = "govuk-internal-administrators"
+  role_user_arns   = ["${var.role_internal_admin_user_arns}"]
+  role_policy_arns = ["${var.role_internal_admin_policy_arns}"]
 }
 
 module "role_platformhealth_poweruser" {


### PR DESCRIPTION
There are too many people in the govuk-administrators role, some AWS
limit is being hit.

Therefore, create a new govuk-internal-administrators role for
administrators from within the GOV.UK Publishing program.

I was going to create a govuk-external-administrators role, and remove
people external to GOV.UK from the existing govuk-administrators role,
but this would affect far more people (who would have to change their
configuration files), so just pull out the internal people instead.