### PR TITLE
Make fastly vcl `datagovuk.vcl` customisable for fastly IPs

### DIFF
--- a/terraform/projects/fastly-datagovuk/datagovuk.vcl
+++ b/terraform/projects/fastly-datagovuk/datagovuk.vcl
@@ -9,22 +9,22 @@ acl purge_ip_whitelist {
   "34.246.209.74";    # AWS NAT GW1 Production
   "34.253.57.8";      # AWS NAT GW2 Production
   "18.202.136.43";    # AWS NAT GW3 Production
-  "23.235.32.0/20";   # Fastly cache node
-  "43.249.72.0/22";   # Fastly cache node
-  "103.244.50.0/24";  # Fastly cache node
-  "103.245.222.0/23"; # Fastly cache node
-  "103.245.224.0/24"; # Fastly cache node
-  "104.156.80.0/20";  # Fastly cache node
-  "151.101.0.0/16";   # Fastly cache node
-  "157.52.64.0/18";   # Fastly cache node
-  "167.82.0.0/17";    # Fastly cache node
-  "167.82.128.0/20";  # Fastly cache node
-  "167.82.160.0/20";  # Fastly cache node
-  "167.82.224.0/20";  # Fastly cache node
-  "172.111.64.0/18";  # Fastly cache node
-  "185.31.16.0/22";   # Fastly cache node
-  "199.27.72.0/21";   # Fastly cache node
-  "199.232.0.0/16";   # Fastly cache node
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
   
 }
 

--- a/terraform/projects/fastly-datagovuk/datagovuk.vcl.tmp
+++ b/terraform/projects/fastly-datagovuk/datagovuk.vcl.tmp
@@ -9,23 +9,7 @@ acl purge_ip_whitelist {
   "34.246.209.74";    # AWS NAT GW1 Production
   "34.253.57.8";      # AWS NAT GW2 Production
   "18.202.136.43";    # AWS NAT GW3 Production
-  "23.235.32.0/20";   # Fastly cache node
-  "43.249.72.0/22";   # Fastly cache node
-  "103.244.50.0/24";  # Fastly cache node
-  "103.245.222.0/23"; # Fastly cache node
-  "103.245.224.0/24"; # Fastly cache node
-  "104.156.80.0/20";  # Fastly cache node
-  "151.101.0.0/16";   # Fastly cache node
-  "157.52.64.0/18";   # Fastly cache node
-  "167.82.0.0/17";    # Fastly cache node
-  "167.82.128.0/20";  # Fastly cache node
-  "167.82.160.0/20";  # Fastly cache node
-  "167.82.224.0/20";  # Fastly cache node
-  "172.111.64.0/18";  # Fastly cache node
-  "185.31.16.0/22";   # Fastly cache node
-  "199.27.72.0/21";   # Fastly cache node
-  "199.232.0.0/16";   # Fastly cache node
-  
+  <%= fastly_cache_node_subnets %>
 }
 
 sub vcl_recv {

--- a/terraform/projects/fastly-datagovuk/datagovuk.vcle
+++ b/terraform/projects/fastly-datagovuk/datagovuk.vcle
@@ -9,23 +9,7 @@ acl purge_ip_whitelist {
   "34.246.209.74";    # AWS NAT GW1 Production
   "34.253.57.8";      # AWS NAT GW2 Production
   "18.202.136.43";    # AWS NAT GW3 Production
-  "23.235.32.0/20";   # Fastly cache node
-  "43.249.72.0/22";   # Fastly cache node
-  "103.244.50.0/24";  # Fastly cache node
-  "103.245.222.0/23"; # Fastly cache node
-  "103.245.224.0/24"; # Fastly cache node
-  "104.156.80.0/20";  # Fastly cache node
-  "151.101.0.0/16";   # Fastly cache node
-  "157.52.64.0/18";   # Fastly cache node
-  "167.82.0.0/17";    # Fastly cache node
-  "167.82.128.0/20";  # Fastly cache node
-  "167.82.160.0/20";  # Fastly cache node
-  "167.82.224.0/20";  # Fastly cache node
-  "172.111.64.0/18";  # Fastly cache node
-  "185.31.16.0/22";   # Fastly cache node
-  "199.27.72.0/21";   # Fastly cache node
-  "199.232.0.0/16";   # Fastly cache node
-  
+  <%= fastly_cache_node_subnets %>
 }
 
 sub vcl_recv {

--- a/terraform/projects/fastly-datagovuk/fastly.sh
+++ b/terraform/projects/fastly-datagovuk/fastly.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+fastly_raw_ips=( $(curl https://api.fastly.com/public-ip-list 2>/dev/null | jq -r ".addresses[]") )
+
+fastly_ips_snippet=""
+
+for ip in "${fastly_raw_ips[@]}"
+do
+   #fastly_ips_snippet="${fastly_ips_snippet}""\\\"${ip}\\\"""; # Fastly cache node"$'\\\n  '
+   fastly_ips_snippet="${fastly_ips_snippet}"$(printf '%-22s' "\\\"${ip}\\\";")"# Fastly cache node"$'\\\n  '
+done
+
+cp "${DIR}/datagovuk.vcl.tmp" "${DIR}/datagovuk.vcl"
+
+sed -ie "s@<%= fastly_cache_node_subnets %>@${fastly_ips_snippet}@g" "${DIR}/datagovuk.vcl"
+
+echo '{"fastly":"datagovuk.vcl"}'

--- a/terraform/projects/fastly-datagovuk/fastly.sh
+++ b/terraform/projects/fastly-datagovuk/fastly.sh
@@ -8,10 +8,10 @@ fastly_raw_ips=( $(curl https://api.fastly.com/public-ip-list 2>/dev/null | jq -
 
 fastly_ips_snippet=""
 
-for ip in "${fastly_raw_ips[@]}"
+for cidrip in "${fastly_raw_ips[@]}"
 do
-   #fastly_ips_snippet="${fastly_ips_snippet}""\\\"${ip}\\\"""; # Fastly cache node"$'\\\n  '
-   fastly_ips_snippet="${fastly_ips_snippet}"$(printf '%-22s' "\\\"${ip}\\\";")"# Fastly cache node"$'\\\n  '
+   ipstr=$(echo "${cidrip}" | awk -F  "/" '{ print("\\\""$1"\\\"""/"$2) }')
+   fastly_ips_snippet="${fastly_ips_snippet}"$(printf "%-22s %s" "${ipstr}\;" "\# Fastly cache node\n  ")
 done
 
 cp "${DIR}/datagovuk.vcl.tmp" "${DIR}/datagovuk.vcl"

--- a/terraform/projects/fastly-datagovuk/main.tf
+++ b/terraform/projects/fastly-datagovuk/main.tf
@@ -55,6 +55,10 @@ provider "fastly" {
   api_key = "${var.fastly_api_key}"
 }
 
+data "external" "fastly" {
+  program = ["/bin/bash", "${path.module}/fastly.sh"]
+}
+
 resource "fastly_service_v1" "datagovuk" {
   name = "${title(var.aws_environment)} data.gov.uk"
 
@@ -100,13 +104,13 @@ resource "fastly_service_v1" "datagovuk" {
 
   vcl {
     name    = "datagovuk_vcl"
-    content = "${file("datagovuk.vcl")}"
+    content = "${file(data.external.fastly.result.fastly)}"
     main    = true
   }
 
   condition {
     name      = "education_standards"
-    type      = "request"
+    type      = "REQUEST"
     statement = "req.url ~ \"^/education-standards\""
   }
 
@@ -130,7 +134,7 @@ resource "fastly_service_v1" "datagovuk" {
 
   condition {
     name      = "contracts_finder_archive"
-    type      = "request"
+    type      = "REQUEST"
     statement = "req.url ~ \"^/data/contracts-finder-archive\""
   }
 


### PR DESCRIPTION
The fastly vcl `datagovuk.vcl` was static but fastly IPs do change with time. We therefore make the vcl `datagovuk.vcl` dynamic by using a template `datagovuk.vcl.tmp` which is then filled in at terraform `apply`/`plan` time.

The template `datagovuk.vcl.tmp` is filled by using a terraform external data source which runs a bash script `fastly.sh`. `fastly.sh` makes a query to fastly to get the latest fastly subnets and then uses these values to insert into the `datagovuk.vcl.tmp` to make the `datagovuk.vcl`.

In addition, there was a need to replace the condition type from `request` to `REQUEST` because of a change in fastly accepted types.

----
@schmie:
Frederic is OOO for the next week due to a family commitment, so I am taking over this PR.

Tested the branch in integration and added a syntax fix for the CIDR addresses (Fastly expects quotes as in '"a.b.c.d"/e' instead of '"a.b.c.d/e"').

The changes were successfully applied in integration: 
https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1787/console