### PR TITLE
Enlarge volume for app-backend instances

### DIFF
--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -200,7 +200,7 @@ module "backend" {
   asg_min_size                  = "${var.asg_size}"
   asg_desired_capacity          = "${var.asg_size}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
-  root_block_device_volume_size = "30"
+  root_block_device_volume_size = "60"
 }
 
 module "alarms-elb-backend-internal" {


### PR DESCRIPTION
One of the instances in the autoscaling group is running out of space
There doesn't seem to be anything significant we can delete, so we
are increasing the volume size.