### PR TITLE
adds "default" web ACL to backend/whitehall ALBs

### DIFF
--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -526,6 +526,11 @@ module "backend_public_lb" {
   default_tags                               = "${map("Project", var.stackname, "aws_migration", "backend", "aws_environment", var.aws_environment)}"
 }
 
+resource "aws_wafregional_web_acl_association" "backend_public_lb" {
+  resource_arn = "${module.backend_public_lb.lb_id}"
+  web_acl_id   = "${aws_wafregional_web_acl.default.id}"
+}
+
 resource "aws_lb_listener_rule" "backend_alb_blocked_host_headers" {
   count        = "${length(var.backend_alb_blocked_host_headers)}"
   listener_arn = "${element(module.backend_public_lb.load_balancer_ssl_listeners, 0)}"
@@ -2133,6 +2138,11 @@ module "whitehall_backend_public_lb" {
   security_groups                            = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_external_elb_id}"]
   alarm_actions                              = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
   default_tags                               = "${map("Project", var.stackname, "aws_migration", "whitehall_backend", "aws_environment", var.aws_environment)}"
+}
+
+resource "aws_wafregional_web_acl_association" "whitehall_backend_public_lb" {
+  resource_arn = "${module.whitehall_backend_public_lb.lb_id}"
+  web_acl_id   = "${aws_wafregional_web_acl.default.id}"
 }
 
 resource "aws_route53_record" "whitehall_backend_public_service_names" {


### PR DESCRIPTION
the "default" web ACL provides basic detection of potentially malicious
XSS/SQLi requests, and is currently assigned to the public frontend
cache ALB.

In the future we wish to protect the backend/whitehall apps behind
similar rules too, but these are not yet on the AWS side of the bridge.

To prepare for any false positives and to begin evaluating the impact of the ACL on the backend/whitehall applications we associate the default rule to the ALBs in front of these application in the integration environment in AWS.