### PR TITLE
Remove bad character at the end of the target group name

### DIFF
--- a/terraform/modules/aws/lb_listener_rules/main.tf
+++ b/terraform/modules/aws/lb_listener_rules/main.tf
@@ -103,7 +103,7 @@ variable "target_group_health_check_matcher" {
 
 resource "aws_lb_target_group" "tg" {
   count                = "${length(var.rules_host)}"
-  name                 = "${format("%.10s-%.21s", var.name, var.rules_host[count.index])}"
+  name                 = "${replace(format("%.10s-%.21s", var.name, var.rules_host[count.index]), "/-$/", "")}"
   port                 = "${var.target_group_port}"
   protocol             = "${var.target_group_protocol}"
   vpc_id               = "${var.vpc_id}"


### PR DESCRIPTION
The LB target group name can't be longer than 32 characters. We are using
`format` to ensure we don't pass that limit, but sometimes this can result
in the `-` character appearing at the end of the string, which is also
not allowed an causes an error. For instance:

```
aws_lb_target_group.tg.6: Error creating LB Target Group: ValidationError:
Target group name 'draft-fron-draft-service-manual-' cannot begin or end with '-'
```

We are going to explicity remove this character if it appears at the end
of the generated string.