### PR TITLE
Adds SQLInjection and XSS application firewall rules in ALLOW mode

### DIFF
--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -24,6 +24,15 @@ resource "aws_wafregional_web_acl" "default" {
     rule_id  = "${aws_wafregional_rule.sqli.id}"
   }
 
+  rule {
+    action {
+      type = "ALLOW" # FIXME: Change this to BLOCK after 25th July 2019
+    }
+
+    priority = 4
+    rule_id  = "${aws_wafregional_rule.xss.id}"
+  }
+
   logging_configuration {
     log_destination = "${aws_kinesis_firehose_delivery_stream.splunk.arn}"
 
@@ -42,6 +51,7 @@ resource "aws_wafregional_web_acl" "default" {
   depends_on = [
     "aws_wafregional_rule.x_always_block",
     "aws_wafregional_rule.sqli",
+    "aws_wafregional_rule.xss",
   ]
 }
 

--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -1,33 +1,3 @@
-resource "aws_wafregional_regex_pattern_set" "x_always_block" {
-  name                  = "XAlwaysBlock"
-  regex_pattern_strings = ["true"]
-}
-
-resource "aws_wafregional_regex_match_set" "x_always_block" {
-  name = "XAlwaysBlock"
-
-  regex_match_tuple {
-    field_to_match {
-      data = "X-Always-Block"
-      type = "HEADER"
-    }
-
-    regex_pattern_set_id = "${aws_wafregional_regex_pattern_set.x_always_block.id}"
-    text_transformation  = "NONE"
-  }
-}
-
-resource "aws_wafregional_rule" "x_always_block" {
-  name        = "XAlwaysBlock"
-  metric_name = "XAlwaysBlock"
-
-  predicate {
-    data_id = "${aws_wafregional_regex_match_set.x_always_block.id}"
-    negated = false
-    type    = "RegexMatch"
-  }
-}
-
 resource "aws_wafregional_web_acl" "default" {
   name        = "CachePublicWebACL"
   metric_name = "CachePublicWebACL"
@@ -45,6 +15,15 @@ resource "aws_wafregional_web_acl" "default" {
     rule_id  = "${aws_wafregional_rule.x_always_block.id}"
   }
 
+  rule {
+    action {
+      type = "ALLOW" # FIXME: Change this to BLOCK after 25th July 2019
+    }
+
+    priority = 3
+    rule_id  = "${aws_wafregional_rule.sqli.id}"
+  }
+
   logging_configuration {
     log_destination = "${aws_kinesis_firehose_delivery_stream.splunk.arn}"
 
@@ -60,7 +39,10 @@ resource "aws_wafregional_web_acl" "default" {
     }
   }
 
-  depends_on = ["aws_wafregional_rule.x_always_block"]
+  depends_on = [
+    "aws_wafregional_rule.x_always_block",
+    "aws_wafregional_rule.sqli",
+  ]
 }
 
 resource "aws_s3_bucket" "aws_waf_logs" {

--- a/terraform/projects/infra-public-services/waf_sqli_rule.tf
+++ b/terraform/projects/infra-public-services/waf_sqli_rule.tf
@@ -1,0 +1,112 @@
+# As obtained from https://raw.githubusercontent.com/juiceinc/terraform-aws-juiceinc-waf/master/sqlinjection.tf
+#
+# SQL Injection is a built-in type of traffic that the WAF knows how to filter.  To my knowledge we are left to the mercy
+# of their heuristics on the backend to correctly classify elements as containing malicious SQL.  We just specify which
+# fields to match on and any transformations to do.
+
+# As of this writing valid values for field_to_match are: HEADER (if using this also must set a data value), METHOD,
+# QUERY_STRING, URI, BODY, SINGLE_QUERY_ARG, ALL_QUERY_ARGS.
+
+# Valid values for text_transformation include: CMD_LINE, COMPRESS_WHITE_SPACE, HTML_ENTITY_DECODE, LOWERCASE, NONE, and
+# URL_DECODE
+
+# The following rule set was transcribed from the AWS example in their CloudFormation template.
+
+resource "aws_wafregional_sql_injection_match_set" "sqli" {
+  name = "SQLInjection"
+
+  sql_injection_match_tuple {
+    text_transformation = "URL_DECODE"
+
+    field_to_match {
+      type = "BODY"
+    }
+  }
+
+  sql_injection_match_tuple {
+    text_transformation = "HTML_ENTITY_DECODE"
+
+    field_to_match {
+      type = "BODY"
+    }
+  }
+
+  sql_injection_match_tuple {
+    text_transformation = "HTML_ENTITY_DECODE"
+
+    field_to_match {
+      type = "URI"
+    }
+  }
+
+  sql_injection_match_tuple {
+    text_transformation = "URL_DECODE"
+
+    field_to_match {
+      type = "URI"
+    }
+  }
+
+  sql_injection_match_tuple {
+    text_transformation = "URL_DECODE"
+
+    field_to_match {
+      type = "QUERY_STRING"
+    }
+  }
+
+  sql_injection_match_tuple {
+    text_transformation = "HTML_ENTITY_DECODE"
+
+    field_to_match {
+      type = "QUERY_STRING"
+    }
+  }
+
+  sql_injection_match_tuple {
+    text_transformation = "HTML_ENTITY_DECODE"
+
+    field_to_match {
+      type = "HEADER"
+      data = "cookie"
+    }
+  }
+
+  sql_injection_match_tuple {
+    text_transformation = "URL_DECODE"
+
+    field_to_match {
+      type = "HEADER"
+      data = "cookie"
+    }
+  }
+
+  sql_injection_match_tuple {
+    text_transformation = "HTML_ENTITY_DECODE"
+
+    field_to_match {
+      type = "HEADER"
+      data = "authorization"
+    }
+  }
+
+  sql_injection_match_tuple {
+    text_transformation = "URL_DECODE"
+
+    field_to_match {
+      type = "HEADER"
+      data = "authorization"
+    }
+  }
+}
+
+resource "aws_wafregional_rule" "sqli" {
+  name        = "SQLInjection"
+  metric_name = "SQLInjection"
+
+  predicate {
+    data_id = "${aws_wafregional_sql_injection_match_set.sqli.id}"
+    negated = false
+    type    = "SqlInjectionMatch"
+  }
+}

--- a/terraform/projects/infra-public-services/waf_test_rule.tf
+++ b/terraform/projects/infra-public-services/waf_test_rule.tf
@@ -1,0 +1,33 @@
+# this rule matches any request that contains the header X-Always-Block: true
+# we use it as a simple sanity check / acceptance test from smokey to ensure that
+# the waf is enabled and processing requests
+#
+resource "aws_wafregional_regex_pattern_set" "x_always_block" {
+  name                  = "XAlwaysBlock"
+  regex_pattern_strings = ["true"]
+}
+
+resource "aws_wafregional_regex_match_set" "x_always_block" {
+  name = "XAlwaysBlock"
+
+  regex_match_tuple {
+    field_to_match {
+      data = "X-Always-Block"
+      type = "HEADER"
+    }
+
+    regex_pattern_set_id = "${aws_wafregional_regex_pattern_set.x_always_block.id}"
+    text_transformation  = "NONE"
+  }
+}
+
+resource "aws_wafregional_rule" "x_always_block" {
+  name        = "XAlwaysBlock"
+  metric_name = "XAlwaysBlock"
+
+  predicate {
+    data_id = "${aws_wafregional_regex_match_set.x_always_block.id}"
+    negated = false
+    type    = "RegexMatch"
+  }
+}

--- a/terraform/projects/infra-public-services/waf_xss_rule.tf
+++ b/terraform/projects/infra-public-services/waf_xss_rule.tf
@@ -1,0 +1,62 @@
+resource "aws_wafregional_xss_match_set" "xss" {
+  name = "XSS"
+
+  xss_match_tuple {
+    text_transformation = "URL_DECODE"
+
+    field_to_match {
+      type = "QUERY_STRING"
+    }
+  }
+
+  xss_match_tuple {
+    text_transformation = "HTML_ENTITY_DECODE"
+
+    field_to_match {
+      type = "QUERY_STRING"
+    }
+  }
+
+  xss_match_tuple {
+    text_transformation = "URL_DECODE"
+
+    field_to_match {
+      type = "BODY"
+    }
+  }
+
+  xss_match_tuple {
+    text_transformation = "HTML_ENTITY_DECODE"
+
+    field_to_match {
+      type = "BODY"
+    }
+  }
+
+  xss_match_tuple {
+    text_transformation = "URL_DECODE"
+
+    field_to_match {
+      type = "URI"
+    }
+  }
+
+  xss_match_tuple {
+    text_transformation = "HTML_ENTITY_DECODE"
+
+    field_to_match {
+      type = "URI"
+    }
+  }
+}
+
+resource "aws_wafregional_rule" "xss" {
+  name        = "XSS"
+  metric_name = "XSS"
+
+  predicate {
+    data_id = "${aws_wafregional_xss_match_set.xss.id}"
+    negated = false
+    type    = "XssMatch"
+  }
+}


### PR DESCRIPTION
### What

Adds rules to the `default` web application firewall ACL (connected to the frontend/cache load balancer) that:

* Attempts to detect SQL injection attempts in cookies/querystrings/uris/body of requests
* Attempts to detect Cross Site Scripting attempts in cookies/querystrings/uris/body of requests

The rules are currently marked to `ALLOW` so will not affect traffic.

The rules have been broken out into their own tf flies to make them easier to maintain.

### Why

So that we can monitor the impact these rules will have against the production traffic before moving into `BLOCK` mode to gain the basic protection these rules will provide against these extremely common attack vectors.

### Notes

Once deployed matched requests can be viewed either from Splunk or from the AWS console.