### PR TITLE
Cloudfront fix logging settings

### DIFF
--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -306,7 +306,7 @@ resource "aws_cloudfront_distribution" "www_distribution" {
 
   logging_config {
     include_cookies = false
-    bucket          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    bucket          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}.s3.amazonaws.com"
     prefix          = "cloudfront/"
   }
 
@@ -377,7 +377,7 @@ resource "aws_cloudfront_distribution" "assets_distribution" {
 
   logging_config {
     include_cookies = false
-    bucket          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    bucket          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}.s3.amazonaws.com"
     prefix          = "cloudfront/"
   }
 


### PR DESCRIPTION
We are seeing this error:

```
aws_cloudfront_distribution...._distribution: error updating CloudFront Distribution
InvalidArgument: The parameter Logging Bucket does not refer to a valid S3 bucket.
```

The `bucket` setting needs to be the bucket domain.
https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#logging-config-arguments