### PR TITLE
Update app-mapit for Training environment

### DIFF
--- a/terraform/projects/app-mapit/README.md
+++ b/terraform/projects/app-mapit/README.md
@@ -13,6 +13,8 @@ Mapit node
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | instance_type | The type of EC2 instance to use for both ASGs. | string | `t2.medium` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | mapit_1_subnet | Name of the subnet to place the mapit instance 1 and EBS volume | string | - | yes |
 | mapit_2_subnet | Name of the subnet to place the mapit instance 1 and EBS volume | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -51,11 +51,26 @@ variable "instance_type" {
   default     = "t2.medium"
 }
 
+variable "internal_zone_name" {
+  type        = "string"
+  description = "The name of the Route53 zone that contains internal records"
+}
+
+variable "internal_domain_name" {
+  type        = "string"
+  description = "The domain name of the internal DNS records, it could be different from the zone name"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
   backend          "s3"             {}
   required_version = "= 0.11.7"
+}
+
+data "aws_route53_zone" "internal" {
+  name         = "${var.internal_zone_name}"
+  private_zone = true
 }
 
 provider "aws" {
@@ -107,8 +122,8 @@ resource "aws_elb" "mapit_elb" {
 }
 
 resource "aws_route53_record" "mapit_service_record" {
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
-  name    = "mapit.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
+  zone_id = "${data.aws_route53_zone.internal.zone_id}"
+  name    = "mapit.${var.internal_domain_name}"
   type    = "A"
 
   alias {

--- a/terraform/projects/app-mapit/training.govuk.backend
+++ b/terraform/projects/app-mapit/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-mapit.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add backend to build app-mapit in the Training environment.

Add parameters to select which domain to use with the DNS records (Training
does not use the stack domain).