### PR TITLE
Allow staging env to access prod organogram bucket

### DIFF
--- a/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
@@ -65,7 +65,7 @@ resource "aws_s3_bucket" "datagovuk-organogram" {
 
   cors_rule {
     allowed_methods = ["GET"]
-    allowed_origins = ["${var.domain}"]
+    allowed_origins = "${compact(list(var.domain, var.aws_environment == "production" ? "https://staging.data.gov.uk" : ""))}"
   }
 
   tags {


### PR DESCRIPTION
This will allow the staging environment to access the production organogram S3 bucket.

Trello card: https://trello.com/c/Vx11ucIl/1043-fix-display-of-organogram-visualisations-on-stagingdatagovuk