### PR TITLE
Switch db-admin to read from only production S3 buckets

### DIFF
--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -159,22 +159,20 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
   }
 }
 
+# All environments should be able to write to the backups bucket for
+# their respective environment.
 resource "aws_iam_role_policy_attachment" "write_db-admin_database_backups_iam_role_policy_attachment" {
   count      = 1
   role       = "${module.db-admin.instance_iam_role_name}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.dbadmin_write_database_backups_bucket_policy_arn}"
 }
 
-resource "aws_iam_role_policy_attachment" "read_integration_db-admin_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment == "integration" ? 1 : 0}"
+# All environments should be able to read from the production database
+# backups bucket, to enable restoring the backups, and the overnight
+# data syncs.
+resource "aws_iam_role_policy_attachment" "read_from_production_database_backups_from_production_iam_role_policy_attachment" {
   role       = "${module.db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.integration_dbadmin_read_database_backups_bucket_policy_arn}"
-}
-
-resource "aws_iam_role_policy_attachment" "read_staging_db-admin_database_backups_iam_role_policy_attachment" {
-  count      = "${var.aws_environment == "staging" ? 1 : 0}"
-  role       = "${module.db-admin.instance_iam_role_name}"
-  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.staging_dbadmin_read_database_backups_bucket_policy_arn}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.production_dbadmin_read_database_backups_bucket_policy_arn}"
 }
 
 resource "aws_iam_policy" "db-admin_iam_policy" {


### PR DESCRIPTION
Previously this policy disallowed staging and integration to read from
production backup buckets and instead only their own environments, for
example integration could read from integration and staging
could read from staging.

However this does not work where backups are configured to read from
production, which is the case of the only database using this:
content_data_admin. Therefore this follows the same precedence of
app-content-data-api-db-admin [1] of allowing all environments to read
from production and all to write to their own environment.

[1]: https://github.com/alphagov/govuk-aws/blob/cb4d427c8ece83f69ae0a7cf8abf8c635e8e3519/terraform/projects/app-content-data-api-db-admin/main.tf