### PR TITLE
Update app-calculators-frontend for Training environment

### DIFF
--- a/terraform/projects/app-calculators-frontend/README.md
+++ b/terraform/projects/app-calculators-frontend/README.md
@@ -15,6 +15,8 @@ Calculators Frontend application servers
 | enable_alb | Use application specific target groups and healthchecks based on the list of services in the cname variable. | string | `false` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | instance_type | Instance type | string | `c5.xlarge` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-calculators-frontend/training.govuk.backend
+++ b/terraform/projects/app-calculators-frontend/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-calculators-frontend.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add backend to build app-calculators-frontend in the Training environment.

Add parameters to select which domain to use with the DNS records (Training
does not use the stack domain).