### PR TITLE
Migrate dev_vm project from govuk-terraform-provisioning

### DIFF
--- a/terraform/projects/infra-dev_vm/README.md
+++ b/terraform/projects/infra-dev_vm/README.md
@@ -1,0 +1,20 @@
+## Module: projects/infra-dev_vm
+
+Creates an S3 bucket to store the development VMs used in govuk-puppet
+Vagrantfile
+
+Mifrated from:
+https://github.com/alphagov/govuk-terraform-provisioning/tree/master/old-projects/dev_vm
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| bucket_name |  | string | `govuk-dev-boxes` | no |
+| stackname | Stackname | string | `` | no |
+| team |  | string | `Infrastructure` | no |
+| username |  | string | `govuk-dev-box-uploader` | no |
+

--- a/terraform/projects/infra-dev_vm/main.tf
+++ b/terraform/projects/infra-dev_vm/main.tf
@@ -1,0 +1,74 @@
+/**
+* ## Module: projects/infra-dev_vm
+*
+* Creates an S3 bucket to store the development VMs used in govuk-puppet
+* Vagrantfile
+*
+* Mifrated from:
+* https://github.com/alphagov/govuk-terraform-provisioning/tree/master/old-projects/dev_vm
+*/
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+  default     = ""
+}
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+variable "bucket_name" {
+  type    = "string"
+  default = "govuk-dev-boxes"
+}
+
+variable "team" {
+  type    = "string"
+  default = "Infrastructure"
+}
+
+variable "username" {
+  type    = "string"
+  default = "govuk-dev-box-uploader"
+}
+
+# Resources
+# --------------------------------------------------------------
+
+terraform {
+  backend "s3" {}
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "${var.bucket_name}-${var.aws_environment}"
+  policy = "${data.aws_iam_policy_document.readonly_policy.json}"
+
+  tags {
+    Environment = "${var.aws_environment}"
+    Team        = "${var.team}"
+  }
+}
+
+resource "aws_iam_policy" "readwrite_policy" {
+  name        = "${var.bucket_name}_${var.username}-policy"
+  description = "${var.bucket_name} allows writes"
+  policy      = "${data.aws_iam_policy_document.readwrite_policy.json}"
+}
+
+resource "aws_iam_user" "iam_user" {
+  name = "${var.username}"
+}
+
+resource "aws_iam_policy_attachment" "iam_policy_attachment" {
+  name       = "${var.bucket_name}_${var.username}_attachment_policy"
+  users      = ["${aws_iam_user.iam_user.name}"]
+  policy_arn = "${aws_iam_policy.readwrite_policy.arn}"
+}

--- a/terraform/projects/infra-dev_vm/policy.tf
+++ b/terraform/projects/infra-dev_vm/policy.tf
@@ -1,0 +1,58 @@
+data "aws_iam_policy_document" "readonly_policy" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:ListBucket"]
+    effect  = "Allow"
+
+    resources = ["arn:aws:s3:::${var.bucket_name}-${var.aws_environment}"]
+  }
+
+  statement {
+    sid    = "Allow public read-only access"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${var.bucket_name}-${var.aws_environment}/*"]
+  }
+}
+
+data "aws_iam_policy_document" "readwrite_policy" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListBucketVersions",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::${var.bucket_name}-${var.aws_environment}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::${var.bucket_name}-${var.aws_environment}/*",
+    ]
+  }
+}

--- a/terraform/projects/infra-dev_vm/test.govuk.backend
+++ b/terraform/projects/infra-dev_vm/test.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-test"
+key     = "govuk/infra-dev_vm.tfstate"
+encrypt = true
+region  = "eu-west-1"


### PR DESCRIPTION
Migrate `dev_vm` to this repository:
https://github.com/alphagov/govuk-terraform-provisioning/tree/master/old-projects/dev_vm