### PR TITLE
Add an S3 bucket to store Gatling results

### DIFF
--- a/terraform/projects/app-gatling/README.md
+++ b/terraform/projects/app-gatling/README.md
@@ -18,6 +18,7 @@ Gatling node
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | instance_type | Instance type used for EC2 resources | string | `m5.2xlarge` | no |
+| office_ips | An array of CIDR blocks that will be allowed offsite access. | list | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |


### PR DESCRIPTION
This bucket can be used to store Gatling load testing results for a longer period of time, as currently the results get wiped whenever we need to reprovision the machine.

It's configured to allow static website access from office IP addresses meaning we can view the results directly either in the office or by using the VPN rather than having to download them first.

[Trello Card](https://trello.com/c/Juuu8OvE/1251-5-host-the-gatling-reports-graphs-somewhere)