### PR TITLE
enable shield advanced protection of cache ALB

### DIFF
--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -705,6 +705,11 @@ resource "aws_wafregional_web_acl_association" "cache_public_web_acl" {
   web_acl_id   = "${aws_wafregional_web_acl.default.id}"
 }
 
+resource "aws_shield_protection" "cache_public_web_acl" {
+  name         = "${var.stackname}-cache-public"
+  resource_arn = "${module.cache_public_lb.lb_id}"
+}
+
 resource "aws_route53_record" "cache_public_service_names" {
   count   = "${length(var.cache_public_service_names)}"
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"


### PR DESCRIPTION
GDS have purchased AWS Shield Advanced which provides us with extended
support/protection against layer 3/4 attacks.

This marks the public cache ALB (frontend) as a "protected resource"
under the scheme.