### PR TITLE
Add Cyber security audit role

### DIFF
--- a/terraform/projects/infra-cyber-security-audit/README.md
+++ b/terraform/projects/infra-cyber-security-audit/README.md
@@ -1,0 +1,12 @@
+## Module: projects/infra-cyber-security-audit
+
+Role and policy for Cyber security audit, to eventually deprecate the CSW-specific role
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_region |  | string | `eu-west-1` | no |
+| chain_account_id |  | string | `988997429095` | no |
+

--- a/terraform/projects/infra-cyber-security-audit/integration.govuk.backend
+++ b/terraform/projects/infra-cyber-security-audit/integration.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "govuk/infra-cyber-security-audit.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-cyber-security-audit/main.tf
+++ b/terraform/projects/infra-cyber-security-audit/main.tf
@@ -1,0 +1,33 @@
+/**
+* ## Module: projects/infra-cyber-security-audit
+*
+* Role and policy for Cyber security audit, to eventually deprecate the CSW-specific role
+*/
+
+variable "chain_account_id" {
+  type    = "string"
+  default = "988997429095"
+}
+
+variable "aws_region" {
+  type    = "string"
+  default = "eu-west-1"
+}
+
+# Resources
+# --------------------------------------------------------------
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.60.0"
+}
+
+module "cyber_security_audit_role" {
+  source = "git::https://github.com/alphagov/tech-ops//cyber-security/modules/gds_security_audit_role?ref=2d39415f6f92874dcf5eaee376f4d0af49992b8d"
+
+  chain_account_id = "988997429095"
+}

--- a/terraform/projects/infra-cyber-security-audit/production.govuk.backend
+++ b/terraform/projects/infra-cyber-security-audit/production.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "govuk/infra-cyber-security-audit.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-cyber-security-audit/staging.govuk.backend
+++ b/terraform/projects/infra-cyber-security-audit/staging.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+key     = "govuk/infra-cyber-security-audit.tfstate"
+encrypt = true
+region  = "eu-west-1"


### PR DESCRIPTION
This was requested by cyber to provide access to TrustedAdvisor
resources to them across the GDS estate

solo: @schmie