### PR TITLE
Allow apps in Carrenza/6DG to talk to Publishing API in AWS.

### DIFF
--- a/terraform/projects/infra-security-groups/publishing-api.tf
+++ b/terraform/projects/infra-security-groups/publishing-api.tf
@@ -104,6 +104,18 @@ resource "aws_security_group_rule" "publishing-api-elb-external_ingress_office_h
   cidr_blocks       = ["${var.office_ips}"]
 }
 
+resource "aws_security_group_rule" "publishing-api-elb-external_ingress_carrenza_https" {
+  description = "Access from apps in Carrenza (6DG) to Pub API. Remove once everything is in AWS."
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.publishing-api_elb_external.id}"
+  cidr_blocks       = ["${var.carrenza_env_ips}"]
+}
+
 resource "aws_security_group_rule" "publishing-api-elb-external_egress_any_any" {
   type              = "egress"
   from_port         = 0


### PR DESCRIPTION
This allows traffic from the 6DG egress addresses into the
external-facing Classic ELB for Publishing API in AWS.

This is a prerequisite for migrating Publishing API to AWS.