### PR TITLE
set terraform version to be the same as in main.tf i.e. 1.60

### DIFF
--- a/terraform/projects/infra-monitoring/secondary.tf
+++ b/terraform/projects/infra-monitoring/secondary.tf
@@ -16,7 +16,7 @@ variable "aws_secondary_region" {
 provider "aws" {
   alias   = "aws_secondary"
   region  = "${var.aws_secondary_region}"
-  version = "1.40.0"
+  version = "1.60.0"
 }
 
 data "template_file" "s3_aws_secondary_logging_policy_template" {


### PR DESCRIPTION
# Context

The aws terraform plugin version is now set to 1.60.0 in the main.tf and therefore all tf files in this project should be set to 1.60 to avoid mixing versions and causing an error.

# Decisions
1. set 1.40.0 in the secondary.tf file.