### PR TITLE
Change publishing-api ELB healthchecks to hit the app, not the nginx.

### DIFF
--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -134,7 +134,7 @@ resource "aws_elb" "publishing-api_elb_internal" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:80"
+    target              = "HTTP:80/_healthcheck_publishing-api"
     interval            = 30
   }
 
@@ -185,7 +185,7 @@ resource "aws_elb" "publishing-api_elb_external" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:80"
+    target              = "HTTP:80/_healthcheck_publishing-api"
     interval            = 30
   }
 


### PR DESCRIPTION
This switches the load balancer healthchecks for publishing-api from TCP
healthchecks (which only test the nginx proxy) to HTTP healthchecks
which are routed through to the app instance.

This is in line with ADR 37: https://github.com/alphagov/govuk-aws/blob/master/doc/architecture/decisions/0037-alb-health-checks.md

Co-authored-by: Camille Descartes <camille.descartes@digital.cabinet-office.gov.uk>