### PR TITLE
Update app-mongo-api for Training environment

### DIFF
--- a/terraform/projects/app-mongo-api/README.md
+++ b/terraform/projects/app-mongo-api/README.md
@@ -11,6 +11,8 @@ Mongo API hosts
 | aws_region | AWS region | string | `eu-west-1` | no |
 | ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | mongo_1_ip | IP address of the private IP to assign to the instance | string | - | yes |
 | mongo_1_reserved_ips_subnet | Name of the subnet to place the reserved IP of the instance | string | - | yes |
 | mongo_1_subnet | Name of the subnet to place the Mongo instance 1 and EBS volume | string | - | yes |

--- a/terraform/projects/app-mongo-api/training.govuk.backend
+++ b/terraform/projects/app-mongo-api/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-mongo-api.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add backend to build app-mongo-api in the Training environment.

Add parameters to select which domain to use with the DNS records (Training
does not use the stack domain).