### PR TITLE
Update app-elasticsearch5 for Training environment

### DIFF
--- a/terraform/projects/app-elasticsearch5/README.md
+++ b/terraform/projects/app-elasticsearch5/README.md
@@ -39,6 +39,8 @@ doesn't support:
 | elasticsearch5_master_instance_type | Instance type of the dedicated master nodes in the cluster | string | `c4.large.elasticsearch` | no |
 | elasticsearch5_snapshot_start_hour | The hour in which the daily snapshot is taken | string | `1` | no |
 | elasticsearch_subnet_names | Names of the subnets to place the ElasticSearch domain in | list | - | yes |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-elasticsearch5/training.govuk.backend
+++ b/terraform/projects/app-elasticsearch5/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-elasticsearch5.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add backend to build app-elasticsearch5 in the Training environment.

Add parameters to select which domain to use with the DNS records (Training
does not use the stack domain).

Training app-elasticsearch5 runs with fewer instances and t2.smalls to save
on costs.