### PR TITLE
Fix and clean up load balancer configs for whitehall-admin.

### DIFF
--- a/terraform/projects/app-whitehall-backend/README.md
+++ b/terraform/projects/app-whitehall-backend/README.md
@@ -11,15 +11,9 @@ Whitehall Backend nodes
 | asg_size | The autoscaling groups desired/max/min capacity | string | `2` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
-| create_external_elb | Create the external ELB | string | `true` | no |
-| elb_external_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
-| external_domain_name | The domain name of the external DNS records, it could be different from the zone name | string | - | yes |
-| external_zone_name | The name of the Route53 zone that contains external records | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | instance_type | Instance type used for EC2 resources | string | `m5.large` | no |
-| internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
-| internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | remote_state_infra_networking_key_stack | Override infra_networking remote state path | string | `` | no |
@@ -34,8 +28,5 @@ Whitehall Backend nodes
 
 | Name | Description |
 |------|-------------|
-| external_service_dns_name | DNS name to access the external node service |
-| internal_service_dns_name | DNS name to access the node service |
-| whitehall-backend_external_elb_address | AWS' external DNS name for the whitehall-backend ELB |
-| whitehall-backend_internal_elb_address | AWS' internal DNS name for the whitehall-backend ELB |
+| internal_service_dns_name | Internal DNS name for the whitehall_backend internal LB |
 

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -30,11 +30,6 @@ variable "elb_internal_certname" {
   description = "The ACM cert domain name to find the ARN of"
 }
 
-variable "elb_external_certname" {
-  type        = "string"
-  description = "The ACM cert domain name to find the ARN of"
-}
-
 variable "app_service_records" {
   type        = "list"
   description = "List of application service names that get traffic via this loadbalancer"
@@ -45,31 +40,6 @@ variable "asg_size" {
   type        = "string"
   description = "The autoscaling groups desired/max/min capacity"
   default     = "2"
-}
-
-variable "internal_domain_name" {
-  type        = "string"
-  description = "The domain name of the internal DNS records, it could be different from the zone name"
-}
-
-variable "internal_zone_name" {
-  type        = "string"
-  description = "The name of the Route53 zone that contains internal records"
-}
-
-variable "external_zone_name" {
-  type        = "string"
-  description = "The name of the Route53 zone that contains external records"
-}
-
-variable "external_domain_name" {
-  type        = "string"
-  description = "The domain name of the external DNS records, it could be different from the zone name"
-}
-
-variable "create_external_elb" {
-  description = "Create the external ELB"
-  default     = true
 }
 
 variable "instance_type" {
@@ -91,18 +61,8 @@ provider "aws" {
 }
 
 data "aws_route53_zone" "internal" {
-  name         = "${var.internal_zone_name}"
+  name         = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
   private_zone = true
-}
-
-data "aws_route53_zone" "external" {
-  name         = "${var.external_zone_name}"
-  private_zone = false
-}
-
-data "aws_acm_certificate" "elb_external_cert" {
-  domain   = "${var.elb_external_certname}"
-  statuses = ["ISSUED"]
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {
@@ -110,200 +70,75 @@ data "aws_acm_certificate" "elb_internal_cert" {
   statuses = ["ISSUED"]
 }
 
-resource "aws_elb" "whitehall-backend_internal_elb" {
-  name            = "${var.stackname}-whitehall-backend-internal"
+module "internal_lb" {
+  source                           = "../../modules/aws/lb"
+  name                             = "whitehall-backend-internal"
+  internal                         = true
+  vpc_id                           = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix        = "elb/whitehall-backend-internal-elb"
+  listener_certificate_domain_name = "${var.elb_internal_certname}"
+  target_group_health_check_path   = "/_healthcheck_whitehall-admin"
+
+  listener_action = {
+    "HTTPS:443" = "HTTP:80"
+  }
+
   subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_internal_elb_id}"]
-  internal        = "true"
+  alarm_actions   = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
 
-  access_logs {
-    bucket        = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-    bucket_prefix = "elb/${var.stackname}-whitehall-backend-internal-elb"
-    interval      = 60
+  default_tags = {
+    Name            = "${var.stackname}-whitehall-backend"
+    Project         = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+    aws_migration   = "whitehall_backend"
   }
-
-  listener {
-    instance_port     = 80
-    instance_protocol = "http"
-    lb_port           = 443
-    lb_protocol       = "https"
-
-    ssl_certificate_id = "${data.aws_acm_certificate.elb_internal_cert.arn}"
-  }
-
-  health_check {
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-    timeout             = 3
-    target              = "TCP:80"
-    interval            = 30
-  }
-
-  cross_zone_load_balancing   = true
-  idle_timeout                = 400
-  connection_draining         = true
-  connection_draining_timeout = 400
-
-  tags = "${map("Name", "${var.stackname}-whitehall-backend", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "whitehall_backend")}"
 }
 
-resource "aws_route53_record" "internal_service_record" {
+# For each service name, create DNS A records pointing at the internal LB.
+resource "aws_route53_record" "internal_service_names" {
+  count   = "${length(var.app_service_records)}"
   zone_id = "${data.aws_route53_zone.internal.zone_id}"
-  name    = "whitehall-backend.${var.internal_domain_name}"
+  name    = "${element(var.app_service_records, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
   type    = "A"
 
   alias {
-    name                   = "${aws_elb.whitehall-backend_internal_elb.dns_name}"
-    zone_id                = "${aws_elb.whitehall-backend_internal_elb.zone_id}"
+    name                   = "${module.internal_lb.lb_dns_name}"
+    zone_id                = "${module.internal_lb.lb_zone_id}"
     evaluate_target_health = true
   }
-}
-
-resource "aws_route53_record" "internal_app_service_records" {
-  count   = "${length(var.app_service_records)}"
-  zone_id = "${data.aws_route53_zone.internal.zone_id}"
-  name    = "${element(var.app_service_records, count.index)}.${var.internal_domain_name}"
-  type    = "CNAME"
-  records = ["whitehall-backend.${var.internal_domain_name}}"]
-  ttl     = "300"
-}
-
-resource "aws_elb" "whitehall-backend_external_elb" {
-  count = "${var.create_external_elb}"
-
-  name            = "${var.stackname}-whitehall-backend-external"
-  subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_external_elb_id}"]
-  internal        = "false"
-
-  access_logs {
-    bucket        = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-    bucket_prefix = "elb/${var.stackname}-whitehall-backend-external-elb"
-    interval      = 60
-  }
-
-  listener {
-    instance_port     = 80
-    instance_protocol = "http"
-    lb_port           = 443
-    lb_protocol       = "https"
-
-    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
-  }
-
-  health_check {
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-    timeout             = 3
-    target              = "TCP:80"
-    interval            = 30
-  }
-
-  cross_zone_load_balancing   = true
-  idle_timeout                = 400
-  connection_draining         = true
-  connection_draining_timeout = 400
-
-  tags = "${map("Name", "${var.stackname}-whitehall-backend", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "whitehall_backend")}"
-}
-
-resource "aws_route53_record" "external_service_record" {
-  count = "${var.create_external_elb}"
-
-  zone_id = "${data.aws_route53_zone.external.zone_id}"
-  name    = "whitehall-backend.${var.external_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${aws_elb.whitehall-backend_external_elb.dns_name}"
-    zone_id                = "${aws_elb.whitehall-backend_external_elb.zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_route53_record" "app_service_records" {
-  count   = "${length(var.app_service_records)}"
-  zone_id = "${data.aws_route53_zone.external.zone_id}"
-  name    = "${element(var.app_service_records, count.index)}.${var.external_domain_name}"
-  type    = "CNAME"
-  records = ["whitehall-backend.${var.external_domain_name}"]
-  ttl     = "300"
-}
-
-locals {
-  instance_elb_ids_length = "${var.create_external_elb ? 2 : 1}"
-  instance_elb_ids        = "${compact(list( aws_elb.whitehall-backend_internal_elb.id, join("", aws_elb.whitehall-backend_external_elb.*.id) ))}"
 }
 
 module "whitehall-backend" {
-  source                        = "../../modules/aws/node_group"
-  name                          = "${var.stackname}-whitehall-backend"
-  default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "whitehall_backend", "aws_hostname", "whitehall-backend-1")}"
-  instance_subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
-  instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
-  instance_type                 = "${var.instance_type}"
-  instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
-  instance_elb_ids_length       = "${local.instance_elb_ids_length}"
-  instance_elb_ids              = ["${local.instance_elb_ids}"]
-  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
-  asg_max_size                  = "${var.asg_size}"
-  asg_min_size                  = "${var.asg_size}"
-  asg_desired_capacity          = "${var.asg_size}"
-  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
-}
+  source = "../../modules/aws/node_group"
+  name   = "${var.stackname}-whitehall-backend"
 
-module "alarms-elb-whitehall-backend-internal" {
-  source                         = "../../modules/aws/alarms/elb"
-  name_prefix                    = "${var.stackname}-whitehall-backend-internal"
-  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  elb_name                       = "${aws_elb.whitehall-backend_internal_elb.name}"
-  httpcode_backend_4xx_threshold = "0"
-  httpcode_backend_5xx_threshold = "100"
-  httpcode_elb_4xx_threshold     = "100"
-  httpcode_elb_5xx_threshold     = "100"
-  surgequeuelength_threshold     = "0"
-  healthyhostcount_threshold     = "0"
-}
+  default_tags = {
+    Project         = "${var.stackname}"
+    aws_stackname   = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+    aws_migration   = "whitehall_backend"
+    aws_hostname    = "whitehall-backend-1"
+  }
 
-locals {
-  elb_httpcode_backend_5xx_threshold = "${var.create_external_elb ? 100 : 0}"
-  elb_httpcode_elb_5xx_threshold     = "${var.create_external_elb ? 100 : 0}"
-  elb_httpcode_elb_4xx_threshold     = "${var.create_external_elb ? 100 : 0}"
-}
-
-module "alarms-elb-whitehall-backend-external" {
-  source        = "../../modules/aws/alarms/elb"
-  name_prefix   = "${var.stackname}-whitehall-backend-external"
-  alarm_actions = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  elb_name      = "${join("", aws_elb.whitehall-backend_external_elb.*.name)}"
-
-  httpcode_backend_4xx_threshold = "0"
-  httpcode_backend_5xx_threshold = "${local.elb_httpcode_backend_5xx_threshold}"
-  httpcode_elb_4xx_threshold     = "${local.elb_httpcode_elb_4xx_threshold}"
-  httpcode_elb_5xx_threshold     = "${local.elb_httpcode_elb_5xx_threshold}"
-  surgequeuelength_threshold     = "0"
-  healthyhostcount_threshold     = "0"
+  instance_subnet_ids               = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
+  instance_security_group_ids       = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
+  instance_type                     = "${var.instance_type}"
+  instance_additional_user_data     = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
+  instance_target_group_arns_length = "1"
+  instance_target_group_arns        = ["${module.internal_lb.target_group_arns[0]}"]
+  instance_ami_filter_name          = "${var.instance_ami_filter_name}"
+  asg_max_size                      = "${var.asg_size}"
+  asg_min_size                      = "${var.asg_size}"
+  asg_desired_capacity              = "${var.asg_size}"
+  asg_notification_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
 }
 
 # Outputs
 # --------------------------------------------------------------
 
-output "whitehall-backend_internal_elb_address" {
-  value       = "${aws_elb.whitehall-backend_internal_elb.dns_name}"
-  description = "AWS' internal DNS name for the whitehall-backend ELB"
-}
-
 output "internal_service_dns_name" {
-  value       = "${aws_route53_record.internal_service_record.name}"
-  description = "DNS name to access the node service"
-}
-
-output "whitehall-backend_external_elb_address" {
-  value       = "${join("", aws_elb.whitehall-backend_external_elb.*.dns_name)}"
-  description = "AWS' external DNS name for the whitehall-backend ELB"
-}
-
-output "external_service_dns_name" {
-  value       = "${join("", aws_elb.whitehall-backend_external_elb.*.dns_name)}"
-  description = "DNS name to access the external node service"
+  value       = "${module.internal_lb.lb_dns_name}"
+  description = "Internal DNS name for the whitehall_backend internal LB"
 }

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -2314,11 +2314,21 @@ module "whitehall_backend_public_lb" {
   access_logs_bucket_prefix                  = "elb/${var.stackname}-whitehall-backend-public-elb"
   listener_certificate_domain_name           = "${var.elb_public_certname}"
   listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-  listener_action                            = "${map("HTTPS:443", "HTTP:80")}"
-  subnets                                    = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups                            = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_external_elb_id}"]
-  alarm_actions                              = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                               = "${map("Project", var.stackname, "aws_migration", "whitehall_backend", "aws_environment", var.aws_environment)}"
+
+  listener_action = {
+    "HTTPS:443" = "HTTP:80"
+  }
+
+  target_group_health_check_path = "/_healthcheck_whitehall-admin"
+  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_external_elb_id}"]
+  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+
+  default_tags = {
+    Project         = "${var.stackname}"
+    aws_migration   = "whitehall_backend"
+    aws_environment = "${var.aws_environment}"
+  }
 }
 
 resource "aws_wafregional_web_acl_association" "whitehall_backend_public_lb" {


### PR DESCRIPTION
This replaces the Classic ELBs for `whitehall-admin` with ALBs and
uses the healthcheck which goes through to the application instead of
the generic nginx healthcheck which succeeds even when the app is not
running.

The healthcheck and ALB setup is described in
https://github.com/alphagov/govuk-aws/blob/master/doc/architecture/decisions/0037-alb-health-checks.md

We also remove some unused domain names which refer to
`whitehall_backend`. Nothing is configured to serve traffic for these
hostnames, so their existence only leads to confusion and surprise.