### PR TITLE
Update enable_alb implementation in frontend apps

### DIFF
--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -188,8 +188,8 @@ module "calculators-frontend" {
   instance_additional_user_data     = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length           = "1"
   instance_elb_ids                  = ["${aws_elb.calculators-frontend_elb.id}"]
-  instance_target_group_arns_length = "${var.enable_alb ? 1 : 0}"
-  instance_target_group_arns        = ["${var.enable_alb ? module.internal_lb.target_group_arns[0] : ""}"]
+  instance_target_group_arns_length = "1"
+  instance_target_group_arns        = ["${module.internal_lb.target_group_arns[0]}"]
   instance_ami_filter_name          = "${var.instance_ami_filter_name}"
   asg_max_size                      = "${var.asg_size}"
   asg_min_size                      = "${var.asg_size}"

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -182,8 +182,8 @@ module "draft-frontend" {
   instance_additional_user_data     = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length           = "1"
   instance_elb_ids                  = ["${aws_elb.draft-frontend_elb.id}"]
-  instance_target_group_arns_length = "${var.enable_alb ? 1 : 0}"
-  instance_target_group_arns        = ["${var.enable_alb ? module.internal_lb.target_group_arns[0] : ""}"]
+  instance_target_group_arns_length = "1"
+  instance_target_group_arns        = ["${module.internal_lb.target_group_arns[0]}"]
   instance_ami_filter_name          = "${var.instance_ami_filter_name}"
   asg_max_size                      = "${var.asg_size}"
   asg_min_size                      = "${var.asg_size}"

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -188,8 +188,8 @@ module "frontend" {
   instance_additional_user_data     = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length           = "1"
   instance_elb_ids                  = ["${aws_elb.frontend_elb.id}"]
-  instance_target_group_arns_length = "${var.enable_alb ? 1 : 0}"
-  instance_target_group_arns        = ["${var.enable_alb ? module.internal_lb.target_group_arns[0] : ""}"]
+  instance_target_group_arns_length = "1"
+  instance_target_group_arns        = ["${module.internal_lb.target_group_arns[0]}"]
   instance_ami_filter_name          = "${var.instance_ami_filter_name}"
   asg_max_size                      = "${var.asg_size}"
   asg_min_size                      = "${var.asg_size}"


### PR DESCRIPTION
We have applied the changes to enable the new ALBs on the frontend app
projects. The `instance_target_group_arns_length` and `instance_target_group_arns`
are actually irrelevant if the alb is enabled or disabled, because those
setting only attach the default group of the new ALB to the ASG.

Just in case we need to rollback the change, it's actually easier to
understand the plan, if the only relevant change when setting `enable_alb`
to false is a change in the DNS record ALIAS value to point to the original
ELB.

For these reasons we are going to update the code and always do the
attachment of the ALB default group.