### PR TITLE
Review s3 lifecycle policy

### DIFF
--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -48,7 +48,7 @@ resource "aws_s3_bucket" "fastly_logs" {
     enabled = true
 
     expiration {
-      days = 90
+      days = 30
     }
   }
 }

--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -65,6 +65,14 @@ resource "aws_s3_bucket" "transition_fastly_logs" {
     target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
     target_prefix = "s3/govuk-${var.aws_environment}-transition-fastly-logs/"
   }
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
 }
 
 # We require a user for Fastly to write to S3 buckets


### PR DESCRIPTION
Setting a lifecycle policy to ensure we honour our privacy policy correctly.

[Trello](https://trello.com/c/UBvLjmWy/1304-5-set-lifecycle-policy-of-30-days-on-s3-buckets-with-logs)