### PR TITLE
Add Dot to End of CNAME Record for Consistency

### DIFF
--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -147,7 +147,7 @@ resource "aws_route53_record" "app_service_records" {
   zone_id = "${data.aws_route53_zone.internal.zone_id}"
   name    = "${element(var.app_service_records, count.index)}.${var.internal_domain_name}"
   type    = "CNAME"
-  records = ["calculators-frontend.${var.internal_domain_name}"]
+  records = ["calculators-frontend.${var.internal_domain_name}."]
   ttl     = "300"
 }
 


### PR DESCRIPTION
This prevents Terraform reporting that an unnecessary change needs
to be made to the CNAME. AWS automatically adds a dot to the end of
a CNAME if none exists.