### PR TITLE
Update app-cache for Training environment

### DIFF
--- a/terraform/projects/app-cache/README.md
+++ b/terraform/projects/app-cache/README.md
@@ -11,9 +11,14 @@ Cache application servers
 | asg_size | The autoscaling groups desired/max/min capacity | string | `2` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| create_external_elb | Create the external ELB | string | `true` | no |
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
+| external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
+| external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
+| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -47,6 +47,31 @@ variable "asg_size" {
   default     = "2"
 }
 
+variable "external_zone_name" {
+  type        = "string"
+  description = "The name of the Route53 zone that contains external records"
+}
+
+variable "external_domain_name" {
+  type        = "string"
+  description = "The domain name of the external DNS records, it could be different from the zone name"
+}
+
+variable "internal_zone_name" {
+  type        = "string"
+  description = "The name of the Route53 zone that contains internal records"
+}
+
+variable "internal_domain_name" {
+  type        = "string"
+  description = "The domain name of the internal DNS records, it could be different from the zone name"
+}
+
+variable "create_external_elb" {
+  description = "Create the external ELB"
+  default     = true
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -57,6 +82,16 @@ terraform {
 provider "aws" {
   region  = "${var.aws_region}"
   version = "1.60.0"
+}
+
+data "aws_route53_zone" "external" {
+  name         = "${var.external_zone_name}"
+  private_zone = false
+}
+
+data "aws_route53_zone" "internal" {
+  name         = "${var.internal_zone_name}"
+  private_zone = true
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {
@@ -108,8 +143,8 @@ resource "aws_elb" "cache_elb" {
 }
 
 resource "aws_route53_record" "cache_service_record" {
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
-  name    = "cache.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
+  zone_id = "${data.aws_route53_zone.internal.zone_id}"
+  name    = "cache.${var.internal_domain_name}"
   type    = "A"
 
   alias {
@@ -122,14 +157,16 @@ resource "aws_route53_record" "cache_service_record" {
 # TODO publicapi is a special set of nginx config that routes /api requests to
 # their relevant apps upstream.
 resource "aws_route53_record" "cache_publicapi_service_record" {
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.internal_zone_id}"
-  name    = "publicapi.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"
+  zone_id = "${data.aws_route53_zone.internal.zone_id}"
+  name    = "publicapi.${var.internal_domain_name}"
   type    = "CNAME"
-  records = ["cache.${data.terraform_remote_state.infra_stack_dns_zones.internal_domain_name}"]
+  records = ["cache.${var.internal_domain_name}."]
   ttl     = 300
 }
 
 resource "aws_elb" "cache_external_elb" {
+  count = "${var.create_external_elb}"
+
   name            = "${var.stackname}-cache-external"
   subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_cache_external_elb_id}"]
@@ -168,8 +205,10 @@ resource "aws_elb" "cache_external_elb" {
 }
 
 resource "aws_route53_record" "cache_external_service_record" {
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
-  name    = "cache.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
+  count = "${var.create_external_elb}"
+
+  zone_id = "${data.aws_route53_zone.external.zone_id}"
+  name    = "cache.${var.external_domain_name}"
   type    = "A"
 
   alias {
@@ -181,11 +220,16 @@ resource "aws_route53_record" "cache_external_service_record" {
 
 resource "aws_route53_record" "app_service_records" {
   count   = "${length(var.app_service_records)}"
-  zone_id = "${data.terraform_remote_state.infra_stack_dns_zones.external_zone_id}"
-  name    = "${element(var.app_service_records, count.index)}.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"
+  zone_id = "${data.aws_route53_zone.external.zone_id}"
+  name    = "${element(var.app_service_records, count.index)}.${var.external_domain_name}"
   type    = "CNAME"
-  records = ["cache.${data.terraform_remote_state.infra_stack_dns_zones.external_domain_name}"]
+  records = ["cache.${var.external_domain_name}."]
   ttl     = "300"
+}
+
+locals {
+  instance_elb_ids_length = "${var.create_external_elb ? 2 : 1}"
+  instance_elb_ids        = "${compact(list(join("", aws_elb.cache_external_elb.*.id), aws_elb.cache_elb.id))}"
 }
 
 module "cache" {
@@ -196,8 +240,8 @@ module "cache" {
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_cache_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "m5.xlarge"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
-  instance_elb_ids_length       = "2"
-  instance_elb_ids              = ["${aws_elb.cache_elb.id}", "${aws_elb.cache_external_elb.id}"]
+  instance_elb_ids_length       = "${local.instance_elb_ids_length}"
+  instance_elb_ids              = ["${local.instance_elb_ids}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "${var.asg_size}"
   asg_min_size                  = "${var.asg_size}"
@@ -218,15 +262,20 @@ module "alarms-elb-cache-internal" {
   healthyhostcount_threshold     = "0"
 }
 
+locals {
+  elb_httpcode_backend_5xx_threshold = "${var.create_external_elb ? 50 : 0}"
+  elb_httpcode_elb_5xx_threshold     = "${var.create_external_elb ? 50 : 0}"
+}
+
 module "alarms-elb-cache-external" {
   source                         = "../../modules/aws/alarms/elb"
   name_prefix                    = "${var.stackname}-cache-external"
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  elb_name                       = "${aws_elb.cache_external_elb.name}"
+  elb_name                       = "${join("", aws_elb.cache_external_elb.*.name)}"
   httpcode_backend_4xx_threshold = "0"
-  httpcode_backend_5xx_threshold = "50"
+  httpcode_backend_5xx_threshold = "${local.elb_httpcode_backend_5xx_threshold}"
   httpcode_elb_4xx_threshold     = "0"
-  httpcode_elb_5xx_threshold     = "50"
+  httpcode_elb_5xx_threshold     = "${local.elb_httpcode_elb_5xx_threshold}"
   surgequeuelength_threshold     = "0"
   healthyhostcount_threshold     = "0"
 }
@@ -245,11 +294,11 @@ output "service_dns_name" {
 }
 
 output "cache_external_elb_dns_name" {
-  value       = "${aws_elb.cache_external_elb.dns_name}"
+  value       = "${join("", aws_elb.cache_external_elb.*.dns_name)}"
   description = "DNS name to access the external cache service"
 }
 
 output "external_service_dns_name" {
-  value       = "${aws_route53_record.cache_external_service_record.fqdn}"
+  value       = "${join("", aws_route53_record.cache_external_service_record.*.fqdn)}"
   description = "DNS name to access the external service"
 }

--- a/terraform/projects/app-cache/training.govuk.backend
+++ b/terraform/projects/app-cache/training.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-training-terraform-state"
+key     = "govuk/app-cache.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
Add backend to build app-cache in the Training environment.

Add parameters to select which domain to use with the DNS records (Training
does not use the stack domain).