### PR TITLE
Make instance_type configurable for all EC2 resources

### DIFF
--- a/terraform/projects/app-apt/README.md
+++ b/terraform/projects/app-apt/README.md
@@ -16,6 +16,7 @@ Apt node
 | external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -65,6 +65,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "t2.medium"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -164,7 +170,7 @@ module "apt" {
   default_tags                      = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "apt", "aws_hostname", "apt-1")}"
   instance_subnet_ids               = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.apt_1_subnet))}"
   instance_security_group_ids       = ["${data.terraform_remote_state.infra_security_groups.sg_apt_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                     = "t2.medium"
+  instance_type                     = "${var.instance_type}"
   instance_additional_user_data     = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_target_group_arns        = ["${concat(module.apt_internal_lb.target_group_arns, module.apt_external_lb.target_group_arns)}"]
   instance_target_group_arns_length = "${length(distinct(values(local.external_lb_map))) + length(distinct(values(local.internal_lb_map)))}"

--- a/terraform/projects/app-asset-master/README.md
+++ b/terraform/projects/app-asset-master/README.md
@@ -10,6 +10,7 @@ Asset Master node.
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.large` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-asset-master/main.tf
+++ b/terraform/projects/app-asset-master/main.tf
@@ -25,6 +25,12 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.large"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -64,7 +70,7 @@ module "asset-master" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "asset_master", "aws_hostname", "asset-master-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_asset-master_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.large"
+  instance_type                 = "${var.instance_type}"
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "0"

--- a/terraform/projects/app-backend/README.md
+++ b/terraform/projects/app-backend/README.md
@@ -17,6 +17,7 @@ Backend node
 | external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.2xlarge` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -72,6 +72,12 @@ variable "create_external_elb" {
   default     = true
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.2xlarge"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -235,7 +241,7 @@ module "backend" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend", "aws_hostname", "backend-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}", "${data.terraform_remote_state.infra_security_groups.sg_aws-vpn_id}"]
-  instance_type                 = "m5.2xlarge"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "${local.instance_elb_ids_length}"
   instance_elb_ids              = ["${local.instance_elb_ids}"]

--- a/terraform/projects/app-bouncer/README.md
+++ b/terraform/projects/app-bouncer/README.md
@@ -13,6 +13,7 @@ Bouncer node
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `t3.xlarge` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -41,6 +41,12 @@ variable "asg_size" {
   default     = "2"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "t3.xlarge"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -156,7 +162,7 @@ module "bouncer" {
   default_tags                      = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "bouncer", "aws_hostname", "bouncer-1")}"
   instance_subnet_ids               = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids       = ["${data.terraform_remote_state.infra_security_groups.sg_bouncer_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                     = "t3.xlarge"
+  instance_type                     = "${var.instance_type}"
   instance_additional_user_data     = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length           = "1"
   instance_elb_ids                  = ["${aws_elb.bouncer_external_elb.id}"]

--- a/terraform/projects/app-cache/README.md
+++ b/terraform/projects/app-cache/README.md
@@ -17,6 +17,7 @@ Cache application servers
 | external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.xlarge` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -72,6 +72,12 @@ variable "create_external_elb" {
   default     = true
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.xlarge"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -238,7 +244,7 @@ module "cache" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "cache", "aws_hostname", "cache-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_cache_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.xlarge"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "${local.instance_elb_ids_length}"
   instance_elb_ids              = ["${local.instance_elb_ids}"]

--- a/terraform/projects/app-calculators-frontend/README.md
+++ b/terraform/projects/app-calculators-frontend/README.md
@@ -14,7 +14,7 @@ Calculators Frontend application servers
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | enable_alb | Use application specific target groups and healthchecks based on the list of services in the cname variable. | string | `false` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
-| instance_type | Instance type | string | `c5.xlarge` | no |
+| instance_type | Instance type used for EC2 resources | string | `c5.xlarge` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -50,7 +50,7 @@ variable "root_block_device_volume_size" {
 
 variable "instance_type" {
   type        = "string"
-  description = "Instance type"
+  description = "Instance type used for EC2 resources"
   default     = "c5.xlarge"
 }
 

--- a/terraform/projects/app-ckan/README.md
+++ b/terraform/projects/app-ckan/README.md
@@ -15,6 +15,7 @@ CKAN node
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.xlarge` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-ckan/main.tf
+++ b/terraform/projects/app-ckan/main.tf
@@ -51,6 +51,12 @@ variable "ckan_subnet" {
   description = "Name of the subnet to place the ckan instance and the EBS volume"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.xlarge"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -195,7 +201,7 @@ module "ckan" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "ckan", "aws_hostname", "ckan-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.ckan_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_ckan_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.xlarge"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "2"
   instance_elb_ids              = ["${aws_elb.ckan_elb_internal.id}", "${aws_elb.ckan_elb_external.id}"]

--- a/terraform/projects/app-content-data-api-db-admin/README.md
+++ b/terraform/projects/app-content-data-api-db-admin/README.md
@@ -9,6 +9,7 @@ DB admin boxes for the Content Data API RDS instance
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_database_backups_bucket_key_stack | Override stackname path to infra_database_backups_bucket remote state | string | `` | no |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-content-data-api-db-admin/main.tf
+++ b/terraform/projects/app-content-data-api-db-admin/main.tf
@@ -25,6 +25,12 @@ variable "remote_state_infra_database_backups_bucket_key_stack" {
   default     = ""
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "t2.medium"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -43,7 +49,7 @@ module "content-data-api-db-admin" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "content_data_api_db_admin", "aws_hostname", "content-data-api-db-admin-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_content-data-api-db-admin_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "0"
   instance_elb_ids              = []

--- a/terraform/projects/app-content-data-api-postgresql/README.md
+++ b/terraform/projects/app-content-data-api-postgresql/README.md
@@ -10,6 +10,7 @@ RDS PostgreSQL instance for the Content Data API
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
+| instance_type | Instance type used for RDS resources | string | `db.m4.large` | no |
 | multi_az | Enable multi-az. | string | `true` | no |
 | password | DB password | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-content-data-api-postgresql/main.tf
+++ b/terraform/projects/app-content-data-api-postgresql/main.tf
@@ -51,6 +51,12 @@ variable "snapshot_identifier" {
   default     = ""
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for RDS resources"
+  default     = "db.m4.large"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -124,7 +130,7 @@ module "content-data-api-postgresql-primary_rds_instance" {
   username             = "${var.username}"
   password             = "${var.password}"
   allocated_storage    = "1024"
-  instance_class       = "db.m4.large"
+  instance_class       = "${var.instance_type}"
   instance_name        = "${var.stackname}-content-data-api-postgresql-primary"
   multi_az             = "${var.multi_az}"
   security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_content-data-api-postgresql-primary_id}"]

--- a/terraform/projects/app-content-store/README.md
+++ b/terraform/projects/app-content-store/README.md
@@ -16,6 +16,7 @@ content-store node
 | external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.large` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -66,6 +66,12 @@ variable "create_external_elb" {
   default     = true
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.large"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -211,7 +217,7 @@ module "content-store" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "content_store", "aws_hostname", "content-store-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.large"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "${local.instance_elb_ids_length}"
   instance_elb_ids              = ["${local.instance_elb_ids}"]

--- a/terraform/projects/app-data-science/README.md
+++ b/terraform/projects/app-data-science/README.md
@@ -12,6 +12,8 @@ Run resource intensive scripts for data science purposes.
 | aws_environment | AWS environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-2` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `c5.4xlarge` | no |
+| machine_learning_instance_type | Instance type used for EC2 resources | string | `p3.8xlarge` | no |
 | office_ips | An array of CIDR blocks that will be allowed offsite access. | list | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-data-science/main.tf
+++ b/terraform/projects/app-data-science/main.tf
@@ -32,6 +32,18 @@ variable "stackname" {
   description = "Stackname"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "c5.4xlarge"
+}
+
+variable "machine_learning_instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "p3.8xlarge"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -113,7 +125,7 @@ module "data-science-1" {
   default_tags                  = "${map("aws_environment", var.aws_environment, "aws_migration", "data-science", "aws_hostname", "data-science-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.public_subnet_ids}"
   instance_security_group_ids   = ["${aws_security_group.data-science.id}"]
-  instance_type                 = "c5.4xlarge"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.data-science_external_elb.id}"]
   instance_elb_ids_length       = "1"
@@ -128,7 +140,7 @@ module "data-science-2" {
   default_tags                  = "${map("aws_environment", var.aws_environment, "aws_migration", "data-science", "aws_hostname", "data-science-2")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.public_subnet_ids}"
   instance_security_group_ids   = ["${aws_security_group.data-science.id}"]
-  instance_type                 = "p3.8xlarge"
+  instance_type                 = "${var.machine_learning_instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.data-science_external_elb.id}"]
   instance_elb_ids_length       = "1"

--- a/terraform/projects/app-db-admin/README.md
+++ b/terraform/projects/app-db-admin/README.md
@@ -12,6 +12,7 @@ These nodes connect to RDS instances and administer them.
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -43,6 +43,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "t2.medium"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -109,7 +115,7 @@ module "db-admin" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "db_admin", "aws_hostname", "db-admin-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_db-admin_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "1"
   instance_elb_ids              = ["${aws_elb.db-admin_elb.id}"]

--- a/terraform/projects/app-deploy/README.md
+++ b/terraform/projects/app-deploy/README.md
@@ -17,6 +17,7 @@ Deploy node
 | external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -76,6 +76,12 @@ variable "create_external_elb" {
   default     = true
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "t2.medium"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -235,7 +241,7 @@ module "deploy" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "jenkins", "aws_hostname", "jenkins-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.deploy_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_deploy_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "${local.instance_elb_ids_length}"
   instance_elb_ids              = ["${local.instance_elb_ids}"]

--- a/terraform/projects/app-docker-management/README.md
+++ b/terraform/projects/app-docker-management/README.md
@@ -10,6 +10,7 @@ Docker management node, used to run run adhoc containers.
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-docker-management/main.tf
+++ b/terraform/projects/app-docker-management/main.tf
@@ -25,6 +25,12 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "t2.medium"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -93,7 +99,7 @@ module "docker_management" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "docker_management", "aws_hostname", "docker-management-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_docker_management_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "1"
   instance_elb_ids              = ["${aws_elb.docker_management_etcd_elb.id}"]

--- a/terraform/projects/app-draft-cache/README.md
+++ b/terraform/projects/app-draft-cache/README.md
@@ -14,6 +14,7 @@ Draft Cache servers
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -47,6 +47,12 @@ variable "asg_size" {
   default     = "2"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "t2.medium"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -206,7 +212,7 @@ module "draft-cache" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "draft_cache", "aws_hostname", "draft-cache-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_draft-cache_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "2"
   instance_elb_ids              = ["${aws_elb.draft-cache_elb.id}", "${aws_elb.draft-cache_external_elb.id}"]

--- a/terraform/projects/app-draft-content-store/README.md
+++ b/terraform/projects/app-draft-content-store/README.md
@@ -13,6 +13,7 @@ draft-content-store node
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -41,6 +41,12 @@ variable "asg_size" {
   default     = "2"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "t2.medium"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -167,7 +173,7 @@ module "draft-content-store" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "draft_content_store", "aws_hostname", "draft-content-store-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_draft-content-store_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "2"
   instance_elb_ids              = ["${aws_elb.draft-content-store_external_elb.id}", "${aws_elb.draft-content-store_internal_elb.id}"]

--- a/terraform/projects/app-draft-frontend/README.md
+++ b/terraform/projects/app-draft-frontend/README.md
@@ -14,6 +14,7 @@ Draft Frontend application servers
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | enable_alb | Use application specific target groups and healthchecks based on the list of services in the cname variable. | string | `false` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.large` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -64,6 +64,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.large"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -178,7 +184,7 @@ module "draft-frontend" {
   default_tags                      = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "draft_frontend", "aws_hostname", "draft-frontend-1")}"
   instance_subnet_ids               = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids       = ["${data.terraform_remote_state.infra_security_groups.sg_draft-frontend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                     = "m5.large"
+  instance_type                     = "${var.instance_type}"
   instance_additional_user_data     = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length           = "1"
   instance_elb_ids                  = ["${aws_elb.draft-frontend_elb.id}"]

--- a/terraform/projects/app-elasticsearch5/README.md
+++ b/terraform/projects/app-elasticsearch5/README.md
@@ -32,14 +32,14 @@ doesn't support:
 | elasticsearch5_ebs_size | The amount of EBS storage to attach | string | `32` | no |
 | elasticsearch5_ebs_type | The type of EBS storage to attach | string | `gp2` | no |
 | elasticsearch5_instance_count | The number of ElasticSearch nodes | string | `6` | no |
-| elasticsearch5_instance_type | The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported | string | `r4.xlarge.elasticsearch` | no |
 | elasticsearch5_manual_snapshot_bucket_arns | Bucket ARNs this domain can read/write for manual snapshots | list | `<list>` | no |
 | elasticsearch5_master_instance_count | Number of dedicated master nodes in the cluster | string | `3` | no |
-| elasticsearch5_master_instance_type | Instance type of the dedicated master nodes in the cluster | string | `c4.large.elasticsearch` | no |
 | elasticsearch5_snapshot_start_hour | The hour in which the daily snapshot is taken | string | `1` | no |
 | elasticsearch_subnet_names | Names of the subnets to place the ElasticSearch domain in | list | - | yes |
+| instance_type | The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported | string | `r4.xlarge.elasticsearch` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
+| master_instance_type | Instance type of the dedicated master nodes in the cluster | string | `c4.large.elasticsearch` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-elasticsearch5/main.tf
+++ b/terraform/projects/app-elasticsearch5/main.tf
@@ -36,7 +36,7 @@ variable "stackname" {
   description = "Stackname"
 }
 
-variable "elasticsearch5_instance_type" {
+variable "instance_type" {
   type        = "string"
   description = "The instance type of the individual ElasticSearch nodes, only instances which allow EBS volumes are supported"
   default     = "r4.xlarge.elasticsearch"
@@ -54,7 +54,7 @@ variable "elasticsearch5_dedicated_master_enabled" {
   default     = "true"
 }
 
-variable "elasticsearch5_master_instance_type" {
+variable "master_instance_type" {
   type        = "string"
   description = "Instance type of the dedicated master nodes in the cluster"
   default     = "c4.large.elasticsearch"
@@ -216,10 +216,10 @@ resource "aws_elasticsearch_domain" "elasticsearch5" {
   elasticsearch_version = "5.6"
 
   cluster_config {
-    instance_type            = "${var.elasticsearch5_instance_type}"
+    instance_type            = "${var.instance_type}"
     instance_count           = "${var.elasticsearch5_instance_count}"
     dedicated_master_enabled = "${var.elasticsearch5_dedicated_master_enabled}"
-    dedicated_master_type    = "${var.elasticsearch5_master_instance_type}"
+    dedicated_master_type    = "${var.master_instance_type}"
     dedicated_master_count   = "${var.elasticsearch5_master_instance_count}"
     zone_awareness_enabled   = true
   }

--- a/terraform/projects/app-email-alert-api/README.md
+++ b/terraform/projects/app-email-alert-api/README.md
@@ -16,6 +16,7 @@ email-alert-api node
 | external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.large` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-email-alert-api/main.tf
+++ b/terraform/projects/app-email-alert-api/main.tf
@@ -66,6 +66,12 @@ variable "create_external_elb" {
   default     = true
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.large"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -209,7 +215,7 @@ module "email-alert-api" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "email_alert_api", "aws_hostname", "email-alert-api-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_email-alert-api_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.large"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "${local.instance_elb_ids_length}"
   instance_elb_ids              = ["${local.instance_elb_ids}"]

--- a/terraform/projects/app-frontend/README.md
+++ b/terraform/projects/app-frontend/README.md
@@ -14,7 +14,7 @@ Frontend application servers
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | enable_alb | Use application specific target groups and healthchecks based on the list of services in the cname variable. | string | `false` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
-| instance_type | Instance type | string | `m5.xlarge` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.xlarge` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -50,7 +50,7 @@ variable "root_block_device_volume_size" {
 
 variable "instance_type" {
   type        = "string"
-  description = "Instance type"
+  description = "Instance type used for EC2 resources"
   default     = "m5.xlarge"
 }
 

--- a/terraform/projects/app-graphite/README.md
+++ b/terraform/projects/app-graphite/README.md
@@ -17,6 +17,7 @@ Graphite node
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | graphite_1_subnet | Name of the subnet to place the Graphite instance 1 and EBS volume | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.xlarge` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -76,6 +76,12 @@ variable "create_external_elb" {
   default     = true
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.xlarge"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -251,7 +257,7 @@ module "graphite-1" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "graphite", "aws_hostname", "graphite-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.graphite_1_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_graphite_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.xlarge"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "${local.instance_elb_ids_length}"
   instance_elb_ids              = ["${local.instance_elb_ids}"]

--- a/terraform/projects/app-jumpbox/README.md
+++ b/terraform/projects/app-jumpbox/README.md
@@ -13,6 +13,7 @@ Jumpbox node
 | external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `t2.micro` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -40,6 +40,12 @@ variable "create_external_elb" {
   default     = true
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "t2.micro"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -119,7 +125,7 @@ module "jumpbox" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "jumpbox", "aws_hostname", "jumpbox-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_jumpbox_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.micro"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${local.instance_elb_ids}"]
   instance_elb_ids_length       = "${local.instance_elb_ids_length}"

--- a/terraform/projects/app-mapit/README.md
+++ b/terraform/projects/app-mapit/README.md
@@ -12,7 +12,7 @@ Mapit node
 | ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
-| instance_type | The type of EC2 instance to use for both ASGs. | string | `t2.medium` | no |
+| instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | mapit_1_subnet | Name of the subnet to place the mapit instance 1 and EBS volume | string | - | yes |

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -47,7 +47,7 @@ variable "elb_internal_certname" {
 
 variable "instance_type" {
   type        = "string"
-  description = "The type of EC2 instance to use for both ASGs."
+  description = "Instance type used for EC2 resources"
   default     = "t2.medium"
 }
 

--- a/terraform/projects/app-mirrorer/README.md
+++ b/terraform/projects/app-mirrorer/README.md
@@ -11,8 +11,8 @@ Mirrorer node
 | aws_region | AWS region | string | `eu-west-1` | no |
 | ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.large` | no |
 | mirrorer_ebs_size | Size of addtiional EBS volume in GB | string | `100` | no |
-| mirrorer_instance_type | Instance type for the mirrorer instance | string | `m5.large` | no |
 | mirrorer_subnet | Subnet to contain mirrorer and its EBS volume | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -30,9 +30,9 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
-variable "mirrorer_instance_type" {
+variable "instance_type" {
   type        = "string"
-  description = "Instance type for the mirrorer instance"
+  description = "Instance type used for EC2 resources"
   default     = "m5.large"
 }
 
@@ -65,7 +65,7 @@ module "mirrorer" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mirrorer", "aws_hostname", "mirrorer-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mirrorer_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mirrorer_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "${var.mirrorer_instance_type}"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "0"
   instance_elb_ids              = []

--- a/terraform/projects/app-mongo/README.md
+++ b/terraform/projects/app-mongo/README.md
@@ -11,6 +11,7 @@ Mongo hosts
 | aws_region | AWS region | string | `eu-west-1` | no |
 | ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.large` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | mongo_1_ip | IP address of the private IP to assign to the instance | string | - | yes |

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -91,6 +91,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.large"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -138,7 +144,7 @@ module "mongo-1" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mongo", "aws_hostname", "mongo-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mongo_1_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mongo_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.large"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "0"
   instance_elb_ids              = []
@@ -195,7 +201,7 @@ module "mongo-2" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mongo", "aws_hostname", "mongo-2")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mongo_2_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mongo_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.large"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "0"
   instance_elb_ids              = []
@@ -252,7 +258,7 @@ module "mongo-3" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mongo", "aws_hostname", "mongo-3")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mongo_3_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mongo_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.large"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "0"
   instance_elb_ids              = []

--- a/terraform/projects/app-monitoring/README.md
+++ b/terraform/projects/app-monitoring/README.md
@@ -15,6 +15,7 @@ Monitoring node
 | external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.xlarge` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | monitoring_subnet | Name of the subnet to place the monitoring instance and the EBS volume | string | - | yes |

--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -65,6 +65,12 @@ variable "external_domain_name" {
   description = "The domain name of the external DNS records, it could be different from the zone name"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.xlarge"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -217,7 +223,7 @@ module "monitoring" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "monitoring", "aws_hostname", "monitoring-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.monitoring_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_monitoring_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.xlarge"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "2"
   instance_elb_ids              = ["${aws_elb.monitoring_external_elb.id}", "${aws_elb.monitoring_internal_elb.id}"]

--- a/terraform/projects/app-mysql/README.md
+++ b/terraform/projects/app-mysql/README.md
@@ -10,6 +10,7 @@ RDS Mysql Primary instance
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
+| instance_type | Instance type used for RDS resources | string | `db.m4.xlarge` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | password | DB password | string | - | yes |

--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -61,6 +61,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for RDS resources"
+  default     = "db.m4.xlarge"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -90,7 +96,7 @@ module "mysql_primary_rds_instance" {
   username             = "${var.username}"
   password             = "${var.password}"
   allocated_storage    = "${var.storage_size}"
-  instance_class       = "db.m4.xlarge"
+  instance_class       = "${var.instance_type}"
   security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mysql-primary_id}"]
   parameter_group_name = "${aws_db_parameter_group.mysql-primary.name}"
   event_sns_topic_arn  = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
@@ -148,7 +154,7 @@ module "mysql_replica_rds_instance" {
   source                     = "../../modules/aws/rds_instance"
   name                       = "${var.stackname}-mysql-replica"
   default_tags               = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mysql-replica")}"
-  instance_class             = "db.m4.xlarge"
+  instance_class             = "${var.instance_type}"
   instance_name              = "${var.stackname}-mysql-replica"
   security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_mysql-replica_id}"]
   create_replicate_source_db = "1"

--- a/terraform/projects/app-postgresql/README.md
+++ b/terraform/projects/app-postgresql/README.md
@@ -10,6 +10,7 @@ RDS PostgreSQL instances
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
+| instance_type | Instance type used for RDS resources | string | `db.m5.2xlarge` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | multi_az | Enable multi-az. | string | `true` | no |

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -61,6 +61,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for RDS resources"
+  default     = "db.m5.2xlarge"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -89,7 +95,7 @@ module "postgresql-primary_rds_instance" {
   username            = "${var.username}"
   password            = "${var.password}"
   allocated_storage   = "190"
-  instance_class      = "db.m5.2xlarge"
+  instance_class      = "${var.instance_type}"
   instance_name       = "${var.stackname}-postgresql-primary"
   multi_az            = "${var.multi_az}"
   security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]
@@ -111,7 +117,7 @@ module "postgresql-standby_rds_instance" {
 
   name                       = "${var.stackname}-postgresql-standby"
   default_tags               = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "postgresql_standby")}"
-  instance_class             = "db.m5.2xlarge"
+  instance_class             = "${var.instance_type}"
   instance_name              = "${var.stackname}-postgresql-standby"
   security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]
   create_replicate_source_db = "1"

--- a/terraform/projects/app-prometheus/README.md
+++ b/terraform/projects/app-prometheus/README.md
@@ -6,6 +6,7 @@
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*` | no |
+| instance_type | Instance type used for EC2 resources | string | `t2.micro` | no |
 | prometheus_1_subnet | Name of the subnet to place the Prometheus instance and EBS volume | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |

--- a/terraform/projects/app-prometheus/main.tf
+++ b/terraform/projects/app-prometheus/main.tf
@@ -32,6 +32,12 @@ variable "prometheus_1_subnet" {
   description = "Name of the subnet to place the Prometheus instance and EBS volume"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "t2.micro"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -54,7 +60,7 @@ var.aws_environment, "aws_migration", "prometheus", "aws_hostname", "prometheus-
 keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.prometheus_1_subnet))}"
 
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_prometheus_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.micro"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"

--- a/terraform/projects/app-publishing-api/README.md
+++ b/terraform/projects/app-publishing-api/README.md
@@ -16,6 +16,7 @@ publishing-api node
 | external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.large` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -66,6 +66,12 @@ variable "create_external_elb" {
   default     = true
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.large"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -211,7 +217,7 @@ module "publishing-api" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "publishing_api", "aws_hostname", "publishing-api-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_publishing-api_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.large"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "${local.instance_elb_ids_length}"
   instance_elb_ids              = ["${local.instance_elb_ids}"]

--- a/terraform/projects/app-puppetmaster/README.md
+++ b/terraform/projects/app-puppetmaster/README.md
@@ -12,9 +12,9 @@ Puppetmaster node
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | enable_bootstrap | Whether to create the ELB which allows a user to SSH to the Puppetmaster from the office | string | `false` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.xlarge` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name. | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
-| puppetmaster_instance_type | Instance type for the mirrorer instance | string | `m5.xlarge` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -19,12 +19,6 @@ variable "aws_environment" {
   description = "AWS environment"
 }
 
-variable "puppetmaster_instance_type" {
-  type        = "string"
-  description = "Instance type for the mirrorer instance"
-  default     = "m5.xlarge"
-}
-
 variable "instance_ami_filter_name" {
   type        = "string"
   description = "Name to use to find AMI images"
@@ -50,6 +44,12 @@ variable "internal_zone_name" {
 variable "internal_domain_name" {
   type        = "string"
   description = "The domain name of the internal DNS records, it could be different from the zone name."
+}
+
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.xlarge"
 }
 
 # Resources
@@ -198,7 +198,7 @@ module "puppetmaster" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "puppetmaster", "aws_hostname", "puppetmaster-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_puppetmaster_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "${var.puppetmaster_instance_type}"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids              = ["${aws_elb.puppetmaster_internal_elb.id}", "${aws_elb.puppetmaster_bootstrap_elb.*.id}"]
   instance_elb_ids_length       = "${var.enable_bootstrap > 0 ? 2 : 1}"

--- a/terraform/projects/app-rabbitmq/README.md
+++ b/terraform/projects/app-rabbitmq/README.md
@@ -10,6 +10,7 @@ Rabbitmq cluster
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-rabbitmq/main.tf
+++ b/terraform/projects/app-rabbitmq/main.tf
@@ -35,6 +35,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "t2.medium"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -106,7 +112,7 @@ module "rabbitmq" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "rabbitmq", "aws_hostname", "rabbitmq")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_rabbitmq_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "1"
   instance_elb_ids              = ["${aws_elb.rabbitmq_elb.id}"]

--- a/terraform/projects/app-router-backend/README.md
+++ b/terraform/projects/app-router-backend/README.md
@@ -11,6 +11,7 @@ Router backend hosts both Mongo and router-api
 | aws_region | AWS region | string | `eu-west-1` | no |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -91,6 +91,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "t2.medium"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -193,7 +199,7 @@ module "router-backend-1" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "router_backend", "aws_hostname", "router-backend-1")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.router-backend_1_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_router-backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "1"
   instance_elb_ids              = ["${aws_elb.router_api_elb.id}"]
@@ -232,7 +238,7 @@ module "router-backend-2" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "router_backend", "aws_hostname", "router-backend-2")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.router-backend_2_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_router-backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "1"
   instance_elb_ids              = ["${aws_elb.router_api_elb.id}"]
@@ -271,7 +277,7 @@ module "router-backend-3" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "router_backend", "aws_hostname", "router-backend-3")}"
   instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.router-backend_3_subnet))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_router-backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "1"
   instance_elb_ids              = ["${aws_elb.router_api_elb.id}"]

--- a/terraform/projects/app-search/README.md
+++ b/terraform/projects/app-search/README.md
@@ -15,6 +15,7 @@ Search application servers
 | aws_region | AWS region | string | `eu-west-1` | no |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `c5.large` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -64,6 +64,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "c5.large"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -151,7 +157,7 @@ module "search" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "search", "aws_hostname", "search-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_search_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "c5.large"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "1"
   instance_elb_ids              = ["${aws_elb.search_elb.id}"]

--- a/terraform/projects/app-transition-db-admin/README.md
+++ b/terraform/projects/app-transition-db-admin/README.md
@@ -9,6 +9,7 @@ DB admin boxes for Transition's RDS instance
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -35,6 +35,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "t2.medium"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -94,7 +100,7 @@ module "transition-db-admin" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "transition_db_admin", "aws_hostname", "transition-db-admin-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_transition-db-admin_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "t2.medium"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "1"
   instance_elb_ids              = ["${aws_elb.transition-db-admin_elb.id}"]

--- a/terraform/projects/app-transition-postgresql/README.md
+++ b/terraform/projects/app-transition-postgresql/README.md
@@ -10,6 +10,7 @@ RDS Transition PostgreSQL Primary instance
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
+| instance_type | Instance type used for RDS resources | string | `db.m4.large` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | multi_az | Enable multi-az. | string | `true` | no |

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -61,6 +61,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for RDS resources"
+  default     = "db.m4.large"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -89,7 +95,7 @@ module "transition-postgresql-primary_rds_instance" {
   username            = "${var.username}"
   password            = "${var.password}"
   allocated_storage   = "120"
-  instance_class      = "db.m4.large"
+  instance_class      = "${var.instance_type}"
   instance_name       = "${var.stackname}-transition-postgresql-primary"
   multi_az            = "${var.multi_az}"
   security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_transition-postgresql-primary_id}"]
@@ -111,7 +117,7 @@ module "transition-postgresql-standby_rds_instance" {
 
   name                       = "${var.stackname}-transition-postgresql-standby"
   default_tags               = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "transition_postgresql_standby")}"
-  instance_class             = "db.m4.large"
+  instance_class             = "${var.instance_type}"
   instance_name              = "${var.stackname}-transition-postgresql-standby"
   security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_transition-postgresql-standby_id}"]
   create_replicate_source_db = "1"

--- a/terraform/projects/app-whitehall-backend/README.md
+++ b/terraform/projects/app-whitehall-backend/README.md
@@ -17,6 +17,7 @@ Whitehall Backend nodes
 | external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.large` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -72,6 +72,12 @@ variable "create_external_elb" {
   default     = true
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.large"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -235,7 +241,7 @@ module "whitehall-backend" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "whitehall_backend", "aws_hostname", "whitehall-backend-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.large"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "${local.instance_elb_ids_length}"
   instance_elb_ids              = ["${local.instance_elb_ids}"]

--- a/terraform/projects/app-whitehall-frontend/README.md
+++ b/terraform/projects/app-whitehall-frontend/README.md
@@ -12,6 +12,7 @@ Whitehall Frontend nodes
 | aws_region | AWS region | string | `eu-west-1` | no |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.large` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -46,6 +46,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for EC2 resources"
+  default     = "m5.large"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -123,7 +129,7 @@ module "whitehall-frontend" {
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "whitehall_frontend", "aws_hostname", "whitehall-frontend-1")}"
   instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-frontend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "m5.large"
+  instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
   instance_elb_ids_length       = "1"
   instance_elb_ids              = ["${aws_elb.whitehall-frontend_elb.id}"]


### PR DESCRIPTION
- We want to be able to reduce the size of all EC2 resources in the
integration and training environment.
- Formerly hard-coded instance_type has been introduced as respective
new default value.
- Renamed variables for some formerly configurable instance_types to be
consistently "instance_type"

Depends on: https://github.com/alphagov/govuk-aws-data/pull/493

Tested no-op in integration for Prometheus, Puppetmaster

solo: @schmie