### PR TITLE
Remove prefix from lifecycle_rule

### DIFF
--- a/terraform/projects/infra-monitoring/main.tf
+++ b/terraform/projects/infra-monitoring/main.tf
@@ -68,8 +68,6 @@ resource "aws_s3_bucket" "aws-logging" {
   lifecycle_rule {
     enabled = true
 
-    prefix = "/"
-
     expiration {
       days = 30
     }


### PR DESCRIPTION
This lifecycle rule will not apply with this prefix.

See https://github.com/alphagov/govuk-aws/pull/1099