### PR TITLE
Update Cyber security audit role module

### DIFF
--- a/terraform/projects/infra-cyber-security-audit/main.tf
+++ b/terraform/projects/infra-cyber-security-audit/main.tf
@@ -27,7 +27,7 @@ provider "aws" {
 }
 
 module "cyber_security_audit_role" {
-  source = "git::https://github.com/alphagov/tech-ops//cyber-security/modules/gds_security_audit_role?ref=2d39415f6f92874dcf5eaee376f4d0af49992b8d"
+  source = "git::https://github.com/alphagov/tech-ops.git?ref=13f54e5//cyber-security/modules/gds_security_audit_role"
 
   chain_account_id = "988997429095"
 }


### PR DESCRIPTION
- The policies implemented for the original role did not work as
intended and required updating
- support:Describe* does not work as intended and had to be changed to
support:*
- Planned and applied cleanly in integration:
https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1483
https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1484

solo: @schmie