### PR TITLE
Add Mongo Read Policy for Training Data Sync

### DIFF
--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -382,6 +382,18 @@ resource "aws_iam_role_policy_attachment" "integration_read_mongodb_database_bac
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.integration_mongodb_read_database_backups_bucket_policy_arn}"
 }
 
+resource "aws_iam_role_policy_attachment" "training_read_mongoapi_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "training" ? 3 : 0}"
+  role       = "${element(list(module.mongo-1.instance_iam_role_name, module.mongo-2.instance_iam_role_name, module.mongo-3.instance_iam_role_name), count.index)}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.training_mongo_api_read_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "training_read_mongodb_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "training" ? 3 : 0}"
+  role       = "${element(list(module.mongo-1.instance_iam_role_name, module.mongo-2.instance_iam_role_name, module.mongo-3.instance_iam_role_name), count.index)}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.training_mongodb_read_database_backups_bucket_policy_arn}"
+}
+
 resource "aws_iam_role_policy_attachment" "staging_read_mongoapi_database_backups_iam_role_policy_attachment" {
   count      = "${var.aws_environment == "staging" ? 3 : 0}"
   role       = "${element(list(module.mongo-1.instance_iam_role_name, module.mongo-2.instance_iam_role_name, module.mongo-3.instance_iam_role_name), count.index)}"
@@ -404,6 +416,18 @@ resource "aws_iam_role_policy_attachment" "integration_read_production_mongodb_d
   count      = "${var.aws_environment == "integration" ? 3 : 0}"
   role       = "${element(list(module.mongo-1.instance_iam_role_name, module.mongo-2.instance_iam_role_name, module.mongo-3.instance_iam_role_name), count.index)}"
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.production_mongodb_read_database_backups_bucket_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "training_read_integration_mongoapi_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "training" ? 3 : 0}"
+  role       = "${element(list(module.mongo-1.instance_iam_role_name, module.mongo-2.instance_iam_role_name, module.mongo-3.instance_iam_role_name), count.index)}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.integration_mongodb_database_backups_reader}"
+}
+
+resource "aws_iam_role_policy_attachment" "training_read_integration_mongodb_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "training" ? 3 : 0}"
+  role       = "${element(list(module.mongo-1.instance_iam_role_name, module.mongo-2.instance_iam_role_name, module.mongo-3.instance_iam_role_name), count.index)}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.integration_mongodb_database_backups_reader}"
 }
 
 resource "aws_iam_role_policy_attachment" "staging_read_production_mongoapi_database_backups_iam_role_policy_attachment" {


### PR DESCRIPTION
The Mongo machines in the Training environment need read access to
the Mongo backups Integration S3 bucket for the data sync to work.
This change allow that.