### PR TITLE
Fix empty public asg

### DIFF
--- a/terraform/modules/aws/lb_listener_rules/README.md
+++ b/terraform/modules/aws/lb_listener_rules/README.md
@@ -1,7 +1,10 @@
 ## Modules: aws/lb_listener_rules
 
-This module creates Load Balancer listener rules and target groups for
+This module creates Load Balancer listener rules based on Host header and target groups for
 an existing listener resource.
+
+If the parameter `autoscaling_group_name` is non empty, the module also creates an attachment
+from each target group to the ASG with the specified name.
 
 Limitations:
  - The target group deregistration_delay, health_check_interval and health_check_timeout
@@ -15,7 +18,7 @@ so at the moment only one condition can be specified per rule
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| autoscaling_group_name | Name of ASG to associate with the target group. | string | - | yes |
+| autoscaling_group_name | Name of ASG to associate with the target group. An empty value does not create any attachment to the LB target group. | string | `` | no |
 | default_tags | Additional resource tags | map | `<map>` | no |
 | listener_arn | ARN of the listener. | string | - | yes |
 | name | Prefix of the target group names. The final name is name-rulename. | string | - | yes |

--- a/terraform/modules/aws/lb_listener_rules/main.tf
+++ b/terraform/modules/aws/lb_listener_rules/main.tf
@@ -1,8 +1,11 @@
 /**
 * ## Modules: aws/lb_listener_rules
 *
-* This module creates Load Balancer listener rules and target groups for
+* This module creates Load Balancer listener rules based on Host header and target groups for
 * an existing listener resource.
+*
+* If the parameter `autoscaling_group_name` is non empty, the module also creates an attachment
+* from each target group to the ASG with the specified name.
 *
 * Limitations:
 *  - The target group deregistration_delay, health_check_interval and health_check_timeout
@@ -53,7 +56,8 @@ variable "vpc_id" {
 
 variable "autoscaling_group_name" {
   type        = "string"
-  description = "Name of ASG to associate with the target group."
+  description = "Name of ASG to associate with the target group. An empty value does not create any attachment to the LB target group."
+  default     = ""
 }
 
 variable "target_group_deregistration_delay" {
@@ -124,7 +128,7 @@ resource "aws_lb_target_group" "tg" {
 }
 
 resource "aws_autoscaling_attachment" "tg" {
-  count                  = "${length(var.rules_host)}"
+  count                  = "${var.autoscaling_group_name != "" ? length(var.rules_host) : 0}"
   autoscaling_group_name = "${var.autoscaling_group_name}"
   alb_target_group_arn   = "${aws_lb_target_group.tg.*.arn[count.index]}"
 }


### PR DESCRIPTION
Update infra-public-services listener rules forempty ASGs:

In the Training environment, some of the ASGs don't exist yet. This was
causing an error when passing the parameter `autoscaling_group_name` to
the `_public_lb_rules` modules, because Terraform wasn't able to identify
the type of `names[0]` when the data resource returned no items.

The `aws_autoscaling_group` returns a single item instead of a list, which
is easier to evaluate to cover the cases when nothing is returned. We never
expect to have more than an ASG with a given name per environment, so both
data resources provide the same data.

The `rules_host_domain` in `backend_public_lb_rules` needs to remove the
environment variable in preparation for the deployment on Production, because
the Host headers are using the `publishing` domain.


Allow optional ASG attachment in lb_listener_rules module:

At the moment, the `autoscaling_group_name` value that we pass to this
module comes from a `data` resource, that can be empty if the ASG hasn't
been created yet in an environment. This is currently happening on Training.

By adding a default empty string to this parameter, we can implement the
module even when the ASG doesn't exist. In this case, the attachment should
not be created.
