### PR TITLE
Add ALB and app health checks to app-draft-frontend

### DIFF
--- a/terraform/projects/app-draft-frontend/README.md
+++ b/terraform/projects/app-draft-frontend/README.md
@@ -12,6 +12,7 @@ Draft Frontend application servers
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| enable_alb | Use application specific target groups and healthchecks based on the list of services in the cname variable. | string | `false` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -42,6 +42,12 @@ variable "asg_size" {
   default     = "2"
 }
 
+variable "enable_alb" {
+  type        = "string"
+  description = "Use application specific target groups and healthchecks based on the list of services in the cname variable."
+  default     = false
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -103,8 +109,8 @@ resource "aws_route53_record" "draft-frontend_service_record" {
   type    = "A"
 
   alias {
-    name                   = "${aws_elb.draft-frontend_elb.dns_name}"
-    zone_id                = "${aws_elb.draft-frontend_elb.zone_id}"
+    name                   = "${var.enable_alb ? module.internal_lb.lb_dns_name : aws_elb.draft-frontend_elb.dns_name}"
+    zone_id                = "${var.enable_alb ? module.internal_lb.lb_zone_id  : aws_elb.draft-frontend_elb.zone_id}"
     evaluate_target_health = true
   }
 }
@@ -118,21 +124,50 @@ resource "aws_route53_record" "app_service_records" {
   ttl     = "300"
 }
 
+module "internal_lb" {
+  source                                     = "../../modules/aws/lb"
+  name                                       = "${var.stackname}-draft-frontend-internal"
+  internal                                   = true
+  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix                  = "elb/${var.stackname}-draft-frontend-internal-elb"
+  listener_certificate_domain_name           = "${var.elb_internal_certname}"
+  listener_secondary_certificate_domain_name = ""
+  listener_action                            = "${map("HTTPS:443", "HTTP:80")}"
+  subnets                                    = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
+  security_groups                            = ["${data.terraform_remote_state.infra_security_groups.sg_draft-frontend_elb_id}"]
+  alarm_actions                              = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  default_tags                               = "${map("Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "draft_frontend")}"
+}
+
+module "internal_lb_rules" {
+  source                 = "../../modules/aws/lb_listener_rules"
+  name                   = "draft-frontend-i"
+  autoscaling_group_name = "${module.draft-frontend.autoscaling_group_name}"
+  rules_host_domain      = "*"
+  vpc_id                 = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  listener_arn           = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  rules_host             = ["${concat(list("draft-frontend"), var.app_service_records)}"]
+  default_tags           = "${map("Project", var.stackname, "aws_migration", "draft_frontend", "aws_environment", var.aws_environment)}"
+}
+
 module "draft-frontend" {
-  source                        = "../../modules/aws/node_group"
-  name                          = "${var.stackname}-draft-frontend"
-  default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "draft_frontend", "aws_hostname", "draft-frontend-1")}"
-  instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
-  instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_draft-frontend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.large"
-  instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
-  instance_elb_ids_length       = "1"
-  instance_elb_ids              = ["${aws_elb.draft-frontend_elb.id}"]
-  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
-  asg_max_size                  = "${var.asg_size}"
-  asg_min_size                  = "${var.asg_size}"
-  asg_desired_capacity          = "${var.asg_size}"
-  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  source                            = "../../modules/aws/node_group"
+  name                              = "${var.stackname}-draft-frontend"
+  default_tags                      = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "draft_frontend", "aws_hostname", "draft-frontend-1")}"
+  instance_subnet_ids               = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
+  instance_security_group_ids       = ["${data.terraform_remote_state.infra_security_groups.sg_draft-frontend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
+  instance_type                     = "m5.large"
+  instance_additional_user_data     = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
+  instance_elb_ids_length           = "1"
+  instance_elb_ids                  = ["${aws_elb.draft-frontend_elb.id}"]
+  instance_target_group_arns_length = "${var.enable_alb ? 1 : 0}"
+  instance_target_group_arns        = ["${var.enable_alb ? module.internal_lb.target_group_arns[0] : ""}"]
+  instance_ami_filter_name          = "${var.instance_ami_filter_name}"
+  asg_max_size                      = "${var.asg_size}"
+  asg_min_size                      = "${var.asg_size}"
+  asg_desired_capacity              = "${var.asg_size}"
+  asg_notification_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
 }
 
 module "alarms-elb-draft-frontend-internal" {


### PR DESCRIPTION
We want to send traffic to each instance only when the application
has been deployed and is healthy. The draft-frontend class only
has an internal ELB to receive traffic. In order to use application
specific health check paths from a LB, we need to use an ALB instead
of ELB and create application specific target groups/health checks
with the lb_listener_rules module.

We initially create a new ALB, and we can move traffic to this new LB
with the `enable_alb` parameter. This parameter updates the ALIAS of
the main service record to point to the ALB instead of the original ELB.
Once we have migrated all the traffic to ALBs, we can remove the code and
resources of the original ELB.