### PR TITLE
Add vars for configuring TLS and snapshot retention on Licensify DocDB.

### DIFF
--- a/terraform/projects/app-licensify-documentdb/README.md
+++ b/terraform/projects/app-licensify-documentdb/README.md
@@ -9,6 +9,7 @@ DocumentDB cluster for Licensify
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| backup_retention_period | Retention period in days for DocumentDB automatic snapshots | string | `1` | no |
 | instance_count | Instance count used for Licensify DocumentDB resources | string | `3` | no |
 | instance_type | Instance type used for Licensify DocumentDB resources | string | `db.r5.large` | no |
 | master_password | Password of master user on Licensify DocumentDB cluster | string | - | yes |
@@ -18,6 +19,7 @@ DocumentDB cluster for Licensify
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_security_key_stack | Override infra_security stackname path to infra_vpc remote state | string | `` | no |
 | stackname | Stackname | string | - | yes |
+| tls | Whether to enable or disable TLS for the Licensify DocumentDB cluster. Must be either 'enabled' or 'disabled'. | string | `enabled` | no |
 
 ## Outputs
 

--- a/terraform/projects/app-licensify-documentdb/main.tf
+++ b/terraform/projects/app-licensify-documentdb/main.tf
@@ -24,6 +24,18 @@ variable "master_username" {
   description = "Username of master user on Licensify DocumentDB cluster"
 }
 
+variable "tls" {
+  type        = "string"
+  description = "Whether to enable or disable TLS for the Licensify DocumentDB cluster. Must be either 'enabled' or 'disabled'."
+  default     = "enabled"
+}
+
+variable "backup_retention_period" {
+  type        = "string"
+  description = "Retention period in days for DocumentDB automatic snapshots"
+  default     = "1"
+}
+
 variable "instance_count" {
   type        = "string"
   description = "Instance count used for Licensify DocumentDB resources"
@@ -65,7 +77,7 @@ resource "aws_docdb_cluster_parameter_group" "licensify_parameter_group" {
 
   parameter {
     name  = "tls"
-    value = "enabled"
+    value = "${var.tls}"
   }
 }
 
@@ -77,6 +89,7 @@ resource "aws_docdb_cluster" "licensify_cluster" {
   master_username                 = "${var.master_username}"
   master_password                 = "${var.master_password}"
   storage_encrypted               = true
+  backup_retention_period         = "${var.backup_retention_period}"
   kms_key_id                      = "${data.terraform_remote_state.infra_security.licensify_documentdb_kms_key_arn}"
   vpc_security_group_ids          = ["${data.terraform_remote_state.infra_security_groups.sg_licensify_documentdb_id}"]
 


### PR DESCRIPTION
Companion PR which sets these variables: https://github.com/alphagov/govuk-aws-data/pull/553

No diffs from Terraform plan in Integration: https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2014/console