### PR TITLE
Add target_prefix to module

### DIFF
--- a/terraform/modules/aws/s3_bucket_lifecycle/README.md
+++ b/terraform/modules/aws/s3_bucket_lifecycle/README.md
@@ -10,6 +10,7 @@
 | enable_noncurrent_expiration | Enables this lifecycle rule | string | `false` | no |
 | noncurrent_expiration_days | Number of days to keep noncurrent versions | string | `5` | no |
 | target_bucketid_for_logs | ID for logging bucket | string | - | yes |
+| target_prefix_for_logs | Prefix for logs written to the s3 bucket | string | - | yes |
 
 ## Outputs
 

--- a/terraform/modules/aws/s3_bucket_lifecycle/main.tf
+++ b/terraform/modules/aws/s3_bucket_lifecycle/main.tf
@@ -21,6 +21,11 @@ variable "target_bucketid_for_logs" {
   description = "ID for logging bucket"
 }
 
+variable "target_prefix_for_logs" {
+  type        = "string"
+  description = "Prefix for logs written to the s3 bucket"
+}
+
 # lifecycle rule 1 vars
 variable "enable_current_expiration" {
   type        = "string"
@@ -65,7 +70,7 @@ resource "aws_s3_bucket" "s3_bucket" {
 
   logging {
     target_bucket = "${var.target_bucketid_for_logs}"
-    target_prefix = "log/"
+    target_prefix = "${var.target_prefix_for_logs}"
   }
 
   lifecycle_rule {

--- a/terraform/projects/infra-s3-mirrors/main.tf
+++ b/terraform/projects/infra-s3-mirrors/main.tf
@@ -43,6 +43,7 @@ module "govuk_mirror" {
   aws_environment              = "${var.aws_environment}"
   bucket_name                  = "govuk-mirror-${var.aws_environment}"
   target_bucketid_for_logs     = "${aws_s3_bucket.govuk_mirror_access_logs.id}"
+  target_prefix_for_logs       = "log/"
   enable_noncurrent_expiration = "true"
 }
 


### PR DESCRIPTION
This module expects a logging bucket. To allow multiple things to log to the
same bucket a different prefix should be available. Currently this module is
only in use in one location and this commit includes the changes to the module
and the usage of that module.