### PR TITLE
Fix duplicate DNS records for whitehall-admin, for real this time.

### DIFF
--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -96,6 +96,20 @@ module "internal_lb" {
   }
 }
 
+# For each service name, create DNS A records pointing at the internal LB.
+resource "aws_route53_record" "internal_service_names" {
+  count   = "${length(var.app_service_records)}"
+  zone_id = "${data.aws_route53_zone.internal.zone_id}"
+  name    = "${element(var.app_service_records, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${module.internal_lb.lb_dns_name}"
+    zone_id                = "${module.internal_lb.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
 module "whitehall-backend" {
   source = "../../modules/aws/node_group"
   name   = "${var.stackname}-whitehall-backend"

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -2358,24 +2358,6 @@ resource "aws_autoscaling_attachment" "whitehall_backend_asg_attachment_alb" {
   alb_target_group_arn   = "${element(module.whitehall_backend_public_lb.target_group_arns, 0)}"
 }
 
-resource "aws_route53_record" "whitehall_backend_internal_service_names" {
-  count   = "${length(var.whitehall_backend_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
-  name    = "${element(var.whitehall_backend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.whitehall_backend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "whitehall_backend_internal_service_cnames" {
-  count   = "${length(var.whitehall_backend_internal_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
-  name    = "${element(var.whitehall_backend_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.whitehall_backend_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
 #
 # whitehall_frontend
 #


### PR DESCRIPTION
My fix in #1126 removed the wrong duplicate DNS record. We need to
create A records in `app-whitehall-backend` because this is where the
load balancer is defined. If we try to do this in
`infra-public-services`, we would introduce a cycle into the dependency
graph of terraform projects which would make things tricky to deploy.

We therefore create the A (ALIAS) records in `app-whitehall-backend` and
remove the (now unnecessary) CNAMES from `infra-public-services`. This
makes the DNS arrangements for `whitehall-admin` follow the same pattern
as those for `licensify-admin`, which is fairly well-tested at this
point.