### PR TITLE
Add vpn route propagation to govuk_reserved_ips_private subnets

### DIFF
--- a/terraform/projects/infra-carrenza-vpn/main.tf
+++ b/terraform/projects/infra-carrenza-vpn/main.tf
@@ -128,6 +128,12 @@ resource "aws_vpn_gateway_route_propagation" "Carrenza_route_propagation" {
   route_table_id = "${element(values(data.terraform_remote_state.infra_networking.private_subnet_names_route_tables_map), count.index)}"
 }
 
+resource "aws_vpn_gateway_route_propagation" "Carrenza_route_propagation_reserved_ips" {
+  count          = "${length(data.terraform_remote_state.infra_networking.private_subnet_reserved_ips_names_route_tables_map)}"
+  vpn_gateway_id = "${aws_vpn_gateway.aws_vpn_gateway.id}"
+  route_table_id = "${element(values(data.terraform_remote_state.infra_networking.private_subnet_reserved_ips_names_route_tables_map), count.index)}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 


### PR DESCRIPTION
We now use the govuk_reserved_ips_private subnet to host the
additional interfaces we need to create a rabbitmq federation from
 carrenza to AWS for the migration of publishing API to AWS.