### PR TITLE
Use the iam_role name attribute when defining the policy attachment

### DIFF
--- a/terraform/modules/aws/iam/role_user/main.tf
+++ b/terraform/modules/aws/iam/role_user/main.tf
@@ -80,7 +80,7 @@ resource "aws_iam_role" "user_role" {
 
 resource "aws_iam_role_policy_attachment" "user_policy_attachment" {
   count      = "${length(var.role_policy_arns) * local.create_role}"
-  role       = "${var.role_name}"
+  role       = "${aws_iam_role.user_role.name}"
   policy_arn = "${element(var.role_policy_arns, count.index)}"
 }
 


### PR DESCRIPTION
As this informs Terraform there's a dependency between the two
resources, so it'll create the role prior to attempting to attach the
policy.