### PR TITLE
Add Mirror Cloudfront configuration

### DIFF
--- a/terraform/projects/infra-mirror-bucket/README.md
+++ b/terraform/projects/infra-mirror-bucket/README.md
@@ -15,6 +15,12 @@ The primary bucket should be in London and the backup in Ireland.
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region where primary s3 bucket is located | string | `eu-west-2` | no |
 | aws_replica_region | AWS region where replica s3 bucket is located | string | `eu-west-1` | no |
+| cloudfront_assets_certificate_domain | The domain of the Assets CloudFront certificate to look up. | string | `` | no |
+| cloudfront_assets_distribution_aliases | Extra CNAMEs (alternate domain names), if any, for the Assets CloudFront distribution. | list | `<list>` | no |
+| cloudfront_create | Create Cloudfront resources. | string | `false` | no |
+| cloudfront_enable | Enable Cloudfront distributions. | string | `false` | no |
+| cloudfront_www_certificate_domain | The domain of the WWW CloudFront certificate to look up. | string | `` | no |
+| cloudfront_www_distribution_aliases | Extra CNAMEs (alternate domain names), if any, for the WWW CloudFront distribution. | list | `<list>` | no |
 | office_ips | An array of CIDR blocks that will be allowed offsite access. | list | - | yes |
 | remote_state_app_mirrorer_key_stack | stackname path to app_mirrorer remote state | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -46,6 +46,40 @@ variable "office_ips" {
   description = "An array of CIDR blocks that will be allowed offsite access."
 }
 
+variable "cloudfront_create" {
+  description = "Create Cloudfront resources."
+  default     = false
+}
+
+variable "cloudfront_enable" {
+  description = "Enable Cloudfront distributions."
+  default     = false
+}
+
+variable "cloudfront_www_distribution_aliases" {
+  type        = "list"
+  description = "Extra CNAMEs (alternate domain names), if any, for the WWW CloudFront distribution."
+  default     = []
+}
+
+variable "cloudfront_www_certificate_domain" {
+  type        = "string"
+  description = "The domain of the WWW CloudFront certificate to look up."
+  default     = ""
+}
+
+variable "cloudfront_assets_distribution_aliases" {
+  type        = "list"
+  description = "Extra CNAMEs (alternate domain names), if any, for the Assets CloudFront distribution."
+  default     = []
+}
+
+variable "cloudfront_assets_certificate_domain" {
+  type        = "string"
+  description = "The domain of the Assets CloudFront certificate to look up."
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -63,6 +97,12 @@ provider "aws" {
 provider "aws" {
   region  = "${var.aws_replica_region}"
   alias   = "aws_replica"
+  version = "1.60.0"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  alias   = "aws_cloudfront_certificate"
   version = "1.60.0"
 }
 
@@ -221,4 +261,164 @@ resource "aws_iam_policy_attachment" "govuk_mirror_read_policy_attachment" {
   name       = "s3-govuk-mirror-read-policy-attachment"
   users      = ["${aws_iam_user.govuk_mirror_google_reader.name}"]
   policy_arn = "${aws_iam_policy.govuk_mirror_read_policy.arn}"
+}
+
+#
+# CloudFront
+#
+resource "aws_cloudfront_origin_access_identity" "mirror_access_identity" {
+  comment = "S3 WWW"
+}
+
+data "aws_acm_certificate" "www" {
+  count = "${var.cloudfront_create}"
+
+  domain   = "${var.cloudfront_www_certificate_domain}"
+  statuses = ["ISSUED"]
+  provider = "aws.aws_cloudfront_certificate"
+}
+
+data "aws_acm_certificate" "assets" {
+  count = "${var.cloudfront_create}"
+
+  domain   = "${var.cloudfront_assets_certificate_domain}"
+  statuses = ["ISSUED"]
+  provider = "aws.aws_cloudfront_certificate"
+}
+
+resource "aws_cloudfront_distribution" "www_distribution" {
+  count = "${var.cloudfront_create}"
+
+  origin {
+    domain_name = "${aws_s3_bucket.govuk-mirror.bucket_regional_domain_name}"
+    origin_id   = "S3 www"
+    origin_path = "/www.gov.uk"
+
+    s3_origin_config {
+      origin_access_identity = "${aws_cloudfront_origin_access_identity.mirror_access_identity.cloudfront_access_identity_path}"
+    }
+  }
+
+  enabled             = "${var.cloudfront_enable}"
+  is_ipv6_enabled     = true
+  comment             = "WWW"
+  default_root_object = "index.html"
+
+  logging_config {
+    include_cookies = false
+    bucket          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    prefix          = "cloudfront/"
+  }
+
+  aliases = ["${var.cloudfront_www_distribution_aliases}"]
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "S3 www"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+  }
+
+  price_class = "PriceClass_All"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = "${data.aws_acm_certificate.www.arn}"
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.1_2016"
+  }
+
+  custom_error_response {
+    error_code            = 403
+    response_code         = 503
+    response_page_path    = "/error/503.html"
+    error_caching_min_ttl = 300
+  }
+
+  tags = {
+    Project         = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
+resource "aws_cloudfront_distribution" "assets_distribution" {
+  count = "${var.cloudfront_create}"
+
+  origin {
+    domain_name = "${aws_s3_bucket.govuk-mirror.bucket_regional_domain_name}"
+    origin_id   = "S3-govuk-${var.aws_environment}-mirror/assets.publishing.service.gov.uk"
+    origin_path = "/assets.publishing.service.gov.uk"
+
+    s3_origin_config {
+      origin_access_identity = "${aws_cloudfront_origin_access_identity.mirror_access_identity.cloudfront_access_identity_path}"
+    }
+  }
+
+  enabled             = "${var.cloudfront_enable}"
+  is_ipv6_enabled     = true
+  comment             = "Assets"
+  default_root_object = "index.html"
+
+  logging_config {
+    include_cookies = false
+    bucket          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    prefix          = "cloudfront/"
+  }
+
+  aliases = ["${var.cloudfront_assets_distribution_aliases}"]
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "S3 www"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+  }
+
+  price_class = "PriceClass_All"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = "${data.aws_acm_certificate.assets.arn}"
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.1_2016"
+  }
+
+  tags = {
+    Project         = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+  }
 }

--- a/terraform/projects/infra-mirror-bucket/mirror-read-policy.tf
+++ b/terraform/projects/infra-mirror-bucket/mirror-read-policy.tf
@@ -72,6 +72,26 @@ data "aws_iam_policy_document" "s3_mirror_read_policy_doc" {
       identifiers = ["*"]
     }
   }
+
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.govuk-mirror.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${aws_cloudfront_origin_access_identity.mirror_access_identity.iam_arn}"]
+    }
+  }
+
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = ["${aws_s3_bucket.govuk-mirror.arn}"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${aws_cloudfront_origin_access_identity.mirror_access_identity.iam_arn}"]
+    }
+  }
 }
 
 data "aws_iam_policy_document" "s3_mirror_replica_read_policy_doc" {


### PR DESCRIPTION
We want to be able to switch to a secondary CDN provider in case our
primary one is having issues. Here we are creating a new CloudFront
distribution able to serve the content in the primary S3 mirror bucket.