### PR TITLE
Assets Cloudfront distribution remove default_root_object

### DIFF
--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -371,10 +371,9 @@ resource "aws_cloudfront_distribution" "assets_distribution" {
     }
   }
 
-  enabled             = "${var.cloudfront_enable}"
-  is_ipv6_enabled     = true
-  comment             = "Assets"
-  default_root_object = "index.html"
+  enabled         = "${var.cloudfront_enable}"
+  is_ipv6_enabled = true
+  comment         = "Assets"
 
   logging_config {
     include_cookies = false


### PR DESCRIPTION
The default_root_object setting in the Assets Cloudfront distribution is
not required because we always request specific objects. We can remove
the setting from the configuration.