### PR TITLE
Add monitoring policy for ELBs

### DIFF
--- a/terraform/projects/app-monitoring/additional_policy.json
+++ b/terraform/projects/app-monitoring/additional_policy.json
@@ -15,6 +15,7 @@
                 "rds:Describe*",
                 "rds:ListTagsForResource",
                 "elasticache:Describe*",
+                "elasticloadbalancing:Describe*",
                 "cloudwatch:DescribeAlarmHistory",
                 "cloudwatch:GetDashboard",
                 "cloudwatch:GetMetricData",


### PR DESCRIPTION
We want to start monitoring the number of healthy hosts on ELB/ELBv2
resources. The Icinga machine needs to be able to run Describe actions
to perform the check.