### PR TITLE
Create load balancer target groups before destroying

### DIFF
--- a/terraform/modules/aws/lb/main.tf
+++ b/terraform/modules/aws/lb/main.tf
@@ -266,6 +266,10 @@ resource "aws_lb_target_group" "tg_default" {
     timeout             = "${var.target_group_health_check_timeout}"
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags = "${merge(
     var.default_tags,
     map(


### PR DESCRIPTION
This means that Terraform will create replacement target groups prior
to deleting the old ones. This avoids trying to delete target groups
when they're still used by the listener.