### PR TITLE
replicate ckan elb s3 logs to cyber s3 bucket

### DIFF
--- a/terraform/policies/s3_govuk_aws_logging_replication_policy.tpl
+++ b/terraform/policies/s3_govuk_aws_logging_replication_policy.tpl
@@ -1,0 +1,34 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${govuk_aws_logging_arn}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl",
+        "s3:GetObjectVersionTagging"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${govuk_aws_logging_arn}/*"
+      ]
+    },
+    {
+      "Action": [
+        "s3:ReplicateObject",
+        "s3:ReplicateDelete"
+      ],
+      "Effect": "Allow",
+      "Resource": "${govuk_cyber_splunk_arn}/*"
+    }
+  ]
+}

--- a/terraform/policies/s3_govuk_aws_logging_replication_role.tpl
+++ b/terraform/policies/s3_govuk_aws_logging_replication_role.tpl
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+    "Action": "sts:AssumeRole",
+    "Principal": {
+      "Service": "s3.amazonaws.com"
+    },
+    "Effect": "Allow",
+    "Sid": ""
+    }
+  ]
+}

--- a/terraform/projects/infra-monitoring/README.md
+++ b/terraform/projects/infra-monitoring/README.md
@@ -18,6 +18,8 @@ Create resources to manage infrastructure and app monitoring:
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | aws_secondary_region | Secondary AWS region | string | `eu-west-2` | no |
+| cyber_slunk_aws_account_id | AWS account ID of the Cyber S3 bucket where aws logging will be replicated | string | `na` | no |
+| cyber_slunk_s3_bucket_name | Name of the Cyber S3 bucket where aws logging will be replicated | string | `na` | no |
 | stackname | Stackname | string | `` | no |
 
 ## Outputs


### PR DESCRIPTION
As part of an incident action, there is a need to replicate the logs of the ckan public elb into the cyber s3 bucket for processing by splunk.

It should be noted that the replication rule is only enabled for the production stack as Cyber is only interested in that. Unfortunately, the way that terraform 0.11.x works is we can't set a count for an nested resource. Hence, the replication rule is created for all environments but only enabled for the production environment.

In addition, we set the version to enabled as replication requires that. This would not have effect on the size of the s3 bucket because AWS writes new log files with new timestamp as the part of the file name so each log files is unique.

data component of this PR: https://github.com/alphagov/govuk-aws-data/pull/599