### PR TITLE
add ID to replication rule for artefact bucket

### DIFF
--- a/terraform/projects/infra-artefact-bucket/main.tf
+++ b/terraform/projects/infra-artefact-bucket/main.tf
@@ -157,6 +157,7 @@ resource "aws_s3_bucket" "artefact" {
     role = "${aws_iam_role.artefact_replication.arn}"
 
     rules {
+      id     = "govuk-artefact-replication-whole-bucket-rule"
       status = "Enabled"
       prefix = ""
 


### PR DESCRIPTION
This is required to maintain idempotency when doing terraform plan and no changes are expected.