### PR TITLE
Update app-content-store for Training environment

### DIFF
--- a/terraform/projects/app-content-store/README.md
+++ b/terraform/projects/app-content-store/README.md
@@ -10,9 +10,14 @@ content-store node
 | asg_size | The autoscaling groups desired/max/min capacity | string | `2` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| create_external_elb | Create the external ELB | string | `true` | no |
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
+| external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -41,11 +41,46 @@ variable "asg_size" {
   default     = "2"
 }
 
+variable "internal_zone_name" {
+  type        = "string"
+  description = "The name of the Route53 zone that contains internal records"
+}
+
+variable "internal_domain_name" {
+  type        = "string"
+  description = "The domain name of the internal DNS records, it could be different from the zone name"
+}
+
+variable "external_zone_name" {
+  type        = "string"
+  description = "The name of the Route53 zone that contains external records"
+}
+
+variable "external_domain_name" {
+  type        = "string"
+  description = "The domain name of the external DNS records, it could be different from the zone name"
+}
+
+variable "create_external_elb" {
+  description = "Create the external ELB"
+  default     = true
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
   backend          "s3"             {}
   required_version = "= 0.11.7"
+}
+
+data "aws_route53_zone" "internal" {
+  name         = "${var.internal_zone_name}"
+  private_zone = true
+}
+
+data "aws_route53_zone" "external" {
+  name         = "${var.external_zone_name}"
+  private_zone = false
 }
 
 provider "aws" {
@@ -64,6 +99,8 @@ data "aws_acm_certificate" "elb_internal_cert" {
 }
 
 resource "aws_elb" "content-store_external_elb" {
+  count = "${var.create_external_elb}"
+
   name            = "${var.stackname}-content-store-external"
   subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_external_elb_id}"]
@@ -101,8 +138,10 @@ resource "aws_elb" "content-store_external_elb" {
 }
 
 resource "aws_route53_record" "external_service_record" {
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
-  name    = "content-store.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
+  count = "${var.create_external_elb}"
+
+  zone_id = "${data.aws_route53_zone.external.zone_id}"
+  name    = "content-store.${var.external_domain_name}"
   type    = "A"
 
   alias {
@@ -150,8 +189,8 @@ resource "aws_elb" "content-store_internal_elb" {
 }
 
 resource "aws_route53_record" "internal_service_record" {
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
-  name    = "content-store.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
+  zone_id = "${data.aws_route53_zone.internal.zone_id}"
+  name    = "content-store.${var.internal_domain_name}"
   type    = "A"
 
   alias {
@@ -159,6 +198,11 @@ resource "aws_route53_record" "internal_service_record" {
     zone_id                = "${aws_elb.content-store_internal_elb.zone_id}"
     evaluate_target_health = true
   }
+}
+
+locals {
+  instance_elb_ids_length = "${var.create_external_elb ? 2 : 1}"
+  instance_elb_ids        = "${compact(list(aws_elb.content-store_internal_elb.id, join("", aws_elb.content-store_external_elb.*.id)))}"
 }
 
 module "content-store" {
@@ -169,8 +213,8 @@ module "content-store" {
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "m5.large"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
-  instance_elb_ids_length       = "2"
-  instance_elb_ids              = ["${aws_elb.content-store_external_elb.id}", "${aws_elb.content-store_internal_elb.id}"]
+  instance_elb_ids_length       = "${local.instance_elb_ids_length}"
+  instance_elb_ids              = ["${local.instance_elb_ids}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "${var.asg_size}"
   asg_min_size                  = "${var.asg_size}"
@@ -192,15 +236,20 @@ module "alarms-elb-content-store-internal" {
   healthyhostcount_threshold     = "0"
 }
 
+locals {
+  elb_httpcode_backend_5xx_threshold = "${var.create_external_elb ? 50 : 0}"
+  elb_httpcode_elb_5xx_threshold     = "${var.create_external_elb ? 50 : 0}"
+}
+
 module "alarms-elb-content-store-external" {
   source                         = "../../modules/aws/alarms/elb"
   name_prefix                    = "${var.stackname}-content-store-external"
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  elb_name                       = "${aws_elb.content-store_external_elb.name}"
+  elb_name                       = "${join("", aws_elb.content-store_external_elb.*.name)}"
   httpcode_backend_4xx_threshold = "0"
-  httpcode_backend_5xx_threshold = "50"
+  httpcode_backend_5xx_threshold = "${local.elb_httpcode_backend_5xx_threshold}"
   httpcode_elb_4xx_threshold     = "0"
-  httpcode_elb_5xx_threshold     = "50"
+  httpcode_elb_5xx_threshold     = "${local.elb_httpcode_elb_5xx_threshold}"
   surgequeuelength_threshold     = "0"
   healthyhostcount_threshold     = "0"
 }
@@ -209,12 +258,12 @@ module "alarms-elb-content-store-external" {
 # --------------------------------------------------------------
 
 output "content-store_elb_address" {
-  value       = "${aws_elb.content-store_external_elb.dns_name}"
+  value       = "${join("", aws_elb.content-store_external_elb.*.dns_name)}"
   description = "AWS' internal DNS name for the content-store ELB"
 }
 
 output "external_service_dns_name" {
-  value       = "${aws_route53_record.external_service_record.name}"
+  value       = "${join("", aws_route53_record.external_service_record.*.name)}"
   description = "DNS name to access the node service"
 }
 

--- a/terraform/projects/app-content-store/training.govuk.backend
+++ b/terraform/projects/app-content-store/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-content-store.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add backend to build app-content-store in the Training environment.

Add parameters to select which domain to use with the DNS records (Training
does not use the stack domain).