### PR TITLE
Increase storage allocated to postgres RDS instances

### DIFF
--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -94,7 +94,7 @@ module "postgresql-primary_rds_instance" {
   subnet_ids          = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
   username            = "${var.username}"
   password            = "${var.password}"
-  allocated_storage   = "190"
+  allocated_storage   = "209"
   instance_class      = "${var.instance_type}"
   instance_name       = "${var.stackname}-postgresql-primary"
   multi_az            = "${var.multi_az}"


### PR DESCRIPTION
We have seen postgres primary in AWS integration
run out of memory during the data sync from production

Although integration and production have the same
allocated storage (the lowest at 190 GB), integration
uses substantially more. This is because some dbs in
production don't use AWS yet.

This change increases the allocated storage to 209 GB,
the next lowest available.

It makes the increase across all environments. At the
moment production is hugely overprovisioned (and this
adds an extra 19GB). Let me know if we don't want this
extra storage on production. This will be an extra
~$2.50 per instance per environment per month ($5 total).