### PR TITLE
Move code from old deprecated repo for mongodb-backup buckets

### DIFF
--- a/terraform/projects/infra-mongodb-backup/README.md
+++ b/terraform/projects/infra-mongodb-backup/README.md
@@ -1,0 +1,12 @@
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| bucket_name |  | string | `govuk-mongodb-backup-s3` | no |
+| team |  | string | `Infrastructure` | no |
+| username |  | string | `govuk-mongodb-backup-s3` | no |
+| versioning |  | string | `true` | no |
+

--- a/terraform/projects/infra-mongodb-backup/integration.govuk.backend
+++ b/terraform/projects/infra-mongodb-backup/integration.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "govuk/infra-mongodb-backup.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-mongodb-backup/main.tf
+++ b/terraform/projects/infra-mongodb-backup/main.tf
@@ -1,0 +1,123 @@
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "bucket_name" {
+  type    = "string"
+  default = "govuk-mongodb-backup-s3"
+}
+
+variable "team" {
+  type    = "string"
+  default = "Infrastructure"
+}
+
+variable "username" {
+  type    = "string"
+  default = "govuk-mongodb-backup-s3"
+}
+
+variable "versioning" {
+  type    = "string"
+  default = "true"
+}
+
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.60.0"
+}
+
+resource "template_file" "readwrite_policy_file" {
+  template = "${file("templates/readwrite_policy.tpl")}"
+
+  vars {
+    bucket_name     = "${var.bucket_name}"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
+resource "aws_s3_bucket" "govuk-mongodb-backup-s3" {
+  bucket = "${var.bucket_name}-${var.aws_environment}"
+
+  tags {
+    Environment = "${var.aws_environment}"
+    Team        = "${var.team}"
+  }
+
+  versioning {
+    enabled = "${var.versioning}"
+  }
+
+  lifecycle_rule {
+    prefix  = ""
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+
+    noncurrent_version_expiration {
+      days = 7
+    }
+  }
+}
+
+resource "aws_s3_bucket" "govuk-mongodb-backup-s3-daily" {
+  bucket = "${var.bucket_name}-daily-${var.aws_environment}"
+
+  tags {
+    Environment = "${var.aws_environment}"
+    Team        = "${var.team}"
+  }
+
+  versioning {
+    enabled = "${var.versioning}"
+  }
+
+  lifecycle_rule {
+    prefix  = ""
+    enabled = true
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+}
+
+resource "aws_iam_policy" "readwrite_policy" {
+  name        = "${var.bucket_name}_${var.username}-policy"
+  description = "${var.bucket_name} allows writes"
+  policy      = "${template_file.readwrite_policy_file.rendered}"
+}
+
+resource "aws_iam_user" "iam_user" {
+  name = "${var.username}"
+}
+
+resource "aws_iam_policy_attachment" "iam_policy_attachment" {
+  name       = "${var.bucket_name}_${var.username}_attachment_policy"
+  users      = ["${aws_iam_user.iam_user.name}"]
+  policy_arn = "${aws_iam_policy.readwrite_policy.arn}"
+}

--- a/terraform/projects/infra-mongodb-backup/production.govuk.backend
+++ b/terraform/projects/infra-mongodb-backup/production.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "govuk/infra-mongodb-backup.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-mongodb-backup/staging.govuk.backend
+++ b/terraform/projects/infra-mongodb-backup/staging.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+key     = "govuk/infra-mongodb-backup.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-mongodb-backup/templates/readwrite_policy.tpl
+++ b/terraform/projects/infra-mongodb-backup/templates/readwrite_policy.tpl
@@ -1,0 +1,34 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketVersions"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${aws_environment}",
+        "arn:aws:s3:::${bucket_name}-daily-${aws_environment}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectACL",
+        "s3:PutObject",
+        "s3:PutObjectACL",
+        "S3:DeleteObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${aws_environment}/*",
+        "arn:aws:s3:::${bucket_name}-daily-${aws_environment}/*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
As a Reliability Engineer
I would like code for these AWS resources to exist in a current repo
So that I can make changes as expected, using an active repo.

These resources were initially created from a deprecated repo. To correct this
the code needed to be moved to the current repo, a new terraform state file 
created with an S3 backend, existing resources imported and a `terraform
apply` run to confirm what is essentially a no-op.

This has been tested and completed in staging but not yet in the other
environments.

solo: jstandring-gds