### PR TITLE
Add ALB and app health checks to app-frontend

### DIFF
--- a/terraform/projects/app-frontend/README.md
+++ b/terraform/projects/app-frontend/README.md
@@ -12,6 +12,7 @@ Frontend application servers
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| enable_alb | Use application specific target groups and healthchecks based on the list of services in the cname variable. | string | `false` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | instance_type | Instance type | string | `m5.xlarge` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |


### PR DESCRIPTION
Add an ALB to app-frontend to be able to implement application
specific forward rules and health checks.

We use the `enable_alb` variable to update the target of the
service DNS record to resolve to the ALB instead of the original
ELB.