### PR TITLE
Enable read access to mirror buckets from NAT IPs

### DIFF
--- a/terraform/projects/infra-mirror-bucket/README.md
+++ b/terraform/projects/infra-mirror-bucket/README.md
@@ -25,5 +25,6 @@ The primary bucket should be in London and the backup in Ireland.
 | remote_state_app_mirrorer_key_stack | stackname path to app_mirrorer remote state | string | `` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
+| remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
 | stackname | Stackname | string | - | yes |
 

--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -41,6 +41,12 @@ variable "remote_state_infra_monitoring_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_networking_key_stack" {
+  type        = "string"
+  description = "Override infra_networking remote state path"
+  default     = ""
+}
+
 variable "office_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will be allowed offsite access."
@@ -114,6 +120,16 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
+    region = "${var.aws_replica_region}"
+  }
+}
+
+data "terraform_remote_state" "infra_networking" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
     region = "${var.aws_replica_region}"
   }
 }

--- a/terraform/projects/infra-mirror-bucket/mirror-read-policy.tf
+++ b/terraform/projects/infra-mirror-bucket/mirror-read-policy.tf
@@ -74,6 +74,27 @@ data "aws_iam_policy_document" "s3_mirror_read_policy_doc" {
   }
 
   statement {
+    sid     = "S3NATInternalReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror.id}/*",
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["${data.terraform_remote_state.infra_networking.nat_gateway_elastic_ips_list}"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+
+  statement {
     actions   = ["s3:GetObject"]
     resources = ["${aws_s3_bucket.govuk-mirror.arn}/*"]
 
@@ -150,6 +171,27 @@ data "aws_iam_policy_document" "s3_mirror_replica_read_policy_doc" {
       test     = "IpAddress"
       variable = "aws:SourceIp"
       values   = ["${var.office_ips}"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+
+  statement {
+    sid     = "S3NATInternalReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-replica.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-replica.id}/*",
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["${data.terraform_remote_state.infra_networking.nat_gateway_elastic_ips_list}"]
     }
 
     principals {


### PR DESCRIPTION
We are going to run Smokey tests from our platform, that require
read access to the content in the mirror buckets. Outbound traffic uses
NAT gateways, we can use infra-networking state to retrieve the list of
NAT ip addresses to whitelist.