### PR TITLE
adds an example web acl rule to the cache alb

### DIFF
--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -685,6 +685,11 @@ module "cache_public_lb" {
   default_tags                               = "${map("Project", var.stackname, "aws_migration", "cache", "aws_environment", var.aws_environment)}"
 }
 
+resource "aws_wafregional_web_acl_association" "cache_public_web_acl" {
+  resource_arn = "${module.cache_public_lb.lb_id}"
+  web_acl_id   = "${aws_wafregional_web_acl.default.id}"
+}
+
 resource "aws_route53_record" "cache_public_service_names" {
   count   = "${length(var.cache_public_service_names)}"
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"

--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -1,0 +1,49 @@
+resource "aws_wafregional_regex_pattern_set" "x_always_block" {
+  name                  = "XAlwaysBlock"
+  regex_pattern_strings = ["true"]
+}
+
+resource "aws_wafregional_regex_match_set" "x_always_block" {
+  name = "XAlwaysBlock"
+
+  regex_match_tuple {
+    field_to_match {
+      data = "X-Always-Block"
+      type = "HEADER"
+    }
+
+    regex_pattern_set_id = "${aws_wafregional_regex_pattern_set.x_always_block.id}"
+    text_transformation  = "NONE"
+  }
+}
+
+resource "aws_wafregional_rule" "x_always_block" {
+  name        = "XAlwaysBlock"
+  metric_name = "XAlwaysBlock"
+
+  predicate {
+    data_id = "${aws_wafregional_regex_match_set.x_always_block.id}"
+    negated = false
+    type    = "RegexMatch"
+  }
+}
+
+resource "aws_wafregional_web_acl" "default" {
+  name        = "CachePublicWebACL"
+  metric_name = "CachePublicWebACL"
+
+  default_action {
+    type = "ALLOW"
+  }
+
+  rule {
+    action {
+      type = "BLOCK"
+    }
+
+    priority = 2
+    rule_id  = "${aws_wafregional_rule.x_always_block.id}"
+  }
+
+  depends_on = ["aws_wafregional_rule.x_always_block"]
+}


### PR DESCRIPTION
## what

adds an example acl rule that blocks requests containing an
`X-Always-Block: true` header and associates it with the public cache alb.

## why

so that we have an entrypoint for addiing web acl rules if required

## related

https://github.com/alphagov/smokey/pull/564