### PR TITLE
Enlarge volume for app-draft-frontend instances

### DIFF
--- a/terraform/projects/app-draft-frontend/README.md
+++ b/terraform/projects/app-draft-frontend/README.md
@@ -21,6 +21,7 @@ Draft Frontend application servers
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| root_block_device_volume_size | The size of the instance root volume in gigabytes | string | `40` | no |
 | stackname | Stackname | string | - | yes |
 | user_data_snippets | List of user-data snippets | list | - | yes |
 

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -48,6 +48,12 @@ variable "enable_alb" {
   default     = false
 }
 
+variable "root_block_device_volume_size" {
+  type        = "string"
+  description = "The size of the instance root volume in gigabytes"
+  default     = "40"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -168,6 +174,7 @@ module "draft-frontend" {
   asg_min_size                      = "${var.asg_size}"
   asg_desired_capacity              = "${var.asg_size}"
   asg_notification_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size     = "${var.root_block_device_volume_size}"
 }
 
 module "alarms-elb-draft-frontend-internal" {


### PR DESCRIPTION
Add new variable to main.tf to allow for a custom volume size.

One of the instances in the autoscaling group is running out of inodes
There doesn't seem to be anything significant we can delete, so we
are increasing the volume size.