### PR TITLE
add backend for production version of infra-google-mirror-bucket

### DIFF
--- a/doc/guides/deploying-google-terraform.md
+++ b/doc/guides/deploying-google-terraform.md
@@ -7,46 +7,11 @@ Platform (GCP). At the time of writing, there are very few resources in
 GCP that are under the control of terraform. The terraforming of GCP resources
 started with the new GOV.UK mirror redesign.
 
-### Deployment of GCP-based Terraform Projects
+The first step is an initialisation step for new environment where there is
+not GCP storage bucker to store the terraform state files. This is run once per
+environment.
 
-The deployment of GCP-based terraform projects is similar to the AWS ones
-except for one difference that the GCP credentials will also have to be provided.
-
-The GCP projects can usually be identified by the prefix being:
-`infra-google` or `app-google`.
-
-The steps to deploy a GCP-based terraform project is:
-1. <a name="service_account_credentials"></a> get the GCP service account that you
-   want to use to deploy the project. You can use your general
-   GDS account to authenticate with the GCP web console. You should then consult
-   the GCP documentation about retrieving credentials of a service account
-   [here](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#getting_a_service_account_key) and saving it on your local secure machine.
-
-2. export the location of the service account credentials by doing:
-   ```
-   export GOOGLE_APPLICATION_CREDENTIALS=<service_account_credentials_file_path>
-   ```
-   where `<service_account_credentials_file_path>` is the path where the file
-   containing the service account credentials is located.
-
-3. deploy the terraform project as usual. For e.g. if you use aws-vault:
-   ```
-   aws-vault exec <aws_vault_environment_profile> -- tools/build-terraform-project.sh \
-   -c apply -p <terraform_project_to_be_deployed> -d <govuk_aws_data_path> \
-   -e <govuk_environment> -s <govuk_stack>
-   ```
-   where:
-   1. `<govuk_environment>` is the name of the GOV.UK environment, e.g. staging
-   2. `<aws_vault_environment_profile>` is the name of the aws-vault profile for
-      the AWS account of the specific `<govuk_environment>`. The reason why you
-      *sometimes* need AWS credentials even if you are deploying GCP-based
-      projects is that some projects are dependent on AWS project data. E.g.
-      A GCP resource may need some AWS credentials to do some syncing of AWS S3
-      buckets
-   3. `<govuk_aws_data_path>` is the path where you cloned the *govuk-aws-data*
-       git project
-   4. `<govuk_stack>` is the stack where you want to deploy the project. e.g.
-       govuk
+The second step is to deploy your google-based terraform projects.
 
 ### Google Cloud Storage Backend for Terraform
 
@@ -57,8 +22,18 @@ This GCS bucket was created by doing the following steps:
 1. (if not done already) install the GCP Cloud SDK by following the instructions
    [here](https://cloud.google.com/sdk/)
 
-2. get and export the service account credentials as in the previous
-   section ([Step 1 and 2](#service_account_credentials))
+2. get the GCP service account that you
+   want to use to deploy the project. You can use your general
+   GDS account to authenticate with the GCP web console. You should then consult
+   the GCP documentation about retrieving credentials of a service account
+   [here](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#getting_a_service_account_key) and saving it on your local secure machine.
+
+3. add the service account to the gcloud tool by running:
+   ```
+   gcloud auth activate-service-account --key-file <service_account_credentials_file_path>
+   ```
+   where `<service_account_credentials_file_path>` is the path where the file
+   containing the service account credentials is located.
 
 3. create the GCS bucket:
    ```
@@ -95,5 +70,46 @@ You can then configure a terraform project to use this backend by:
    1. `<govuk_environment>` is the name of the GOV.UK environment, e.g. staging
    2. `<gcp_project_id>` is the project ID of the GCP project where you want to deploy
    3. `<terraform_project_name>` is the name of the terraform project.
+
+### Deployment of GCP-based Terraform Projects
+
+The deployment of GCP-based terraform projects is similar to the AWS ones
+except for one difference that the GCP credentials will also have to be provided.
+
+The GCP projects can usually be identified by the prefix being:
+`infra-google` or `app-google`.
+
+The steps to deploy a GCP-based terraform project is:
+1. get the GCP service account that you
+   want to use to deploy the project. You can use your general
+   GDS account to authenticate with the GCP web console. You should then consult
+   the GCP documentation about retrieving credentials of a service account
+   [here](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#getting_a_service_account_key) and saving it on your local secure machine.
+
+2. export the location of the service account credentials by doing:
+   ```
+   export GOOGLE_APPLICATION_CREDENTIALS=<service_account_credentials_file_path>
+   ```
+   where `<service_account_credentials_file_path>` is the path where the file
+   containing the service account credentials is located.
+
+3. deploy the terraform project as usual. For e.g. if you use aws-vault:
+   ```
+   aws-vault exec <aws_vault_environment_profile> -- tools/build-terraform-project.sh \
+   -c apply -p <terraform_project_to_be_deployed> -d <govuk_aws_data_path> \
+   -e <govuk_environment> -s <govuk_stack>
+   ```
+   where:
+   1. `<govuk_environment>` is the name of the GOV.UK environment, e.g. staging
+   2. `<aws_vault_environment_profile>` is the name of the aws-vault profile for
+      the AWS account of the specific `<govuk_environment>`. The reason why you
+      *sometimes* need AWS credentials even if you are deploying GCP-based
+      projects is that some projects are dependent on AWS project data. E.g.
+      A GCP resource may need some AWS credentials to do some syncing of AWS S3
+      buckets
+   3. `<govuk_aws_data_path>` is the path where you cloned the *govuk-aws-data*
+       git project
+   4. `<govuk_stack>` is the stack where you want to deploy the project. e.g.
+       govuk
 
 You can see an example of a GCP project [here](../../terraform/projects/infra-google-monitoring)

--- a/terraform/projects/infra-google-mirror-bucket/prerequisites.md
+++ b/terraform/projects/infra-google-mirror-bucket/prerequisites.md
@@ -1,0 +1,11 @@
+# Pre-requisites
+
+The following pre-requisites are required:
+1. Google Storage Transfer API must have been enable for this terraform project
+   to be applied successfully. While the google console layout may change, you
+   generally have to:
+   1. log into GCP console and switch to the project where you want to deploy
+       this project
+   2. in the menu bar, select `APIs and Services` and click on
+      `Enable APIs and Services`
+   3. Search for the `Storage Transfer API` and enable it.

--- a/terraform/projects/infra-google-mirror-bucket/production.govuk.backend
+++ b/terraform/projects/infra-google-mirror-bucket/production.govuk.backend
@@ -1,0 +1,3 @@
+bucket  = "govuk-terraform-steppingstone-production"
+project = "govuk-production"
+prefix  = "govuk/infra-google-mirror-bucket"

--- a/terraform/projects/infra-google-monitoring/production.govuk.backend
+++ b/terraform/projects/infra-google-monitoring/production.govuk.backend
@@ -1,0 +1,3 @@
+bucket  = "govuk-terraform-steppingstone-production"
+project = "govuk-production"
+prefix  = "govuk/infra-google-monitoring"


### PR DESCRIPTION
# Context

infra-google-mirror-bucket is now ready for production so we add the production backend to the project as well as the infra-google monitoring which is used to store bucket logs.

The google terraform deployment documentation is also updated.

# Decisions
1. add production backend definitions for infra-google monitoring and infra-google-mirror-bucket
2. update documentation for clarity