### PR TITLE
Allow Draft-Cache Machine to Access DocumentDB Cluster

### DIFF
--- a/terraform/projects/infra-security-groups/documentdb.tf
+++ b/terraform/projects/infra-security-groups/documentdb.tf
@@ -44,6 +44,19 @@ resource "aws_security_group_rule" "documentdb_ingress_cache_mongodb" {
   source_security_group_id = "${aws_security_group.cache.id}"
 }
 
+resource "aws_security_group_rule" "documentdb_ingress_draft-cache_mongodb" {
+  type      = "ingress"
+  from_port = 27017
+  to_port   = 27017
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.documentdb.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.draft-cache.id}"
+}
+
 resource "aws_security_group_rule" "documentdb_ingress_router-backend_mongodb" {
   type      = "ingress"
   from_port = 27017


### PR DESCRIPTION
This is needed so the router and router-api apps can
communicate with the new DocumentDB cluster.