### PR TITLE
Update the kms_sops_policy for the internal_admin role

### DIFF
--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -325,7 +325,7 @@ data "aws_iam_policy_document" "kms_sops_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${module.role_admin.role_arn}"]
+      identifiers = ["${module.role_admin.role_arn}", "${module.role_internal_admin.role_arn}"]
     }
   }
 
@@ -344,7 +344,7 @@ data "aws_iam_policy_document" "kms_sops_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${module.role_admin.role_arn}"]
+      identifiers = ["${module.role_admin.role_arn}", "${module.role_internal_admin.role_arn}"]
     }
   }
 
@@ -361,7 +361,7 @@ data "aws_iam_policy_document" "kms_sops_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${module.role_admin.role_arn}"]
+      identifiers = ["${module.role_admin.role_arn}", "${module.role_internal_admin.role_arn}"]
     }
   }
 }


### PR DESCRIPTION
The govuk-internal-administrators role is intended to be the same as
the govuk-administrators role, except from the name. Ana pointed out
that the Role ARN was missing here.