### PR TITLE
Allow draft-frontend to talk to backend-redis

### DIFF
--- a/terraform/projects/infra-security-groups/backend-redis.tf
+++ b/terraform/projects/infra-security-groups/backend-redis.tf
@@ -150,3 +150,16 @@ resource "aws_security_group_rule" "backend-redis_ingress_frontend_redis" {
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.frontend.id}"
 }
+
+resource "aws_security_group_rule" "backend-redis_ingress_draft-frontend_redis" {
+  type      = "ingress"
+  from_port = 6379
+  to_port   = 6379
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.backend-redis.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.draft-frontend.id}"
+}


### PR DESCRIPTION
This is needed for the emergency banner to work in the draft environment. Without it, static returns a 500 error when trying to render a page.