### PR TITLE
Remove warehouse related entries from infra-public-services

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -97,8 +97,6 @@ This project adds global resources for app components:
 | transition_db_admin_internal_service_names |  | list | `<list>` | no |
 | transition_postgresql_internal_service_names |  | list | `<list>` | no |
 | ubuntutest_public_service_names |  | list | `<list>` | no |
-| warehouse_db_admin_internal_service_names |  | list | `<list>` | no |
-| warehouse_postgresql_internal_service_names |  | list | `<list>` | no |
 | whitehall_backend_internal_service_cnames |  | list | `<list>` | no |
 | whitehall_backend_internal_service_names |  | list | `<list>` | no |
 | whitehall_backend_public_service_cnames |  | list | `<list>` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -404,16 +404,6 @@ variable "transition_postgresql_internal_service_names" {
   default = []
 }
 
-variable "warehouse_db_admin_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "warehouse_postgresql_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
 variable "publishing-api_db_admin_internal_service_names" {
   type    = "list"
   default = []
@@ -2036,32 +2026,6 @@ resource "aws_route53_record" "transition_postgresql_internal_service_names" {
   name    = "${element(var.transition_postgresql_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
   type    = "CNAME"
   records = ["${element(var.transition_postgresql_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
-# warehouse_db_admin
-#
-
-resource "aws_route53_record" "warehouse_db_admin_internal_service_names" {
-  count   = "${length(var.warehouse_db_admin_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
-  name    = "${element(var.warehouse_db_admin_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.warehouse_db_admin_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
-# warehouse_postgresql
-#
-
-resource "aws_route53_record" "warehouse_postgresql_internal_service_names" {
-  count   = "${length(var.warehouse_postgresql_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
-  name    = "${element(var.warehouse_postgresql_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.warehouse_postgresql_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
   ttl     = "300"
 }
 


### PR DESCRIPTION
The corresponding resources have now been removed, as the Content
Performance Manager has not been migrated over to AWS, under the new
Content Data API name.