### PR TITLE
Update app-publishing-api-db-admin for Training environment

### DIFF
--- a/terraform/projects/app-publishing-api-db-admin/README.md
+++ b/terraform/projects/app-publishing-api-db-admin/README.md
@@ -9,6 +9,8 @@ DB admin boxes for publishing-api's RDS instance
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_database_backups_bucket_key_stack | Override stackname path to infra_database_backups_bucket remote state | string | `` | no |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-publishing-api-db-admin/main.tf
+++ b/terraform/projects/app-publishing-api-db-admin/main.tf
@@ -25,11 +25,26 @@ variable "remote_state_infra_database_backups_bucket_key_stack" {
   default     = ""
 }
 
+variable "internal_zone_name" {
+  type        = "string"
+  description = "The name of the Route53 zone that contains internal records"
+}
+
+variable "internal_domain_name" {
+  type        = "string"
+  description = "The domain name of the internal DNS records, it could be different from the zone name"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
   backend          "s3"             {}
   required_version = "= 0.11.7"
+}
+
+data "aws_route53_zone" "internal" {
+  name         = "${var.internal_zone_name}"
+  private_zone = true
 }
 
 provider "aws" {
@@ -91,8 +106,8 @@ module "publishing-api-db-admin" {
 }
 
 resource "aws_route53_record" "publishing-api_db_admin_service_record" {
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
-  name    = "publishing-api-db-admin.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
+  zone_id = "${data.aws_route53_zone.internal.zone_id}"
+  name    = "publishing-api-db-admin.${var.internal_domain_name}"
   type    = "A"
 
   alias {
@@ -124,7 +139,7 @@ data "terraform_remote_state" "infra_database_backups_bucket" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_database_backups_bucket_key_stack, var.stackname)}/infra-database-backups-bucket.tfstate"
-    region = "eu-west-1"
+    region = "${var.aws_region}"
   }
 }
 

--- a/terraform/projects/app-publishing-api-db-admin/training.govuk.backend
+++ b/terraform/projects/app-publishing-api-db-admin/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-publishing-api-db-admin.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add backend to build app-publishing-api-db-admin in the Training environment.

Add parameters to select which domain to use with the DNS records (Training
does not use the stack domain).