### PR TITLE
Federate rabbitmq from Carrenza

### DIFF
--- a/terraform/projects/app-rabbitmq/README.md
+++ b/terraform/projects/app-rabbitmq/README.md
@@ -13,6 +13,12 @@ Rabbitmq cluster
 | instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
+| rabbitmq_1_ip | IP address of the private IP to assign to the instance | string | - | yes |
+| rabbitmq_1_reserved_ips_subnet | Name of the subnet to place the reserved IP of the instance | string | - | yes |
+| rabbitmq_2_ip | IP address of the private IP to assign to the instance | string | - | yes |
+| rabbitmq_2_reserved_ips_subnet | Name of the subnet to place the reserved IP of the instance | string | - | yes |
+| rabbitmq_3_ip | IP address of the private IP to assign to the instance | string | - | yes |
+| rabbitmq_3_reserved_ips_subnet | Name of the subnet to place the reserved IP of the instance | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-rabbitmq/additional_policy.json
+++ b/terraform/projects/app-rabbitmq/additional_policy.json
@@ -5,7 +5,9 @@
             "Sid": "Stmt1499854881000",
             "Effect": "Allow",
             "Action": [
-                "autoscaling:DescribeAutoScalingInstances"
+                "autoscaling:DescribeAutoScalingInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:AttachNetworkInterface"
             ],
             "Resource": [
                 "*"

--- a/terraform/projects/app-rabbitmq/main.tf
+++ b/terraform/projects/app-rabbitmq/main.tf
@@ -41,6 +41,36 @@ variable "instance_type" {
   default     = "t2.medium"
 }
 
+variable "rabbitmq_1_reserved_ips_subnet" {
+  type        = "string"
+  description = "Name of the subnet to place the reserved IP of the instance"
+}
+
+variable "rabbitmq_2_reserved_ips_subnet" {
+  type        = "string"
+  description = "Name of the subnet to place the reserved IP of the instance"
+}
+
+variable "rabbitmq_3_reserved_ips_subnet" {
+  type        = "string"
+  description = "Name of the subnet to place the reserved IP of the instance"
+}
+
+variable "rabbitmq_1_ip" {
+  type        = "string"
+  description = "IP address of the private IP to assign to the instance"
+}
+
+variable "rabbitmq_2_ip" {
+  type        = "string"
+  description = "IP address of the private IP to assign to the instance"
+}
+
+variable "rabbitmq_3_ip" {
+  type        = "string"
+  description = "IP address of the private IP to assign to the instance"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -146,6 +176,54 @@ module "alarms-elb-rabbitmq-internal" {
   httpcode_elb_5xx_threshold     = "0"
   surgequeuelength_threshold     = "200"
   healthyhostcount_threshold     = "1"
+}
+
+# Interface 1
+resource "aws_network_interface" "rabbitmq-1_eni" {
+  subnet_id       = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_reserved_ips_names_ids_map, var.rabbitmq_1_reserved_ips_subnet)}"
+  private_ips     = ["${var.rabbitmq_1_ip}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_rabbitmq_id}"]
+
+  tags {
+    Name            = "${var.stackname}-rabbitmq"
+    Project         = "${var.stackname}"
+    aws_hostname    = "rabbitmq"
+    aws_migration   = "rabbitmq"
+    aws_stackname   = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
+# Interface 2
+resource "aws_network_interface" "rabbitmq-2_eni" {
+  subnet_id       = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_reserved_ips_names_ids_map, var.rabbitmq_2_reserved_ips_subnet)}"
+  private_ips     = ["${var.rabbitmq_2_ip}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_rabbitmq_id}"]
+
+  tags {
+    Name            = "${var.stackname}-rabbitmq"
+    Project         = "${var.stackname}"
+    aws_hostname    = "rabbitmq"
+    aws_migration   = "rabbitmq"
+    aws_stackname   = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
+# Interface 3
+resource "aws_network_interface" "rabbitmq-3_eni" {
+  subnet_id       = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_reserved_ips_names_ids_map, var.rabbitmq_3_reserved_ips_subnet)}"
+  private_ips     = ["${var.rabbitmq_3_ip}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_rabbitmq_id}"]
+
+  tags {
+    Name            = "${var.stackname}-rabbitmq"
+    Project         = "${var.stackname}"
+    aws_hostname    = "rabbitmq"
+    aws_migration   = "rabbitmq"
+    aws_stackname   = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+  }
 }
 
 # Outputs

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -12,6 +12,7 @@ Manage the security groups for the entire infrastructure
 | carrenza_env_ips | An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox. | list | `<list>` | no |
 | carrenza_integration_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_production_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
+| carrenza_rabbitmq_ips | An array of CIDR blocks that will be allowed to federate with the rabbitmq nodes. | list | - | yes |
 | carrenza_staging_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | list | - | yes |
 | carrenza_vpn_subnet_cidr | The Carrenza VPN subnet CIDR | list | `<list>` | no |
 | concourse_aws_account_id | AWS account ID which contains the Concourse role | string | - | yes |

--- a/terraform/projects/infra-security-groups/rabbitmq.tf
+++ b/terraform/projects/infra-security-groups/rabbitmq.tf
@@ -34,6 +34,17 @@ resource "aws_security_group_rule" "rabbitmq_ingress_rabbitmq-elb_amqp" {
   source_security_group_id = "${aws_security_group.rabbitmq_elb.id}"
 }
 
+resource "aws_security_group_rule" "rabbitmq_ingress_carrenza-rabbitmq_amqp" {
+  type      = "ingress"
+  from_port = 5672
+  to_port   = 5672
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.rabbitmq.id}"
+  cidr_blocks       = ["${var.carrenza_rabbitmq_ips}"]
+}
+
 resource "aws_security_group_rule" "rabbitmq_ingress_rabbitmq-elb_rabbitmq-stomp" {
   type      = "ingress"
   from_port = 6163

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -66,6 +66,11 @@ variable "carrenza_draft_frontend_ips" {
   default     = []
 }
 
+variable "carrenza_rabbitmq_ips" {
+  type        = "list"
+  description = "An array of CIDR blocks that will be allowed to federate with the rabbitmq nodes."
+}
+
 variable "traffic_replay_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will replay traffic against an environment"

--- a/terraform/userdata/10-associate-eni
+++ b/terraform/userdata/10-associate-eni
@@ -21,11 +21,15 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: find network interface ID ..
 if [[ -z $F_MIGRATION ]] || [[ -z $F_STACKNAME ]] || [[ -z $F_HOSTNAME ]] ; then
   echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: ERROR facts not found, skipping associate-eni"
 else
-  NETWORK_INTERFACE_ID=$(aws ec2 describe-network-interfaces --region=$REGION --filters "Name=tag:aws_migration,Values=$F_MIGRATION" "Name=tag:aws_hostname,Values=$F_HOSTNAME" "Name=tag:aws_stackname,Values=$F_STACKNAME" --output=json | jq -r '.NetworkInterfaces[] | .NetworkInterfaceId ')
+  NETWORK_INTERFACE_ID=$(aws ec2 describe-network-interfaces --region=$REGION --filters "Name=tag:aws_migration,Values=$F_MIGRATION" "Name=tag:aws_hostname,Values=$F_HOSTNAME" "Name=tag:aws_stackname,Values=$F_STACKNAME" "Name=status,Values=available" --output=json | jq -r '.NetworkInterfaces[] | .NetworkInterfaceId ')
 
   if [[ -z $NETWORK_INTERFACE_ID ]] ; then
     echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: ERROR ENI not found"
   else
+# If more than one interface ID is returned, select the first one    
+    if [[ $( echo $NETWORK_INTERFACE_ID | wc -w) -gt 1 ]] ; then
+      NETWORK_INTERFACE_ID=$(echo $NETWORK_INTERFACE_ID | awk '{print $1}')
+    fi
     echo "[$(date '+%H:%M:%S %d-%m-%Y')] associate-eni: attaching eni to instance ..."
     aws ec2 attach-network-interface --region=$REGION --instance-id=$INSTANCE_ID --network-interface-id=$NETWORK_INTERFACE_ID --device-index ${IFACE_INDEX}
 


### PR DESCRIPTION
For the AWS migration we create a federation from Carrenza.
This make the federation going both ways, services should then be
able to use rabbitmq from carremza or AWS.