### PR TITLE
Don't try to run two master instances of licensify-feed.

### DIFF
--- a/terraform/projects/app-licensify-backend/README.md
+++ b/terraform/projects/app-licensify-backend/README.md
@@ -8,7 +8,7 @@ Licensify Backend nodes
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | app_service_records | List of application service names that get traffic via the internal LB | list | `<list>` | no |
-| asg_size | The autoscaling group's desired/max/min capacity | string | `2` | no |
+| asg_size | The autoscaling group's desired/max/min capacity. licensify-feed can only have one master instance and mastership is manually configured. | string | `1` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | elb_internal_certname | The domain name of the ACM cert to use for the internal LB | string | - | yes |

--- a/terraform/projects/app-licensify-backend/main.tf
+++ b/terraform/projects/app-licensify-backend/main.tf
@@ -38,8 +38,8 @@ variable "app_service_records" {
 
 variable "asg_size" {
   type        = "string"
-  description = "The autoscaling group's desired/max/min capacity"
-  default     = "2"
+  description = "The autoscaling group's desired/max/min capacity. licensify-feed can only have one master instance and mastership is manually configured."
+  default     = "1"
 }
 
 variable "instance_type" {


### PR DESCRIPTION
licensify-feed requires a single master instance. Failover to a
non-master instance requires a manual config change. In AWS, since we
have automated deployments, it is quicker to let the failed instance
be recycled by the autoscaler than to make the manual config change to
swap the master over.

For now, we therefore plan to put up with running a single instance of the
backend VM (which runs licensify-feed and licensify-admin). If need be,
we could do further work to separate out licensify-admin so that it can
have two instances.