### PR TITLE
Add ingress rule for Knowledge Graph SG to access PostgreSQL

### DIFF
--- a/terraform/projects/infra-security-groups/postgresql.tf
+++ b/terraform/projects/infra-security-groups/postgresql.tf
@@ -82,3 +82,16 @@ resource "aws_security_group_rule" "postgresql-primary_ingress_db-admin_postgres
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.db-admin.id}"
 }
+
+resource "aws_security_group_rule" "postgresql-primary_ingress_knowledge-graph_postgres" {
+  type      = "ingress"
+  from_port = 5432
+  to_port   = 5432
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.postgresql-primary.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.knowledge-graph.id}"
+}


### PR DESCRIPTION
This commit adds a new ingress rule for the `knowledge-graph` SG to access the PostgreSQL `primary` node (in integration) for the purposes of querying the Publishing API database directly. We run this query at present to generate a dataset of people and of roles, which we're experimenting with to improve the Knowledge Graph and the use cases we're testing off the back of it.

This change is temporary (for the lifetime of the Knowledge Graph), after which if we move forward with a knowledge graph then we will do so from the ground-up and not necessarily productionise what we already have in integration at present.

Trello: https://trello.com/c/jXF0o7bT