### PR TITLE
Increase root volume size on Licensify VMs from 20 to 50 GB.

### DIFF
--- a/terraform/projects/app-licensify-backend/main.tf
+++ b/terraform/projects/app-licensify-backend/main.tf
@@ -133,6 +133,7 @@ module "licensify-backend" {
   asg_min_size                      = "${var.asg_size}"
   asg_desired_capacity              = "${var.asg_size}"
   asg_notification_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size     = "50"
 }
 
 # Outputs

--- a/terraform/projects/app-licensify-frontend/main.tf
+++ b/terraform/projects/app-licensify-frontend/main.tf
@@ -165,6 +165,7 @@ module "licensify-frontend" {
   asg_min_size                      = "${var.asg_size}"
   asg_desired_capacity              = "${var.asg_size}"
   asg_notification_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size     = "50"
 }
 
 # Outputs


### PR DESCRIPTION
This is to match what we currently have in Carrenza / UKCloud.