### PR TITLE
Set load balancer healthcheck paths for Licensify.

### DIFF
--- a/terraform/projects/app-licensify-backend/main.tf
+++ b/terraform/projects/app-licensify-backend/main.tf
@@ -78,6 +78,7 @@ module "internal_lb" {
   access_logs_bucket_name          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
   access_logs_bucket_prefix        = "elb/licensify-backend-internal-elb"
   listener_certificate_domain_name = "${var.elb_internal_certname}"
+  target_group_health_check_path   = "/healthcheck"
 
   listener_action = {
     "HTTPS:443" = "HTTP:80"
@@ -94,8 +95,8 @@ module "internal_lb" {
   }
 }
 
-# For each service name (licensify-admin, licensify-feed), create DNS A records
-# pointing at the internal LB.
+# For each service name (there is only licensify-admin for now), create DNS A
+# records pointing at the internal LB.
 resource "aws_route53_record" "internal_service_names" {
   count   = "${length(var.app_service_records)}"
   zone_id = "${data.aws_route53_zone.internal.zone_id}"

--- a/terraform/projects/app-licensify-frontend/main.tf
+++ b/terraform/projects/app-licensify-frontend/main.tf
@@ -103,6 +103,7 @@ module "internal_lb" {
   access_logs_bucket_name          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
   access_logs_bucket_prefix        = "elb/licensify-frontend-internal-lb"
   listener_certificate_domain_name = "${var.elb_internal_certname}"
+  target_group_health_check_path   = "/api/licences"
 
   listener_action = {
     "HTTPS:443" = "HTTP:80"

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1618,6 +1618,7 @@ module "licensify_frontend_public_lb" {
   access_logs_bucket_prefix                  = "elb/${var.stackname}-licensify-frontend-public-elb"
   listener_certificate_domain_name           = "${var.elb_public_certname}"
   listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
+  target_group_health_check_path             = "/api/licences"
 
   listener_action = {
     "HTTPS:443" = "HTTP:80"
@@ -1775,6 +1776,7 @@ module "licensify_backend_public_lb" {
   access_logs_bucket_prefix                  = "elb/licensify-backend-public-elb"
   listener_certificate_domain_name           = "${var.elb_public_certname}"
   listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
+  target_group_health_check_path             = "/healthcheck"
 
   listener_action = {
     "HTTPS:443" = "HTTP:80"


### PR DESCRIPTION
These are the same paths as currently used by the Icinga healthchecks.

`licensify-frontend` serves both the frontend UI and the `uploadlicense`
service. There is therefore one target group and one healthcheck for
`licensify-frontend`. In other words, we are treating the app instance
as the failure domain for the purpose of LB healthchecking.

`licensify-feed` is not load-balanced (because it's a single-master,
manual-failover architecture).