### PR TITLE
Fix rules target group names

### DIFF
--- a/terraform/modules/aws/lb_listener_rules/README.md
+++ b/terraform/modules/aws/lb_listener_rules/README.md
@@ -3,7 +3,7 @@
 This module creates Load Balancer listener rules based on Host header and target groups for
 an existing listener resource.
 
-If the parameter `autoscaling_group_name` is non empty, the module also creates an attachment
+If the parameter `autoscaling_group_name` is not empty, the module also creates an attachment
 from each target group to the ASG with the specified name.
 
 Limitations:
@@ -21,7 +21,6 @@ so at the moment only one condition can be specified per rule
 | autoscaling_group_name | Name of ASG to associate with the target group. An empty value does not create any attachment to the LB target group. | string | `` | no |
 | default_tags | Additional resource tags | map | `<map>` | no |
 | listener_arn | ARN of the listener. | string | - | yes |
-| name | Prefix of the target group names. The final name is name-rulename. | string | - | yes |
 | priority_offset | first priority number assigned to the rules managed by the module. | string | `1` | no |
 | rules_host | A list with the values to create Host-header based listener rules and target groups. | list | `<list>` | no |
 | rules_host_domain | Host header domain to append to the hosts in rules_host. | string | `*` | no |
@@ -31,6 +30,7 @@ so at the moment only one condition can be specified per rule
 | target_group_health_check_path_prefix | The prefix destination for the health check request. | string | `/_healthcheck_` | no |
 | target_group_health_check_timeout | The amount of time, in seconds, during which no response means a failed health check. | string | `5` | no |
 | target_group_port | The port on which targets receive traffic. | string | `80` | no |
+| target_group_prefix | Prefix of the target group names. The limit of this variable is 4 characters. The final name is tg_name_prefix-rulename, it's trimmed to 32 characters, that is the max length of the Target Group Name field. | string | - | yes |
 | target_group_protocol | The protocol to use for routing traffic to the targets. | string | `HTTP` | no |
 | vpc_id | The ID of the VPC in which the default target groups are created. | string | - | yes |
 

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -169,7 +169,7 @@ module "internal_lb" {
 
 module "internal_lb_rules" {
   source                 = "../../modules/aws/lb_listener_rules"
-  name                   = "calculators-front-i"
+  target_group_prefix    = "int"
   autoscaling_group_name = "${module.calculators-frontend.autoscaling_group_name}"
   rules_host_domain      = "*"
   vpc_id                 = "${data.terraform_remote_state.infra_vpc.vpc_id}"

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -163,7 +163,7 @@ module "internal_lb" {
 
 module "internal_lb_rules" {
   source                 = "../../modules/aws/lb_listener_rules"
-  name                   = "draft-frontend-i"
+  target_group_prefix    = "int"
   autoscaling_group_name = "${module.draft-frontend.autoscaling_group_name}"
   rules_host_domain      = "*"
   vpc_id                 = "${data.terraform_remote_state.infra_vpc.vpc_id}"

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -169,7 +169,7 @@ module "internal_lb" {
 
 module "internal_lb_rules" {
   source                 = "../../modules/aws/lb_listener_rules"
-  name                   = "frontend-internal"
+  target_group_prefix    = "int"
   autoscaling_group_name = "${module.frontend.autoscaling_group_name}"
   rules_host_domain      = "*"
   vpc_id                 = "${data.terraform_remote_state.infra_vpc.vpc_id}"

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -539,7 +539,7 @@ resource "aws_lb_listener_rule" "backend_alb_blocked_host_headers" {
 
 module "backend_public_lb_rules" {
   source                 = "../../modules/aws/lb_listener_rules"
-  name                   = "backend"
+  target_group_prefix    = "pub"
   autoscaling_group_name = "${data.aws_autoscaling_group.backend.name}"
   rules_host_domain      = "*"
   vpc_id                 = "${data.terraform_remote_state.infra_vpc.vpc_id}"
@@ -709,7 +709,7 @@ resource "aws_route53_record" "cache_public_service_cnames" {
 
 module "cache_public_lb_rules" {
   source                 = "../../modules/aws/lb_listener_rules"
-  name                   = "cache"
+  target_group_prefix    = "pub"
   autoscaling_group_name = "${data.aws_autoscaling_group.cache.name}"
   rules_host_domain      = "*"
   vpc_id                 = "${data.terraform_remote_state.infra_vpc.vpc_id}"


### PR DESCRIPTION
## lb_listener_rules improvements

Life cycle rules:
We are planning to change the target group name of existing resources and
this is going to recreate the target group and attachment managed by this
module, and refresh the listener rule. We want to ensure the old target
group is only destroyed when the new one has been created and the listener
rule has been updated.

Target Group names:
Previous target groups created by the module ended up with names not very
user friendly, for instance `draft-fron-draft-finder-frontend`. We are using
these names in the configuration of Icinga checks. This format, originated
from the trimming of the `name` variable and the rule name, is making people
confused as it looks like a typo. We need to trim the target group name in
first place because it's limited to 32 characters.

The change here renames the variable to `target_group_prefix` to make it clear
how/where it's used. The description of the variable is improved. We are also
going to enforce the limit of this variable to 4 characters. With the use of
a null_resource resource, the plan/apply of the code will fail if the user
configures the variable with something longer than 4 chars, for instance:

```
Error: module.internal_lb_rules.null_resource.check_target_group_prefix_length:
: invalid or unknown key: ERROR: The length of target_group_prefix is longer than 4 characters
```

Hopefully this will force the user to use a short prefix that uniquely identifies
the target groups. We are expecting to use it with the "zone" of the Loadbalancer,
for instance: `int`, `ext`, `pub`, etc. The Target group tags can be used to search
for TGs instead of expecting to do all the identification from the name.

## Update lb_listener_rules usage

Update how we use `lb_listener_rules`. We need to use `target_group_prefix` instead
of `name` and use a short prefix that helps creating unique TG names.