### PR TITLE
Add HTTP->HTTPS redirect at the LB for licensify-admin.

### DIFF
--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1809,6 +1809,7 @@ resource "aws_lb_listener" "licensify_backend_http_80" {
       status_code = "HTTP_301"
     }
   }
+}
 
 resource "aws_wafregional_web_acl_association" "licensify_backend_public_lb" {
   resource_arn = "${module.licensify_backend_public_lb.lb_id}"

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1793,6 +1793,24 @@ module "licensify_backend_public_lb" {
   }
 }
 
+# Listener for licensify-admin HTTP-to-HTTPS redirect. Does not forward any
+# traffic, only serves redirects directly from the ALB.
+resource "aws_lb_listener" "licensify_backend_http_80" {
+  load_balancer_arn = "${module.licensify_backend_public_lb.lb_id}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
 resource "aws_route53_record" "licensify_backend_public_service_names" {
   count   = "${length(var.licensify_backend_public_service_names)}"
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"

--- a/terraform/projects/infra-security-groups/licensify-backend.tf
+++ b/terraform/projects/infra-security-groups/licensify-backend.tf
@@ -89,7 +89,18 @@ resource "aws_security_group_rule" "licensify-backend-external-elb_ingress_publi
   from_port         = 443
   protocol          = "tcp"
   security_group_id = "${aws_security_group.licensify-backend_external_elb.id}"
-  cidr_blocks       = ["0.0.0.0/0", "${var.office_ips}"]
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+# Allow the public LB to serve HTTP->HTTPS redirects. See
+# licensify_backend_http_80 in ../infra-public-services/main.tf.
+resource "aws_security_group_rule" "licensify-backend-external-elb_ingress_public_http" {
+  type              = "ingress"
+  to_port           = 80
+  from_port         = 80
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.licensify-backend_external_elb.id}"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "licensify-backend-external-elb_egress_any_any" {


### PR DESCRIPTION
This already exists in UKCloud (on the licensify_lb nginx) and we need
to preserve the behaviour when migrating to AWS. The HTTPS redirect is
essential in rare cases, because HSTS preload cannot be relied upon
universally.

We add an ALB listener on port 80 with a default rule which serves
redirects to the same URL but with the https protocol. This way we don't
have to allow any HTTP traffic to be forwarded to the backend and we
keep the backend nginx config simple.

While we're there, also remove some superfluous entries from the ingress
ACL for the public LB. (It already allows port 443 from any source, so
it's not helpful to also list the office IP addresses in that rule. This was
copied from whitehall-admin I believe.)