### PR TITLE
Downsize the bouncer machines to a t3.large by default

### DIFF
--- a/terraform/projects/app-bouncer/README.md
+++ b/terraform/projects/app-bouncer/README.md
@@ -13,7 +13,7 @@ Bouncer node
 | elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
-| instance_type | Instance type used for EC2 resources | string | `t3.xlarge` | no |
+| instance_type | Instance type used for EC2 resources | string | `t3.large` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -44,7 +44,7 @@ variable "asg_size" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for EC2 resources"
-  default     = "t3.xlarge"
+  default     = "t3.large"
 }
 
 # Resources


### PR DESCRIPTION
In Production, only ~1.3GB of memory is being used on these machines,
and the CPU's don't look particularly pressured either, so I think a
smaller instance type is better suited. A t3.medium would probably
work, but I've chosen to just step it down gradually at the moment.