### PR TITLE
Add additional gatling instance and increase machine size

### DIFF
--- a/terraform/projects/app-gatling/README.md
+++ b/terraform/projects/app-gatling/README.md
@@ -7,9 +7,9 @@ Gatling node
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| asg_desired_capacity | The autoscaling groups desired capacity | string | `1` | no |
-| asg_max_size | The autoscaling groups max_size | string | `1` | no |
-| asg_min_size | The autoscaling groups max_size | string | `1` | no |
+| asg_desired_capacity | The autoscaling groups desired capacity | string | `2` | no |
+| asg_max_size | The autoscaling groups max_size | string | `2` | no |
+| asg_min_size | The autoscaling groups max_size | string | `2` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
@@ -17,7 +17,7 @@ Gatling node
 | external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
-| instance_type | Instance type used for EC2 resources | string | `m5.large` | no |
+| instance_type | Instance type used for EC2 resources | string | `m5.2xlarge` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |

--- a/terraform/projects/app-gatling/main.tf
+++ b/terraform/projects/app-gatling/main.tf
@@ -22,19 +22,19 @@ variable "aws_environment" {
 variable "asg_desired_capacity" {
   type        = "string"
   description = "The autoscaling groups desired capacity"
-  default     = "1"
+  default     = "2"
 }
 
 variable "asg_max_size" {
   type        = "string"
   description = "The autoscaling groups max_size"
-  default     = "1"
+  default     = "2"
 }
 
 variable "asg_min_size" {
   type        = "string"
   description = "The autoscaling groups max_size"
-  default     = "1"
+  default     = "2"
 }
 
 variable "ebs_encrypted" {
@@ -66,7 +66,7 @@ variable "instance_ami_filter_name" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for EC2 resources"
-  default     = "m5.large"
+  default     = "m5.2xlarge"
 }
 
 # Resources


### PR DESCRIPTION
Changes to 2 instances, both `m5.2xlarge`, for increased load testing power

[Trello](https://trello.com/c/PKUKehXX/1241-3-investigate-having-2-clustered-gatling-machines)