### PR TITLE
Remove unused variables

### DIFF
--- a/terraform/modules/aws/node_group/README.md
+++ b/terraform/modules/aws/node_group/README.md
@@ -45,7 +45,6 @@ to use with Application Load Balancers with the `instance_target_group_arns` var
 | instance_user_data | User_data provisioning script (default user_data.sh in module directory) | string | `user_data.sh` | no |
 | name | Jumpbox resources name. Only alphanumeric characters and hyphens allowed | string | - | yes |
 | root_block_device_volume_size | The size of the instance root volume in gigabytes | string | `20` | no |
-| vpc_id | The ID of the VPC in which the jumpbox is created | string | - | yes |
 
 ## Outputs
 

--- a/terraform/modules/aws/node_group/main.tf
+++ b/terraform/modules/aws/node_group/main.tf
@@ -28,11 +28,6 @@ variable "default_tags" {
   default     = {}
 }
 
-variable "vpc_id" {
-  type        = "string"
-  description = "The ID of the VPC in which the jumpbox is created"
-}
-
 variable "instance_subnet_ids" {
   type        = "list"
   description = "List of subnet ids where the instance can be deployed"

--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -161,7 +161,6 @@ resource "aws_route53_record" "gemstash_internal_service_record" {
 module "apt" {
   source                            = "../../modules/aws/node_group"
   name                              = "${var.stackname}-apt"
-  vpc_id                            = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                      = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "apt", "aws_hostname", "apt-1")}"
   instance_subnet_ids               = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.apt_1_subnet))}"
   instance_security_group_ids       = ["${data.terraform_remote_state.infra_security_groups.sg_apt_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-asset-master/main.tf
+++ b/terraform/projects/app-asset-master/main.tf
@@ -61,7 +61,6 @@ resource "aws_route53_record" "assets_service_record" {
 module "asset-master" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-asset-master"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "asset_master", "aws_hostname", "asset-master-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_asset-master_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -188,7 +188,6 @@ resource "aws_route53_record" "app_service_records_internal" {
 module "backend" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-backend"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend", "aws_hostname", "backend-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}", "${data.terraform_remote_state.infra_security_groups.sg_aws-vpn_id}"]

--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -153,7 +153,6 @@ resource "aws_route53_record" "service_record_internal" {
 module "bouncer" {
   source                            = "../../modules/aws/node_group"
   name                              = "${var.stackname}-bouncer"
-  vpc_id                            = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                      = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "bouncer", "aws_hostname", "bouncer-1")}"
   instance_subnet_ids               = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids       = ["${data.terraform_remote_state.infra_security_groups.sg_bouncer_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -191,7 +191,6 @@ resource "aws_route53_record" "app_service_records" {
 module "cache" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-cache"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "cache", "aws_hostname", "cache-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_cache_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -133,7 +133,6 @@ resource "aws_route53_record" "app_service_records" {
 module "calculators-frontend" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-calculators-frontend"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "calculators_frontend", "aws_hostname", "calculators-frontend-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_calculators-frontend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-ckan/main.tf
+++ b/terraform/projects/app-ckan/main.tf
@@ -192,7 +192,6 @@ resource "aws_route53_record" "app_service_records_internal" {
 module "ckan" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-ckan"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "ckan", "aws_hostname", "ckan-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.ckan_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_ckan_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-content-data-api-db-admin/main.tf
+++ b/terraform/projects/app-content-data-api-db-admin/main.tf
@@ -40,7 +40,6 @@ provider "aws" {
 module "content-data-api-db-admin" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-content-data-api-db-admin"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "content_data_api_db_admin", "aws_hostname", "content-data-api-db-admin-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_content-data-api-db-admin_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -164,7 +164,6 @@ resource "aws_route53_record" "internal_service_record" {
 module "content-store" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-content-store"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "content_store", "aws_hostname", "content-store-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-data-science/main.tf
+++ b/terraform/projects/app-data-science/main.tf
@@ -110,7 +110,6 @@ resource "aws_elb" "data-science_external_elb" {
 module "data-science-1" {
   source                        = "../../modules/aws/node_group"
   name                          = "data-science-1"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("aws_environment", var.aws_environment, "aws_migration", "data-science", "aws_hostname", "data-science-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.public_subnet_ids}"
   instance_security_group_ids   = ["${aws_security_group.data-science.id}"]
@@ -126,7 +125,6 @@ module "data-science-1" {
 module "data-science-2" {
   source                        = "../../modules/aws/node_group"
   name                          = "data-science-2"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("aws_environment", var.aws_environment, "aws_migration", "data-science", "aws_hostname", "data-science-2")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.public_subnet_ids}"
   instance_security_group_ids   = ["${aws_security_group.data-science.id}"]

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -106,7 +106,6 @@ resource "aws_elb" "db-admin_elb" {
 module "db-admin" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-db-admin"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "db_admin", "aws_hostname", "db-admin-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_db-admin_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -232,7 +232,6 @@ locals {
 module "deploy" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-deploy"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "jenkins", "aws_hostname", "jenkins-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.deploy_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_deploy_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-docker-management/main.tf
+++ b/terraform/projects/app-docker-management/main.tf
@@ -90,7 +90,6 @@ resource "aws_route53_record" "docker_management_etcd_service_record" {
 module "docker_management" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-docker_management"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "docker_management", "aws_hostname", "docker-management-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_docker_management_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -203,7 +203,6 @@ resource "aws_route53_record" "app_service_records" {
 module "draft-cache" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-draft-cache"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "draft_cache", "aws_hostname", "draft-cache-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_draft-cache_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -164,7 +164,6 @@ resource "aws_route53_record" "internal_service_record" {
 module "draft-content-store" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-draft-content-store"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "draft_content_store", "aws_hostname", "draft-content-store-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_draft-content-store_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -121,7 +121,6 @@ resource "aws_route53_record" "app_service_records" {
 module "draft-frontend" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-draft-frontend"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "draft_frontend", "aws_hostname", "draft-frontend-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_draft-frontend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-email-alert-api-db-admin/main.tf
+++ b/terraform/projects/app-email-alert-api-db-admin/main.tf
@@ -91,7 +91,6 @@ resource "aws_elb" "email-alert-api-db-admin_elb" {
 module "email-alert-api-db-admin" {
   source       = "../../modules/aws/node_group"
   name         = "${var.stackname}-email-alert-api-db-admin"
-  vpc_id       = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags = "${map("Project", var.stackname,
   "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "email_alert_api_db_admin", "aws_hostname", "email-alert-api-db-admin-1")}"
 

--- a/terraform/projects/app-email-alert-api-postgresql/README.md
+++ b/terraform/projects/app-email-alert-api-postgresql/README.md
@@ -10,7 +10,6 @@ RDS email-alert-api PostgreSQL Primary instance
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
-| instance_name | The RDS Instance Name. | string | `` | no |
 | multi_az | Enable multi-az. | string | `true` | no |
 | password | DB password | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-email-alert-api-postgresql/main.tf
+++ b/terraform/projects/app-email-alert-api-postgresql/main.tf
@@ -19,12 +19,6 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
-variable "instance_name" {
-  type        = "string"
-  description = "The RDS Instance Name."
-  default     = ""
-}
-
 variable "cloudwatch_log_retention" {
   type        = "string"
   description = "Number of days to retain Cloudwatch logs for"

--- a/terraform/projects/app-email-alert-api/main.tf
+++ b/terraform/projects/app-email-alert-api/main.tf
@@ -164,7 +164,6 @@ resource "aws_route53_record" "service_record_external" {
 module "email-alert-api" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-email-alert-api"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "email_alert_api", "aws_hostname", "email-alert-api-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_email-alert-api_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -133,7 +133,6 @@ resource "aws_route53_record" "app_service_records" {
 module "frontend" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-frontend"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "frontend", "aws_hostname", "frontend-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_frontend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -248,7 +248,6 @@ locals {
 module "graphite-1" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-graphite-1"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "graphite", "aws_hostname", "graphite-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.graphite_1_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_graphite_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -102,7 +102,6 @@ resource "aws_route53_record" "service_record" {
 module "jumpbox" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-jumpbox"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "jumpbox", "aws_hostname", "jumpbox-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_jumpbox_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -121,7 +121,6 @@ resource "aws_route53_record" "mapit_service_record" {
 module "mapit-1" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-1"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_1_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
@@ -154,7 +153,6 @@ resource "aws_ebs_volume" "mapit-1" {
 module "mapit-2" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-2"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-2")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_2_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -56,7 +56,6 @@ provider "aws" {
 module "mirrorer" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mirrorer"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mirrorer", "aws_hostname", "mirrorer-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mirrorer_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mirrorer_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-mongo-api/main.tf
+++ b/terraform/projects/app-mongo-api/main.tf
@@ -120,7 +120,6 @@ resource "aws_route53_record" "mongo_api_1_service_record" {
 module "mongo-api-1" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mongo-api-1"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mongo_api", "aws_hostname", "mongo-api-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mongo_1_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mongo_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
@@ -178,7 +177,6 @@ resource "aws_route53_record" "mongo_api_2_service_record" {
 module "mongo-api-2" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mongo-api-2"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mongo_api", "aws_hostname", "mongo-api-2")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mongo_2_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mongo_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
@@ -236,7 +234,6 @@ resource "aws_route53_record" "mongo_api_3_service_record" {
 module "mongo-api-3" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mongo-api-3"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mongo_api", "aws_hostname", "mongo-api-3")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mongo_3_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mongo_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -135,7 +135,6 @@ resource "aws_route53_record" "mongo_1_service_record" {
 module "mongo-1" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mongo-1"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mongo", "aws_hostname", "mongo-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mongo_1_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mongo_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
@@ -193,7 +192,6 @@ resource "aws_route53_record" "mongo_2_service_record" {
 module "mongo-2" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mongo-2"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mongo", "aws_hostname", "mongo-2")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mongo_2_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mongo_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
@@ -251,7 +249,6 @@ resource "aws_route53_record" "mongo_3_service_record" {
 module "mongo-3" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mongo-3"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mongo", "aws_hostname", "mongo-3")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mongo_3_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mongo_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -214,7 +214,6 @@ resource "aws_elb" "monitoring_internal_elb" {
 module "monitoring" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-monitoring"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "monitoring", "aws_hostname", "monitoring-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.monitoring_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_monitoring_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-mysql/README.md
+++ b/terraform/projects/app-mysql/README.md
@@ -10,7 +10,6 @@ RDS Mysql Primary instance
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
-| instance_name | The RDS Instance Name. | string | `` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | password | DB password | string | - | yes |

--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -19,12 +19,6 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
-variable "instance_name" {
-  type        = "string"
-  description = "The RDS Instance Name."
-  default     = ""
-}
-
 variable "cloudwatch_log_retention" {
   type        = "string"
   description = "Number of days to retain Cloudwatch logs for"

--- a/terraform/projects/app-postgresql/README.md
+++ b/terraform/projects/app-postgresql/README.md
@@ -10,7 +10,6 @@ RDS PostgreSQL instances
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
-| instance_name | The RDS Instance Name. | string | `` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | multi_az | Enable multi-az. | string | `true` | no |

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -19,12 +19,6 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
-variable "instance_name" {
-  type        = "string"
-  description = "The RDS Instance Name."
-  default     = ""
-}
-
 variable "cloudwatch_log_retention" {
   type        = "string"
   description = "Number of days to retain Cloudwatch logs for"

--- a/terraform/projects/app-prometheus/main.tf
+++ b/terraform/projects/app-prometheus/main.tf
@@ -47,7 +47,6 @@ provider "aws" {
 module "prometheus-1" {
   source       = "../../modules/aws/node_group"
   name         = "${var.stackname}-prometheus-1"
-  vpc_id       = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment",
 var.aws_environment, "aws_migration", "prometheus", "aws_hostname", "prometheus-1")}"
 

--- a/terraform/projects/app-publishing-api-db-admin/main.tf
+++ b/terraform/projects/app-publishing-api-db-admin/main.tf
@@ -76,7 +76,6 @@ resource "aws_elb" "publishing-api-db-admin_elb" {
 module "publishing-api-db-admin" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-publishing-api-db-admin"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "publishing_api_db_admin", "aws_hostname", "publishing-api-db-admin-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_publishing-api-db-admin_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -164,7 +164,6 @@ resource "aws_route53_record" "service_record_external" {
 module "publishing-api" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-publishing-api"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "publishing_api", "aws_hostname", "publishing-api-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_publishing-api_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -195,7 +195,6 @@ resource "aws_route53_record" "puppetdb_service_record" {
 module "puppetmaster" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-puppetmaster"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "puppetmaster", "aws_hostname", "puppetmaster-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_puppetmaster_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-rabbitmq/main.tf
+++ b/terraform/projects/app-rabbitmq/main.tf
@@ -103,7 +103,6 @@ resource "aws_route53_record" "rabbitmq_internal_service_record" {
 module "rabbitmq" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-rabbitmq"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "rabbitmq", "aws_hostname", "rabbitmq")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_rabbitmq_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -190,7 +190,6 @@ resource "aws_route53_record" "router-backend_1_service_record" {
 module "router-backend-1" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-router-backend-1"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "router_backend", "aws_hostname", "router-backend-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.router-backend_1_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_router-backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
@@ -230,7 +229,6 @@ resource "aws_route53_record" "router-backend_2_service_record" {
 module "router-backend-2" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-router-backend-2"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "router_backend", "aws_hostname", "router-backend-2")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.router-backend_2_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_router-backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
@@ -270,7 +268,6 @@ resource "aws_route53_record" "router-backend_3_service_record" {
 module "router-backend-3" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-router-backend-3"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "router_backend", "aws_hostname", "router-backend-3")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.router-backend_3_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_router-backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -133,7 +133,6 @@ resource "aws_route53_record" "app_service_records" {
 module "search" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-search"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "search", "aws_hostname", "search-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_search_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -91,7 +91,6 @@ resource "aws_elb" "transition-db-admin_elb" {
 module "transition-db-admin" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-transition-db-admin"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "transition_db_admin", "aws_hostname", "transition-db-admin-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_transition-db-admin_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-transition-postgresql/README.md
+++ b/terraform/projects/app-transition-postgresql/README.md
@@ -10,7 +10,6 @@ RDS Transition PostgreSQL Primary instance
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
-| instance_name | The RDS Instance Name. | string | `` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | multi_az | Enable multi-az. | string | `true` | no |

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -19,12 +19,6 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
-variable "instance_name" {
-  type        = "string"
-  description = "The RDS Instance Name."
-  default     = ""
-}
-
 variable "cloudwatch_log_retention" {
   type        = "string"
   description = "Number of days to retain Cloudwatch logs for"

--- a/terraform/projects/app-ubuntu-test/main.tf
+++ b/terraform/projects/app-ubuntu-test/main.tf
@@ -87,7 +87,6 @@ resource "aws_route53_record" "service_record" {
 module "ubuntutest" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-ubuntutest"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "ubuntutest", "aws_hostname", "ubuntutest-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_ubuntutest_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -105,7 +105,6 @@ resource "aws_route53_record" "service_record" {
 module "whitehall-frontend" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-whitehall-frontend"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "whitehall_frontend", "aws_hostname", "whitehall-frontend-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-frontend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]

--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -13,7 +13,6 @@ database-backups: The bucket that will hold database backups
 | aws_backup_region | AWS region | string | `eu-west-2` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
-| backup_source_bucket | This variable is used to pass the backup bucket that is used to get the data (from production). | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | stackname | Stackname | string | - | yes |

--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -40,12 +40,6 @@ variable "remote_state_infra_monitoring_key_stack" {
   default     = ""
 }
 
-variable "backup_source_bucket" {
-  type        = "string"
-  description = "This variable is used to pass the backup bucket that is used to get the data (from production)."
-  default     = ""
-}
-
 # Set up the backend & provider for each region
 terraform {
   backend          "s3"             {}

--- a/terraform/projects/infra-govuk-csp-forwarder/README.md
+++ b/terraform/projects/infra-govuk-csp-forwarder/README.md
@@ -8,7 +8,6 @@ reports, filter them and forward them to Sentry.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-2` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/infra-govuk-csp-forwarder/main.tf
+++ b/terraform/projects/infra-govuk-csp-forwarder/main.tf
@@ -10,11 +10,6 @@ variable "aws_region" {
   default     = "eu-west-2"
 }
 
-variable "aws_environment" {
-  type        = "string"
-  description = "AWS Environment"
-}
-
 variable "stackname" {
   type        = "string"
   description = "Stackname"

--- a/terraform/projects/infra-s3-mirrors/README.md
+++ b/terraform/projects/infra-s3-mirrors/README.md
@@ -13,6 +13,4 @@ govuk-mirror-{env}: The bucket that will hold the mirror content
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
-| remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
-| stackname | Stackname | string | - | yes |
 

--- a/terraform/projects/infra-s3-mirrors/main.tf
+++ b/terraform/projects/infra-s3-mirrors/main.tf
@@ -19,16 +19,6 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
-variable "stackname" {
-  type        = "string"
-  description = "Stackname"
-}
-
-variable "remote_state_bucket" {
-  type        = "string"
-  description = "S3 bucket we store our terraform state in"
-}
-
 # Resources
 # --------------------------------------------------------------
 


### PR DESCRIPTION
Somewhat related to [1], there are some unused variables in a few projects. I ended up looking at the `vpc_id` variable to the `node_group` module, as something with the same name was mentioned in [1].

1: https://github.com/alphagov/govuk-aws/pull/944

These commits remove most of the unused variables, less configuration is better.

There are a couple that I left, `apt_public_service_names` and `apt_public_service_cnames` in `infra-public-services` as there looks to be a related `TODO` in the file, and there are values for these variables in govuk-aws-data.

I used this code to find the unused variables: https://github.com/pecigonzalo/pre-commit-terraform-vars