### PR TITLE
Remove DocumentDB CNAME

### DIFF
--- a/terraform/projects/app-documentdb/README.md
+++ b/terraform/projects/app-documentdb/README.md
@@ -11,8 +11,6 @@ Shared DocumentDB initially for Licensify
 | aws_region | AWS region | string | `eu-west-1` | no |
 | instance_count | Instance count used for DocumentDB resources | string | `3` | no |
 | instance_type | Instance type used for DocumentDB resources | string | `db.r5.large` | no |
-| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
-| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | master_password | Password of master user on DocumentDB cluster | string | - | yes |
 | master_username | Username of master user on DocumentDB cluster | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-documentdb/main.tf
+++ b/terraform/projects/app-documentdb/main.tf
@@ -41,16 +41,6 @@ variable "master_password" {
   description = "Password of master user on DocumentDB cluster"
 }
 
-variable "internal_zone_name" {
-  type        = "string"
-  description = "The name of the Route53 zone that contains internal records"
-}
-
-variable "internal_domain_name" {
-  type        = "string"
-  description = "The domain name of the internal DNS records, it could be different from the zone name"
-}
-
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -90,17 +80,4 @@ resource "aws_docdb_cluster" "cluster" {
     Name     = "documentdb-licensify"
     Source   = "app-documentdb"
   }
-}
-
-data "aws_route53_zone" "internal" {
-  name         = "${var.internal_zone_name}"
-  private_zone = true
-}
-
-resource "aws_route53_record" "service_record" {
-  zone_id = "${data.aws_route53_zone.internal.zone_id}"
-  name    = "documentdb.${var.internal_domain_name}"
-  type    = "CNAME"
-  ttl     = 300
-  records = ["${aws_docdb_cluster.cluster.endpoint}"]
 }


### PR DESCRIPTION
This was used in app-mongo, but does not appear to be needed here. We are going to
connect using the AWS generated domain name. If we add the CNAME back later we will
need to generate a certificate for it.