### PR TITLE
adds waf log shipping to splunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.tfstate
 *.tfstate.backup
 *.swp
+
+# ignore lambda zip artifact from archive_file
+terraform/lambda/WAFLogTrimmer/lambda.zip

--- a/terraform/lambda/WAFLogTrimmer/README.md
+++ b/terraform/lambda/WAFLogTrimmer/README.md
@@ -1,0 +1,11 @@
+## WAFLogTrimmer
+
+This AWS Lambda function processes the WAF firewall logs in the firehose to
+drop any logs that matched the "default" action before they are shipped on to splunk.
+
+This means that the logs should only contain "interesting" things for example
+BLOCKED requests or ALLOWED requests that matched a rule and were explicitly
+marked as ALLOW.
+
+Without this processing of the WAF logs every single request would be sent for
+indexing in splunk which would be of very little value.

--- a/terraform/lambda/WAFLogTrimmer/lambda.js
+++ b/terraform/lambda/WAFLogTrimmer/lambda.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.handler = (event, context, callback) => {
+	// Drop any records that match the "default" action (ie all the "normal" traffic that isn't matching a rule)
+	const output = event.records.map((record) => {
+		const entry = (new Buffer(record.data, 'base64')).toString('utf8');
+		if (!entry.match(/Default_Action/g)) {
+			return {
+				recordId: record.recordId,
+				result: 'Ok',
+				data: record.data,
+			};
+		}
+		return {
+			recordId: record.recordId,
+			result: 'Dropped',
+			data: record.data,
+		};
+	});
+	console.log(`filtered ${event.records.length - output.length} records matching default action from total of ${event.records.length}.`);
+	callback(null, { records: output });
+};

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -99,6 +99,8 @@ This project adds global resources for app components:
 | transition_db_admin_internal_service_names |  | list | `<list>` | no |
 | transition_postgresql_internal_service_names |  | list | `<list>` | no |
 | ubuntutest_public_service_names |  | list | `<list>` | no |
+| waf_logs_hec_endpoint | Splunk endpoint for shipping application firewall logs | string | - | yes |
+| waf_logs_hec_token | Splunk token for shipping application firewall logs | string | - | yes |
 | whitehall_backend_internal_service_cnames |  | list | `<list>` | no |
 | whitehall_backend_internal_service_names |  | list | `<list>` | no |
 | whitehall_backend_public_service_cnames |  | list | `<list>` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -445,6 +445,16 @@ variable "draft_content_store_public_service_names" {
   default = []
 }
 
+variable "waf_logs_hec_endpoint" {
+  description = "Splunk endpoint for shipping application firewall logs"
+  type        = "string"
+}
+
+variable "waf_logs_hec_token" {
+  description = "Splunk token for shipping application firewall logs"
+  type        = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {

--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -45,5 +45,108 @@ resource "aws_wafregional_web_acl" "default" {
     rule_id  = "${aws_wafregional_rule.x_always_block.id}"
   }
 
+  logging_configuration {
+    log_destination = "${aws_kinesis_firehose_delivery_stream.splunk.arn}"
+
+    redacted_fields {
+      field_to_match {
+        type = "URI"
+      }
+
+      field_to_match {
+        data = "referer"
+        type = "HEADER"
+      }
+    }
+  }
+
   depends_on = ["aws_wafregional_rule.x_always_block"]
+}
+
+resource "aws_s3_bucket" "aws_waf_logs" {
+  bucket = "aws-waf-logs-splunk"
+  acl    = "private"
+  bucket = "govuk-${var.aws_environment}-aws-waf-logs"
+  region = "${var.aws_region}"
+
+  lifecycle_rule {
+    id      = "all"
+    enabled = true
+
+    expiration {
+      days = 3
+    }
+  }
+}
+
+resource "aws_iam_role" "aws_waf_firehose" {
+  name = "${var.aws_environment}-aws-waf-firehose"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "firehose.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "aws_waf_firehose" {
+  name = "${var.aws_environment}-aws-waf-firehose"
+  role = "${aws_iam_role.aws_waf_firehose.id}"
+
+  policy = <<EOF
+{
+    "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+              "s3:AbortMultipartUpload",
+              "s3:GetBucketLocation",
+              "s3:GetObject",
+              "s3:ListBucket",
+              "s3:ListBucketMultipartUploads",
+              "s3:PutObject"
+          ],
+          "Resource": [
+              "arn:aws:s3:::${aws_s3_bucket.aws_waf_logs.bucket}",
+              "arn:aws:s3:::${aws_s3_bucket.aws_waf_logs.bucket}/*"
+          ]
+      }
+    ]
+}
+EOF
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "splunk" {
+  # NOTE: The Kinesis Firehose Delivery Stream name must begin with
+  # aws-waf-logs-. See the AWS WAF Developer Guide for more information
+  # about enabling WAF logging.
+  name = "aws-waf-logs-${var.aws_environment}"
+
+  destination = "splunk"
+
+  s3_configuration {
+    role_arn           = "${aws_iam_role.aws_waf_firehose.arn}"
+    bucket_arn         = "${aws_s3_bucket.aws_waf_logs.arn}"
+    buffer_size        = 10
+    buffer_interval    = 400
+    compression_format = "GZIP"
+  }
+
+  splunk_configuration {
+    hec_endpoint               = "${var.waf_logs_hec_endpoint}"
+    hec_token                  = "${var.waf_logs_hec_token}"
+    hec_acknowledgment_timeout = 180
+    hec_endpoint_type          = "Raw"
+    s3_backup_mode             = "AllEvents"
+  }
 }


### PR DESCRIPTION
## What

Adds a firehose for forwarding web acl logs to splunk and wires up the
"default" ACL to test shipping is working as expected

WAF ACL Logs -> Firehose -> WAFLogTrimmer() -> Splunk

We add a lambda function to trim any logs that are not an explicit ALLOW or BLOCK (ie we do not want every single gov.uk request in this log index, we only want things that have matched an ACL).

long term cyber will be collecting all these kinds of logs for threat
intelligence and will be doing it by exposing a cross-account firehose
destination that we could ship directly to. However at time of writing
this method is not quite ready for prime-time and so we are deploying a
firehose that will ship directly to splunk

The cyber managed Splunk instance  will ingest the logs and make them
available both to GOV.UK members and Cyber threat intelligence.

An S3 bucket captures logs in the event that the splunk delivery or the processing is not operating correctly.

## Why

* So that GOV.UK have visibility of the effect of web ACLs 
* So that Cyber have visibility of the effects of web ACLs 

## Before merge

:warning: requires https://github.com/alphagov/govuk-aws-data/pull/518
