### PR TITLE
Remove prefix from lifecycle_rule

### DIFF
--- a/terraform/projects/infra-monitoring/main.tf
+++ b/terraform/projects/infra-monitoring/main.tf
@@ -68,8 +68,6 @@ resource "aws_s3_bucket" "aws-logging" {
   lifecycle_rule {
     enabled = true
 
-    prefix = "/"
-
     expiration {
       days = 30
     }

--- a/terraform/projects/infra-monitoring/secondary.tf
+++ b/terraform/projects/infra-monitoring/secondary.tf
@@ -43,8 +43,6 @@ resource "aws_s3_bucket" "aws-secondary-logging" {
   lifecycle_rule {
     enabled = true
 
-    prefix = "/"
-
     expiration {
       days = 30
     }


### PR DESCRIPTION
The intention of setting the prefix to "/" was to apply to all objects but S3 object keys don't start with a / so the rule ends up applying to no objects. The prefix field is optional and removing it means the lifecycle rule will apply to the entire bucket.