### PR TITLE
Upgrade instance type for app-related-links generation instance

### DIFF
--- a/terraform/projects/app-related-links/main.tf
+++ b/terraform/projects/app-related-links/main.tf
@@ -208,7 +208,7 @@ resource "aws_key_pair" "concourse_public_key" {
 resource "aws_launch_template" "related-links-generation_launch-template" {
   name          = "related-links-generation_launch-template"
   image_id      = "${data.aws_ami.ubuntu_bionic.id}"
-  instance_type = "m5.2xlarge"
+  instance_type = "m5.4xlarge"
 
   vpc_security_group_ids = [
     "${data.terraform_remote_state.infra_security_groups.sg_related-links_id}",


### PR DESCRIPTION
This PR upgrades the instance type used for related links generation in the `app-related-links` project from `m5.2xlarge` to `m5.4xlarge`. An `m5.4xlarge` was used during development for the testing of the related links algorithm and it was thought that a downgrade might be possible to a lesser instance type, however this has been proven false so reverting back to the original instance type.