### PR TITLE
fix licensify s3 permissions

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -88,6 +88,7 @@ resource "aws_s3_bucket" "database_backups" {
   }
 
   lifecycle_rule {
+    id      = "mysql_lifecycle_rule"
     prefix  = "mysql/"
     enabled = true
 
@@ -107,6 +108,7 @@ resource "aws_s3_bucket" "database_backups" {
   }
 
   lifecycle_rule {
+    id      = "postgres_lifecycle_rule"
     prefix  = "postgres/"
     enabled = true
 
@@ -126,6 +128,7 @@ resource "aws_s3_bucket" "database_backups" {
   }
 
   lifecycle_rule {
+    id      = "mongo_daily_lifecycle_rule"
     prefix  = "mongodb/daily"
     enabled = true
 
@@ -145,6 +148,7 @@ resource "aws_s3_bucket" "database_backups" {
   }
 
   lifecycle_rule {
+    id      = "mongo_regular_lifecycle_rule"
     prefix  = "mongodb/regular"
     enabled = true
 
@@ -154,6 +158,7 @@ resource "aws_s3_bucket" "database_backups" {
   }
 
   lifecycle_rule {
+    id      = "whisper_lifecycle_rule"
     prefix  = "whisper/"
     enabled = true
 
@@ -170,6 +175,7 @@ resource "aws_s3_bucket" "database_backups" {
     role = "${aws_iam_role.backup_replication_role.arn}"
 
     rules {
+      id     = "main_replication_rule"
       prefix = ""
       status = "Enabled"
 

--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -362,9 +362,11 @@ data "aws_iam_policy_document" "integration_dbadmin_database_backups_reader" {
     # Need access to the top level of the tree.
     resources = [
       "arn:aws:s3:::govuk-integration-database-backups",
+      "arn:aws:s3:::govuk-integration-database-backups/*mongo-licensing*",
       "arn:aws:s3:::govuk-integration-database-backups/*mysql*",
       "arn:aws:s3:::govuk-integration-database-backups/*postgres*",
       "arn:aws:s3:::govuk-staging-database-backups",
+      "arn:aws:s3:::govuk-staging-database-backups/*mongo-licensing*",
       "arn:aws:s3:::govuk-staging-database-backups/*mysql*",
       "arn:aws:s3:::govuk-staging-database-backups/*postgres*",
     ]
@@ -580,6 +582,7 @@ data "aws_iam_policy_document" "staging_dbadmin_database_backups_reader" {
       "arn:aws:s3:::govuk-staging-database-backups",
       "arn:aws:s3:::govuk-staging-database-backups/*mysql*",
       "arn:aws:s3:::govuk-staging-database-backups/*postgres*",
+      "arn:aws:s3:::govuk-staging-database-backups/*mongo-licensing*",
     ]
   }
 }
@@ -789,6 +792,7 @@ data "aws_iam_policy_document" "production_dbadmin_database_backups_reader" {
       "arn:aws:s3:::govuk-production-database-backups",
       "arn:aws:s3:::govuk-production-database-backups/*mysql*",
       "arn:aws:s3:::govuk-production-database-backups/*postgres*",
+      "arn:aws:s3:::govuk-production-database-backups/*mongo-licensing*",
     ]
   }
 }

--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -288,6 +288,7 @@ data "aws_iam_policy_document" "dbadmin_database_backups_writer" {
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*whitehall*",
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*email-alert-api*",
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*publishing-api*",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mongo-licensing*",
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mysql*",
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*postgres*",
     ]


### PR DESCRIPTION
The permissions should be as followed for db_admin in:
1. integration: read integration, staging and production & write integration
2. staging: read staging and production & write staging
2. production: read none & write production