### PR TITLE
Add a variable to set the version of the lambda to use

### DIFF
--- a/terraform/projects/infra-mirror-bucket/README.md
+++ b/terraform/projects/infra-mirror-bucket/README.md
@@ -19,6 +19,7 @@ The primary bucket should be in London and the backup in Ireland.
 | cloudfront_assets_distribution_aliases | Extra CNAMEs (alternate domain names), if any, for the Assets CloudFront distribution. | list | `<list>` | no |
 | cloudfront_create | Create Cloudfront resources. | string | `false` | no |
 | cloudfront_enable | Enable Cloudfront distributions. | string | `false` | no |
+| cloudfront_lambda_version | The version of the lambda to use with the cloudfront instance | string | `` | no |
 | cloudfront_www_certificate_domain | The domain of the WWW CloudFront certificate to look up. | string | `` | no |
 | cloudfront_www_distribution_aliases | Extra CNAMEs (alternate domain names), if any, for the WWW CloudFront distribution. | list | `<list>` | no |
 | office_ips | An array of CIDR blocks that will be allowed offsite access. | list | - | yes |

--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -86,6 +86,12 @@ variable "cloudfront_assets_certificate_domain" {
   default     = ""
 }
 
+variable "cloudfront_lambda_version" {
+  type        = "string"
+  description = "The version of the lambda to use with the cloudfront instance"
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -350,7 +356,7 @@ resource "aws_cloudfront_distribution" "www_distribution" {
 
     lambda_function_association {
       event_type   = "viewer-request"
-      lambda_arn   = "${aws_lambda_function.url_rewrite.arn}:1"
+      lambda_arn   = "${aws_lambda_function.url_rewrite.arn}:${var.cloudfront_lambda_version}"
       include_body = false
     }
 


### PR DESCRIPTION
Terraform doesn't behave when trying to use $LATEST, there has to
be a better way to deal with this but in the meantime we have to
increment the version each time we publish a new lambda.