### PR TITLE
Add Replica S3 Bucket for mysql-xtrabackups

### DIFF
--- a/terraform/policies/s3_govuk_mysql_xtrabackups_replication_policy.tpl
+++ b/terraform/policies/s3_govuk_mysql_xtrabackups_replication_policy.tpl
@@ -1,0 +1,34 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${govuk_mysql_xtrabackups_arn}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl",
+        "s3:GetObjectVersionTagging"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${govuk_mysql_xtrabackups_arn}/*"
+      ]
+    },
+    {
+      "Action": [
+        "s3:ReplicateObject",
+        "s3:ReplicateDelete"
+      ],
+      "Effect": "Allow",
+      "Resource": "${govuk_mysql_xtrabackups_replica_arn}/*"
+    }
+  ]
+}

--- a/terraform/policies/s3_govuk_mysql_xtrabackups_replication_role.tpl
+++ b/terraform/policies/s3_govuk_mysql_xtrabackups_replication_role.tpl
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+    "Action": "sts:AssumeRole",
+    "Principal": {
+      "Service": "s3.amazonaws.com"
+    },
+    "Effect": "Allow",
+    "Sid": ""
+    }
+  ]
+}

--- a/terraform/projects/app-mysql-xtrabackups/README.md
+++ b/terraform/projects/app-mysql-xtrabackups/README.md
@@ -12,6 +12,7 @@ https://github.com/alphagov/govuk-terraform-provisioning/tree/master/old-project
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| aws_replica_region | AWS region | string | `eu-west-2` | no |
 | bucket_name |  | string | `govuk-mysql-xtrabackups` | no |
 | create_env_sync_resources | Create users and policies used to sync data between environments. | string | `false` | no |
 | days_to_keep |  | string | `91` | no |


### PR DESCRIPTION
This bucket appears to contain essential database backups and
therefore should be replicated.