### PR TITLE
add elasticache reboot rights for db-admin

### DIFF
--- a/terraform/projects/app-db-admin/elasticache_policy.json
+++ b/terraform/projects/app-db-admin/elasticache_policy.json
@@ -1,0 +1,14 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowElasticacheReboot",
+            "Effect": "Allow",
+            "Action": [
+                "elasticache:DescribeCacheClusters",
+                "elasticache:RebootCacheCluster"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -207,6 +207,19 @@ resource "aws_iam_role_policy_attachment" "db-admin_iam_role_policy_attachment" 
   policy_arn = "${aws_iam_policy.db-admin_iam_policy.arn}"
 }
 
+resource "aws_iam_policy" "db-admin_elasticache_iam_policy" {
+  count  = "${var.aws_environment == "integration" ? 1 : 0}"
+  name   = "${var.stackname}-db-admin-elasticache"
+  path   = "/"
+  policy = "${file("${path.module}/elasticache_policy.json")}"
+}
+
+resource "aws_iam_role_policy_attachment" "db-admin_elasticache_iam_role_policy_attachment" {
+  count      = "${var.aws_environment == "integration" ? 1 : 0}"
+  role       = "${module.db-admin.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.db-admin_elasticache_iam_policy.arn}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 


### PR DESCRIPTION
# Context

As part of the incident review to test the resilience of apps with respect to the reboot of redis cluster, we add the necessary iam permissions for the db_admin machines in AWS integration to trigger the reboot of the redis cluster.

# Decisions
1. add the iam policy to the db_admin to describe and reboot elasticache clusters

Additional [PR](https://github.com/alphagov/govuk-puppet/pull/9668) where a cron job is added to the db_admin machines in AWS Integration to describe and reboot the redis elasticache