### PR TITLE
Give Cache and Router-Backend Machines Access To DocumentDB Cluster

### DIFF
--- a/terraform/projects/infra-security-groups/documentdb.tf
+++ b/terraform/projects/infra-security-groups/documentdb.tf
@@ -31,5 +31,28 @@ resource "aws_security_group_rule" "documentdb_ingress_db-admin_mongodb" {
   source_security_group_id = "${aws_security_group.db-admin.id}"
 }
 
-# TODO: Add an entry for the security group containing the Licensify instances.
+resource "aws_security_group_rule" "documentdb_ingress_cache_mongodb" {
+  type      = "ingress"
+  from_port = 27017
+  to_port   = 27017
+  protocol  = "tcp"
 
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.documentdb.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.cache.id}"
+}
+
+resource "aws_security_group_rule" "documentdb_ingress_router-backend_mongodb" {
+  type      = "ingress"
+  from_port = 27017
+  to_port   = 27017
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.documentdb.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.router-backend.id}"
+}


### PR DESCRIPTION
This is needed for migrating the router app from Mongo to
DocumentDB. Both these machines need to communicate with
the DocumentDB cluster.