### PR TITLE
Remove vpc_id variable from whitehall-backend module

### DIFF
--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -188,7 +188,6 @@ resource "aws_route53_record" "app_service_records" {
 module "whitehall-backend" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-whitehall-backend"
-  vpc_id                        = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "whitehall_backend", "aws_hostname", "whitehall-backend-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]


### PR DESCRIPTION
Looks like this was removed from other projects but
missed here... Removing now for consistency and to prevent
errors:
https://github.com/alphagov/govuk-aws/commit/50b8c7baf35fae6c7de63a46910575e6101934d4