### PR TITLE
Remove access to the warehouse-postgresql files

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -873,11 +873,6 @@ data "aws_iam_policy_document" "production_content_data_api_dbadmin_database_bac
       # This can be removed once the Content Data API is changed to
       # use the content_data_api_production database
       "arn:aws:s3:::govuk-production-database-backups/content-data-api-postgresql/*-content_performance_manager_production.gz",
-
-      # The following resource is for the backups from Carrenza, and
-      # can be removed when the Content Performance Manager no longer
-      # runs there
-      "arn:aws:s3:::govuk-production-database-backups/warehouse-postgresql/*-content_performance_manager_production.gz",
     ]
   }
 }


### PR DESCRIPTION
This configuration related to accessing the Content Performance
Manager database backup from Carrenza, in AWS, as part of the
migration to AWS.

This migration has now happened, with the application being called the
Content Data API in AWS, so this configuration is no longer necessary.