### PR TITLE
Use search-api healthcheck, rather than nginx healthcheck

### DIFF
--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -118,7 +118,7 @@ resource "aws_elb" "search_elb" {
     unhealthy_threshold = 2
     timeout             = 3
 
-    target   = "TCP:80"
+    target   = "HTTP:80/_healthcheck_search-api"
     interval = 30
   }
 


### PR DESCRIPTION
This makes two changes, I'm not sure if both are necessary.

1. Change the ELB healthcheck to check for `/_healthcheck_search-api` over HTTP.  This means that requests will not be sent to an instance until the search-api healthcheck is passing.  This is fine, as search-api is the only app on the app-search machines.

2. Uses per-app healthchecks for external DNS - which is what Carrenza things (whitehall, search-admin) use to communicate with search-api.  I don't know if this is necessary with (1) in place.

I think we could use per-app healthchecks for internal DNS as well (rather than doing (1)), but I think that would require more restructuring, to set up a search-api ALB.

Plans:
- [app-search](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2217/console) (staging) - there's some instance changes which have been manually made in the console, I'll check with RE about the best way to deploy this (add those changes to govuk-aws-data, or just apply this change manually)
- [infra-public-services](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2216/console) (staging)

We should test both the AWS and Carrenza connection to search-api before deploying to production.  When these changes are both in staging, try publishing something from whitehall and then searching for it from finder-frontend.

---

[Trello card](https://trello.com/c/AT7HhBqP/987-prevent-search-api-accepting-requests-before-it-is-provisioned)