### PR TITLE
Upsize draft-cache from 4 to 16 GB RAM in Staging and Prod.

### DIFF
--- a/terraform/projects/app-draft-cache/README.md
+++ b/terraform/projects/app-draft-cache/README.md
@@ -17,7 +17,7 @@ Draft Cache servers
 | external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
 | external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
-| instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
+| instance_type | Instance type used for EC2 resources | string | `t3.xlarge` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -50,7 +50,7 @@ variable "asg_size" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for EC2 resources"
-  default     = "t2.medium"
+  default     = "t3.xlarge"
 }
 
 variable "external_zone_name" {


### PR DESCRIPTION
This is intended as a temporary workaround for `router` using
significantly more RAM when built with Go 1.12. It gives draft-cache the
same amount of RAM as (non-draft) cache.

We also switch from t2 to t3 because it's slightly cheaper and should be
otherwise equivalent or better.