### PR TITLE
Add backends for staging and production for app-licensify-backend

### DIFF
--- a/terraform/projects/app-licensify-backend/production.blue.backend
+++ b/terraform/projects/app-licensify-backend/production.blue.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "blue/app-licensify-backend.tfstate"
+encrypt = true
+region  = "eu-west-2"

--- a/terraform/projects/app-licensify-backend/staging.blue.backend
+++ b/terraform/projects/app-licensify-backend/staging.blue.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-staging"
+key     = "blue/app-licensify-backend.tfstate"
+encrypt = true
+region  = "eu-west-2"


### PR DESCRIPTION
As part of the migration of licensify to AWS