### PR TITLE
Remove gatling instances

### DIFF
--- a/terraform/projects/app-gatling/README.md
+++ b/terraform/projects/app-gatling/README.md
@@ -7,9 +7,9 @@ Gatling node
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| asg_desired_capacity | The autoscaling groups desired capacity | string | `2` | no |
-| asg_max_size | The autoscaling groups max_size | string | `2` | no |
-| asg_min_size | The autoscaling groups max_size | string | `2` | no |
+| asg_desired_capacity | The autoscaling groups desired capacity | string | `0` | no |
+| asg_max_size | The autoscaling groups max_size | string | `0` | no |
+| asg_min_size | The autoscaling groups max_size | string | `0` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | ebs_encrypted | Whether or not the EBS volume is encrypted | string | - | yes |

--- a/terraform/projects/app-gatling/main.tf
+++ b/terraform/projects/app-gatling/main.tf
@@ -22,19 +22,19 @@ variable "aws_environment" {
 variable "asg_desired_capacity" {
   type        = "string"
   description = "The autoscaling groups desired capacity"
-  default     = "2"
+  default     = "0"
 }
 
 variable "asg_max_size" {
   type        = "string"
   description = "The autoscaling groups max_size"
-  default     = "2"
+  default     = "0"
 }
 
 variable "asg_min_size" {
   type        = "string"
   description = "The autoscaling groups max_size"
-  default     = "2"
+  default     = "0"
 }
 
 variable "ebs_encrypted" {


### PR DESCRIPTION
No longer needed for load testing and having those instances is causing an
unknown "At least 1 machine requires reboots due to apt updates" alert in
icinga because they don't have a govuk_safe_to_reboot value specified.