### PR TITLE
Remove redundant configuration from infra-database-backups-bucket

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -36,7 +36,6 @@ database-backups: The bucket that will hold database backups
 | integration_mongodb_read_database_backups_bucket_policy_arn | ARN of the integration read mongodb database_backups-bucket policy |
 | integration_publishing-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the integration read publishing-apiDBAdmin database_backups-bucket policy |
 | integration_transition_dbadmin_read_database_backups_bucket_policy_arn | ARN of the integration read TransitionDBAdmin database_backups-bucket policy |
-| integration_warehouse_dbadmin_read_database_backups_bucket_policy_arn | ARN of the integration read WarehouseDBAdmin database_backups-bucket policy |
 | mongo_api_write_database_backups_bucket_policy_arn | ARN of the mongo-api write database_backups-bucket policy |
 | mongo_router_write_database_backups_bucket_policy_arn | ARN of the router_backend write database_backups-bucket policy |
 | mongodb_write_database_backups_bucket_policy_arn | ARN of the mongodb write database_backups-bucket policy |
@@ -50,7 +49,6 @@ database-backups: The bucket that will hold database backups
 | production_mongodb_read_database_backups_bucket_policy_arn | ARN of the production read mongodb database_backups-bucket policy |
 | production_publishing-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the production read publishing-apiDBAdmin database_backups-bucket policy |
 | production_transition_dbadmin_read_database_backups_bucket_policy_arn | ARN of the production read TransitionDBAdmin database_backups-bucket policy |
-| production_warehouse_dbadmin_read_database_backups_bucket_policy_arn | ARN of the production read WarehouseDBAdmin database_backups-bucket policy |
 | publishing-api_dbadmin_write_database_backups_bucket_policy_arn | ARN of the publishing-apiDBAdmin write database_backups-bucket policy |
 | staging_dbadmin_read_database_backups_bucket_policy_arn | ARN of the staging read DBAdmin database_backups-bucket policy |
 | staging_elasticsearch_read_database_backups_bucket_policy_arn | ARN of the staging read elasticsearch database_backups-bucket policy |
@@ -61,7 +59,5 @@ database-backups: The bucket that will hold database backups
 | staging_mongodb_read_database_backups_bucket_policy_arn | ARN of the staging read mongodb database_backups-bucket policy |
 | staging_publishing-api_dbadmin_read_database_backups_bucket_policy_arn | ARN of the staging read publishing-apiDBAdmin database_backups-bucket policy |
 | staging_transition_dbadmin_read_database_backups_bucket_policy_arn | ARN of the staging read TransitionDBAdmin database_backups-bucket policy |
-| staging_warehouse_dbadmin_read_database_backups_bucket_policy_arn | ARN of the staging read WarehouseDBAdmin database_backups-bucket policy |
 | transition_dbadmin_write_database_backups_bucket_policy_arn | ARN of the TransitionDBAdmin write database_backups-bucket policy |
-| warehouse_dbadmin_write_database_backups_bucket_policy_arn | ARN of the WarehouseDBAdmin write database_backups-bucket policy |
 

--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -396,31 +396,6 @@ data "aws_iam_policy_document" "integration_transition_dbadmin_database_backups_
   }
 }
 
-resource "aws_iam_policy" "integration_warehouse_dbadmin_database_backups_reader" {
-  name        = "govuk-integration-warehouse_dbadmin_database_backups-reader-policy"
-  policy      = "${data.aws_iam_policy_document.integration_warehouse_dbadmin_database_backups_reader.json}"
-  description = "Allows reading the warehouse_dbadmin database_backups bucket"
-}
-
-data "aws_iam_policy_document" "integration_warehouse_dbadmin_database_backups_reader" {
-  statement {
-    sid = "WarehouseDBAdminReadBucket"
-
-    actions = [
-      "s3:Get*",
-      "s3:List*",
-    ]
-
-    # Need access to the top level of the tree.
-    resources = [
-      "arn:aws:s3:::govuk-integration-database-backups",
-      "arn:aws:s3:::govuk-integration-database-backups/*warehouse*",
-      "arn:aws:s3:::govuk-staging-database-backups",
-      "arn:aws:s3:::govuk-staging-database-backups/*warehouse*",
-    ]
-  }
-}
-
 resource "aws_iam_policy" "integration_publishing-api_dbadmin_database_backups_reader" {
   name        = "govuk-integration-publishing-api_dbadmin_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.integration_publishing-api_dbadmin_database_backups_reader.json}"
@@ -628,29 +603,6 @@ data "aws_iam_policy_document" "staging_transition_dbadmin_database_backups_read
     resources = [
       "arn:aws:s3:::govuk-staging-database-backups",
       "arn:aws:s3:::govuk-staging-database-backups/*transition*",
-    ]
-  }
-}
-
-resource "aws_iam_policy" "staging_warehouse_dbadmin_database_backups_reader" {
-  name        = "govuk-staging-warehouse_dbadmin_database_backups-reader-policy"
-  policy      = "${data.aws_iam_policy_document.staging_warehouse_dbadmin_database_backups_reader.json}"
-  description = "Allows reading the warehouse_dbadmin database_backups bucket"
-}
-
-data "aws_iam_policy_document" "staging_warehouse_dbadmin_database_backups_reader" {
-  statement {
-    sid = "WarehouseDBAdminReadBucket"
-
-    actions = [
-      "s3:Get*",
-      "s3:List*",
-    ]
-
-    # Need access to the top level of the tree.
-    resources = [
-      "arn:aws:s3:::govuk-staging-database-backups",
-      "arn:aws:s3:::govuk-staging-database-backups/*warehouse*",
     ]
   }
 }
@@ -905,29 +857,6 @@ data "aws_iam_policy_document" "production_transition_dbadmin_database_backups_r
   }
 }
 
-resource "aws_iam_policy" "production_warehouse_dbadmin_database_backups_reader" {
-  name        = "govuk-production-warehouse_dbadmin_database_backups-reader-policy"
-  policy      = "${data.aws_iam_policy_document.production_warehouse_dbadmin_database_backups_reader.json}"
-  description = "Allows reading the warehouse_dbadmin database_backups bucket"
-}
-
-data "aws_iam_policy_document" "production_warehouse_dbadmin_database_backups_reader" {
-  statement {
-    sid = "WarehouseDBAdminReadBucket"
-
-    actions = [
-      "s3:Get*",
-      "s3:List*",
-    ]
-
-    # Need access to the top level of the tree.
-    resources = [
-      "arn:aws:s3:::govuk-production-database-backups",
-      "arn:aws:s3:::govuk-production-database-backups/*warehouse*",
-    ]
-  }
-}
-
 resource "aws_iam_policy" "production_publishing-api_dbadmin_database_backups_reader" {
   name        = "govuk-production-publishing-api_dbadmin_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.production_publishing-api_dbadmin_database_backups_reader.json}"
@@ -1032,11 +961,6 @@ output "integration_publishing-api_dbadmin_read_database_backups_bucket_policy_a
   description = "ARN of the integration read publishing-apiDBAdmin database_backups-bucket policy"
 }
 
-output "integration_warehouse_dbadmin_read_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.integration_warehouse_dbadmin_database_backups_reader.arn}"
-  description = "ARN of the integration read WarehouseDBAdmin database_backups-bucket policy"
-}
-
 output "integration_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.integration_email-alert-api_dbadmin_database_backups_reader.arn}"
   description = "ARN of the integration read EmailAlertAPUDBAdmin database_backups-bucket policy"
@@ -1080,11 +1004,6 @@ output "staging_transition_dbadmin_read_database_backups_bucket_policy_arn" {
 output "staging_publishing-api_dbadmin_read_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.staging_publishing-api_dbadmin_database_backups_reader.arn}"
   description = "ARN of the staging read publishing-apiDBAdmin database_backups-bucket policy"
-}
-
-output "staging_warehouse_dbadmin_read_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.staging_warehouse_dbadmin_database_backups_reader.arn}"
-  description = "ARN of the staging read WarehouseDBAdmin database_backups-bucket policy"
 }
 
 output "staging_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn" {
@@ -1135,11 +1054,6 @@ output "production_transition_dbadmin_read_database_backups_bucket_policy_arn" {
 output "production_publishing-api_dbadmin_read_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.production_publishing-api_dbadmin_database_backups_reader.arn}"
   description = "ARN of the production read publishing-apiDBAdmin database_backups-bucket policy"
-}
-
-output "production_warehouse_dbadmin_read_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.production_warehouse_dbadmin_database_backups_reader.arn}"
-  description = "ARN of the production read WarehouseDBAdmin database_backups-bucket policy"
 }
 
 output "production_email-alert-api_dbadmin_read_database_backups_bucket_policy_arn" {

--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -411,63 +411,6 @@ data "aws_iam_policy_document" "transition_dbadmin_database_backups_writer" {
   }
 }
 
-resource "aws_iam_policy" "warehouse_dbadmin_database_backups_writer" {
-  name        = "govuk-${var.aws_environment}-warehouse_dbadmin_database_backups-writer-policy"
-  policy      = "${data.aws_iam_policy_document.warehouse_dbadmin_database_backups_writer.json}"
-  description = "Allows writing of the WarehouseDBAdmin database_backups bucket"
-}
-
-data "aws_iam_policy_document" "warehouse_dbadmin_database_backups_writer" {
-  statement {
-    sid = "ReadListOfBuckets"
-
-    actions = [
-      "s3:ListAllMyBuckets",
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    sid = "WarehouseDBAdminReadBucketLists"
-
-    actions = [
-      "s3:ListBucket",
-      "s3:GetBucketLocation",
-    ]
-
-    # The top level access is required.
-    resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}",
-    ]
-
-    # We can now apply restictions on what can be accessed.
-    condition {
-      test     = "StringLike"
-      variable = "s3:prefix"
-
-      values = [
-        "mysql",
-        "postgres",
-      ]
-    }
-  }
-
-  statement {
-    sid = "WarehouseDBAdminWriteGovukDatabaseBackups"
-
-    actions = [
-      "s3:PutObject",
-      "s3:GetObject",
-      "s3:DeleteObject",
-    ]
-
-    resources = [
-      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*warehouse*",
-    ]
-  }
-}
-
 resource "aws_iam_policy" "publishing-api_dbadmin_database_backups_writer" {
   name        = "govuk-${var.aws_environment}-publishing-api_dbadmin_database_backups-writer-policy"
   policy      = "${data.aws_iam_policy_document.publishing-api_dbadmin_database_backups_writer.json}"
@@ -671,11 +614,6 @@ output "content_data_api_dbadmin_write_database_backups_bucket_policy_arn" {
 output "transition_dbadmin_write_database_backups_bucket_policy_arn" {
   value       = "${aws_iam_policy.transition_dbadmin_database_backups_writer.arn}"
   description = "ARN of the TransitionDBAdmin write database_backups-bucket policy"
-}
-
-output "warehouse_dbadmin_write_database_backups_bucket_policy_arn" {
-  value       = "${aws_iam_policy.warehouse_dbadmin_database_backups_writer.arn}"
-  description = "ARN of the WarehouseDBAdmin write database_backups-bucket policy"
 }
 
 output "publishing-api_dbadmin_write_database_backups_bucket_policy_arn" {


### PR DESCRIPTION
This configuration related to the "warehouse" related to the Content
Performance Manager. This has now been renamed to the Content Data
API, so this configuration is now redundant.