### PR TITLE
Use aws_iam_role_policy_attachment for related link roles

### DIFF
--- a/terraform/projects/app-related-links/README.md
+++ b/terraform/projects/app-related-links/README.md
@@ -22,3 +22,10 @@ Run resource intensive scripts for data science purposes.
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
 | stackname | Stackname | string | - | yes |
 
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| policy_read_content_store_backups_bucket_policy_arn | ARN of the policy used to read content store backups from the database backups bucket |
+| policy_read_write_related_links_bucket_policy_arn | ARN of the policy used to read/write data from/to the related links bucket |
+

--- a/terraform/projects/app-related-links/main.tf
+++ b/terraform/projects/app-related-links/main.tf
@@ -112,9 +112,8 @@ resource "aws_iam_policy" "scale_asg_policy" {
   policy = "${data.aws_iam_policy_document.scale_asg_policy_document.json}"
 }
 
-resource "aws_iam_policy_attachment" "scale_asg_concourse_role_attachment" {
-  name       = "scale_asg_concourse_role_attachment"
-  roles      = ["${aws_iam_role.concourse_role.name}"]
+resource "aws_iam_role_policy_attachment" "scale_asg_concourse_role_attachment" {
+  role       = "${aws_iam_role.concourse_role.name}"
   policy_arn = "${aws_iam_policy.scale_asg_policy.arn}"
 }
 
@@ -183,15 +182,13 @@ resource "aws_iam_policy" "read_write_related_links_bucket_policy" {
   policy = "${data.aws_iam_policy_document.read_write_related_links_bucket_policy_document.json}"
 }
 
-resource "aws_iam_policy_attachment" "attach_read_content_store_backups_bucket_policy" {
-  name       = "attach_read_content_store_backups_bucket_policy"
-  roles      = ["${aws_iam_role.ec2_role.name}"]
+resource "aws_iam_role_policy_attachment" "attach_read_content_store_backups_bucket_policy" {
+  role       = "${aws_iam_role.ec2_role.name}"
   policy_arn = "${aws_iam_policy.read_content_store_backups_bucket_policy.arn}"
 }
 
-resource "aws_iam_policy_attachment" "attach_read_write_related_links_bucket_policy" {
-  name       = "attach_read_write_related_links_bucket_policy"
-  roles      = ["${aws_iam_role.ec2_role.name}"]
+resource "aws_iam_role_policy_attachment" "attach_read_write_related_links_bucket_policy" {
+  role       = "${aws_iam_role.ec2_role.name}"
   policy_arn = "${aws_iam_policy.read_write_related_links_bucket_policy.arn}"
 }
 
@@ -309,3 +306,12 @@ resource "aws_autoscaling_group" "related-links-ingestion" {
 # Outputs
 # --------------------------------------------------------------
 
+output "policy_read_content_store_backups_bucket_policy_arn" {
+  value       = "${aws_iam_policy.read_content_store_backups_bucket_policy.arn}"
+  description = "ARN of the policy used to read content store backups from the database backups bucket"
+}
+
+output "policy_read_write_related_links_bucket_policy_arn" {
+  value       = "${aws_iam_policy.read_write_related_links_bucket_policy.arn}"
+  description = "ARN of the policy used to read/write data from/to the related links bucket"
+}


### PR DESCRIPTION
This commit places `aws_iam_policy_attachment`s with `aws_iam_role_policy_attachment`s, as the former only allows a policy to be associated with one role exclusively across projects.

From the Terraform docs:

_The aws_iam_policy_attachment resource creates exclusive attachments of IAM policies. Across the entire AWS account, all of the users/roles/groups to which a single policy is attached must be declared by a single aws_iam_policy_attachment resource._

See https://www.terraform.io/docs/providers/aws/r/iam_policy_attachment.html for more info.

Secondly, this commit adds the ARNs of policies `read_content_store_backups_bucket_policy` and `read_write_related_links_bucket_policy` as outputs, so that they can be reused by the upcoming knowledge-graph project.