### PR TITLE
modifying security groups and load balancers for licensify-frontend

### DIFF
--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1635,6 +1635,27 @@ module "licensify_frontend_public_lb" {
   }
 }
 
+resource "aws_lb_listener" "licensify_frontend_public_http_80" {
+  load_balancer_arn = "${module.licensify_frontend_public_lb.lb_id}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_wafregional_web_acl_association" "licensify_frontend_public_lb" {
+  resource_arn = "${module.licensify_frontend_public_lb.lb_id}"
+  web_acl_id   = "${aws_wafregional_web_acl.default.id}"
+}
+
 resource "aws_route53_record" "licensify_frontend_public_service_names" {
   count   = "${length(var.licensify_frontend_public_service_names)}"
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -7,6 +7,7 @@ Manage the security groups for the entire infrastructure
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | carrenza_draft_frontend_ips | An array of CIDR blocks for the current environment that will allow access to draft-content-store from Carrenza. | list | `<list>` | no |
 | carrenza_env_ips | An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox. | list | `<list>` | no |

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -4,6 +4,14 @@
 * Manage the security groups for the entire infrastructure
 */
 
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+# Resources
+# --------------------------------------------------------------
+
 terraform {
   backend          "s3"             {}
   required_version = "= 0.11.14"


### PR DESCRIPTION
# Context

As part of the AWS migration of licensify, review the security groups linked with licensify frontend.

# Decisions

1. allow licensify frontend internal load balancer to access the
   licensify frontend hosts
2. for production environment, allow any IP to access the
   licensify frontend external load balancer. For integration and
   staging, this should be closed to only office IPs so far
3. add a http/80 listener on licensify frontend external load
   balancer to redirect to https/443
4. enable waf on the licensify frontend external load balancer