### PR TITLE
Ensure New Mapit Nodes Are Healthy

### DIFF
--- a/terraform/modules/aws/node_group/README.md
+++ b/terraform/modules/aws/node_group/README.md
@@ -30,6 +30,9 @@ to use with Application Load Balancers with the `instance_target_group_arns` var
 | create_asg_notifications | Enable Autoscaling Group notifications | string | `true` | no |
 | create_instance_key | Whether to create a key pair for the instance launch configuration | string | `false` | no |
 | default_tags | Additional resource tags | map | `<map>` | no |
+| ebs_device_name | Name of the block device to mount on the instance, e.g. xvdf | string | `xvdf` | no |
+| ebs_device_volume_size | Size of additional ebs volume in GB | string | `20` | no |
+| ebs_encrypted | Whether or not to encrypt the ebs volume | string | `false` | no |
 | instance_additional_user_data | Append additional user-data script | string | `` | no |
 | instance_ami_filter_name | Name to use to find AMI images for the instance | string | `ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*` | no |
 | instance_default_policy | Name of the JSON file containing the default IAM role policy for the instance | string | `default_policy.json` | no |
@@ -43,6 +46,7 @@ to use with Application Load Balancers with the `instance_target_group_arns` var
 | instance_target_group_arns_length | Length of instance_target_group_arns | string | `0` | no |
 | instance_type | Instance type | string | `t2.micro` | no |
 | instance_user_data | User_data provisioning script (default user_data.sh in module directory) | string | `user_data.sh` | no |
+| lc_create_ebs_volume | Creates a launch configuration which will add an additional ebs volume to the instance if this value is set to 1 | string | `0` | no |
 | name | Jumpbox resources name. Only alphanumeric characters and hyphens allowed | string | - | yes |
 | root_block_device_volume_size | The size of the instance root volume in gigabytes | string | `20` | no |
 

--- a/terraform/projects/app-mapit/README.md
+++ b/terraform/projects/app-mapit/README.md
@@ -9,12 +9,15 @@ Mapit node
 |------|-------------|:----:|:-----:|:-----:|
 | aws_environment | AWS environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| ebs_device_name | Name of the block device to mount on the instance, e.g. xvdf | string | - | yes |
+| ebs_device_volume_size | Size of additional ebs volume in GB | string | `20` | no |
 | ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |
 | instance_ami_filter_name | Name to use to find AMI images | string | `` | no |
 | instance_type | Instance type used for EC2 resources | string | `t2.medium` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
+| lc_create_ebs_volume | Creates a launch configuration which will add an additional ebs volume to the instance if this value is set to 1 | string | - | yes |
 | mapit_1_subnet | Name of the subnet to place the mapit instance 1 and EBS volume | string | - | yes |
 | mapit_2_subnet | Name of the subnet to place the mapit instance 1 and EBS volume | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-mapit/additional_policy.json
+++ b/terraform/projects/app-mapit/additional_policy.json
@@ -8,7 +8,8 @@
                 "ec2:AttachVolume",
                 "ec2:DetachVolume",
                 "ec2:DescribeVolumeStatus",
-                "ec2:DescribeVolumes"
+                "ec2:DescribeVolumes",
+                "ec2:CreateTags"
             ],
             "Resource": [
                 "*"

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -61,6 +61,22 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "lc_create_ebs_volume" {
+  type        = "string"
+  description = "Creates a launch configuration which will add an additional ebs volume to the instance if this value is set to 1"
+}
+
+variable "ebs_device_volume_size" {
+  type        = "string"
+  description = "Size of additional ebs volume in GB"
+  default     = "20"
+}
+
+variable "ebs_device_name" {
+  type        = "string"
+  description = "Name of the block device to mount on the instance, e.g. xvdf"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -134,6 +150,7 @@ resource "aws_route53_record" "mapit_service_record" {
 }
 
 module "mapit-1" {
+  lc_create_ebs_volume          = "${var.lc_create_ebs_volume}"
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-1"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-1")}"
@@ -146,6 +163,9 @@ module "mapit-1" {
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
   root_block_device_volume_size = "20"
+  ebs_device_volume_size        = "${var.ebs_device_volume_size}"
+  ebs_encrypted                 = "${var.ebs_encrypted}"
+  ebs_device_name               = "${var.ebs_device_name}"
 }
 
 resource "aws_ebs_volume" "mapit-1" {
@@ -166,6 +186,7 @@ resource "aws_ebs_volume" "mapit-1" {
 }
 
 module "mapit-2" {
+  lc_create_ebs_volume          = "${var.lc_create_ebs_volume}"
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-2"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-2")}"
@@ -178,6 +199,9 @@ module "mapit-2" {
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
   root_block_device_volume_size = "20"
+  ebs_device_volume_size        = "${var.ebs_device_volume_size}"
+  ebs_encrypted                 = "${var.ebs_encrypted}"
+  ebs_device_name               = "${var.ebs_device_name}"
 }
 
 resource "aws_ebs_volume" "mapit-2" {

--- a/terraform/userdata/05-tag-mapit-volume
+++ b/terraform/userdata/05-tag-mapit-volume
@@ -1,0 +1,39 @@
+# This is a snippet so should not have a shebang
+# shellcheck disable=SC2148
+#
+# Snippet: attach-volumes
+#
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] START SNIPPET: tag-mapit-volume"
+
+# The environment variables INSTANCE_ID and REGION are set
+# in the base snippet
+#
+F_STACKNAME=$(facter aws_stackname)
+F_AWS_ENV=$(facter aws_environment)
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] Current instance id is: $INSTANCE_ID"
+
+# Get ebs volume ID
+VOLUME_ID=$(aws ec2 describe-volumes --filters Name=attachment.status,Values=attached,Name=attachment.instance-id,Values=$INSTANCE_ID \
+          --query "Volumes[*].Attachments[?Device == '/dev/xvdf'].VolumeId" --output text \
+          --region=$REGION)
+
+x=0
+while [[ $x -lt 10 ]]; do
+  if ! [[ -e /dev/xvdf ]] ; then
+    sleep 1
+  else
+    break
+  fi
+  x=$((x+1))
+done
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] EBS volume id is: $VOLUME_ID"
+
+# Tag volumes
+aws ec2 create-tags --region=$REGION --resources $VOLUME_ID \
+        --tags Key=Name,Value=$F_STACKNAME-mapit Key=Project,Value=$F_STACKNAME Key=Device,Value=xvdf Key=aws_hostname,Value=mapit-1 Key=aws_migration,Value=mapit Key=aws_stackname,Value=$F_STACKNAME Key=aws_environment,Value=$F_AWS_ENV
+
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] END SNIPPET: tag-mapit-volume"


### PR DESCRIPTION
When autoscaling, new Mapit instances are currenly not created with new EBS volumes.
This is the present state of the mapit machines:

There are two autoscaling groups each containing only one instance. If this singular instance
is terminated, a new one is launched without an EBS volume to take it’s place. Then the old EBS
volume is attached to the new node (the EBS volume contains the database for the postcode lookup).
There are two problems with the current setup:
1. The service cannot be scaled up. The current set up relies on a the single instance being
terminated so that the new instance can use the old/original volume.
2. Any new nodes that are launched are currently unhealthy and require manual intervention to
make them work. This is caused by a Postgres issue. If Postgres detects data on a volume
during installation it will not install fully ( the issue is detailed here :
https://trello.com/c/l6Yalzfd/2671-fix-mapit-deployment-automation-so-that-new-vms-come-up-healthy ).
This means the new nodes also launch with a broken Postgres installation.

This PR implements the following solution:

A new blank EBS volume is now created by the launch configuration each time a new mapit instance
is created through the autoscaling group. After Postgres is installed, puppet automatically updates
the mapit database (see related PR here:
https://github.com/alphagov/govuk-puppet/commit/8dc4a54a2783361a4efd781454ab6428a4b6606c ).

The node_group module has been modified to allow for two types of launch configuration, one for nodes
which need an EBS volume and ones for nodes that do not. The default is the launch configuration
does not create EBS volumes.

A new user data snippet has also been added to tag the mapit node EBS volumes. This is because the attach-volume user data script is no longer used. The launch configuration will automatically attach any specified volumes to the correct node on creation, but annoyingly terraform does not let you add tags to volumes created by the launch configuration.