### PR TITLE
Give the lb module target groups better names

### DIFF
--- a/terraform/modules/aws/lb/main.tf
+++ b/terraform/modules/aws/lb/main.tf
@@ -249,6 +249,7 @@ locals {
 
 resource "aws_lb_target_group" "tg_default" {
   count                = "${length(local.target_groups)}"
+  name                 = "${replace(format("%.21s-%.10s", var.name, replace(local.target_groups[count.index], ":", "-")), "/-$/", "")}"
   port                 = "${element(split(":", element(local.target_groups, count.index)), 1)}"
   protocol             = "${element(split(":", element(local.target_groups, count.index)), 0)}"
   vpc_id               = "${var.vpc_id}"


### PR DESCRIPTION
This change means that more target groups have proper names, rather
than the Terraform defaults. I've been looking at bouncer, so this
change means that instead of something like
tf-20181031151047476700000001, you get blue-bouncer-internal-HTTP-80.