### PR TITLE
Reduce Storage Time of S3 Database Backups in Integration

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -13,10 +13,15 @@ database-backups: The bucket that will hold database backups
 | aws_backup_region | AWS region | string | `eu-west-2` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| expiration_time | Expiration time in days of S3 Objects | string | `120` | no |
+| expiration_time_whisper_mongo | Expiration time in days for Whisper/Mongo S3 database backups | string | `7` | no |
+| glacier_storage_time | Storage time in days for Glacier Objects | string | `90` | no |
+| integration_only | Only apply these policies to integration | string | `false` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
 | stackname | Stackname | string | - | yes |
-| training_and_integration_only | Only apply these policies to training or integration | string | `false` | no |
+| standard_s3_storage_time | Storage time in days for Standard S3 Bucket Objects | string | `30` | no |
+| training_only | Only apply these policies to training | string | `false` | no |
 
 ## Outputs
 

--- a/terraform/projects/infra-database-backups-bucket/reader.tf
+++ b/terraform/projects/infra-database-backups-bucket/reader.tf
@@ -9,7 +9,7 @@
 */
 
 resource "aws_iam_policy" "training_mongo_api_database_backups_reader" {
-  count       = "${var.training_and_integration_only == true ? 1 : 0}"
+  count       = "${var.training_only == true ? 1 : 0}"
   name        = "govuk-training-mongo-api_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.training_mongo_api_database_backups_reader.json}"
   description = "Allows reading the mongo-api database_backups bucket"
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "training_mongo_api_database_backups_reader" {
 }
 
 resource "aws_iam_policy" "training_mongo_router_database_backups_reader" {
-  count       = "${var.training_and_integration_only == true ? 1 : 0}"
+  count       = "${var.training_only == true ? 1 : 0}"
   name        = "govuk-training-mongo-router_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.training_mongo_router_database_backups_reader.json}"
   description = "Allows reading the mongo-router database_backups bucket"
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "training_mongo_router_database_backups_reader" {
 }
 
 resource "aws_iam_policy" "training_mongodb_database_backups_reader" {
-  count       = "${var.training_and_integration_only == true ? 1 : 0}"
+  count       = "${var.training_only == true ? 1 : 0}"
   name        = "govuk-training-mongodb_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.training_mongodb_database_backups_reader.json}"
   description = "Allows reading the mongodb database_backups bucket"
@@ -89,7 +89,7 @@ data "aws_iam_policy_document" "training_mongodb_database_backups_reader" {
 }
 
 resource "aws_iam_policy" "training_elasticsearch_database_backups_reader" {
-  count       = "${var.training_and_integration_only == true ? 1 : 0}"
+  count       = "${var.training_only == true ? 1 : 0}"
   name        = "govuk-training-elasticsearch_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.training_elasticsearch_database_backups_reader.json}"
   description = "Allows reading the elasticsearch database_backups bucket"
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "training_elasticsearch_database_backups_reader" 
 }
 
 resource "aws_iam_policy" "training_dbadmin_database_backups_reader" {
-  count       = "${var.training_and_integration_only == true ? 1 : 0}"
+  count       = "${var.training_only == true ? 1 : 0}"
   name        = "govuk-training-dbadmin_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.training_dbadmin_database_backups_reader.json}"
   description = "Allows reading the dbadmin database_backups bucket"
@@ -143,7 +143,7 @@ data "aws_iam_policy_document" "training_dbadmin_database_backups_reader" {
 }
 
 resource "aws_iam_policy" "training_transition_dbadmin_database_backups_reader" {
-  count       = "${var.training_and_integration_only == true ? 1 : 0}"
+  count       = "${var.training_only == true ? 1 : 0}"
   name        = "govuk-training-transition_dbadmin_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.training_transition_dbadmin_database_backups_reader.json}"
   description = "Allows reading the transition_dbadmin database_backups bucket"
@@ -169,7 +169,7 @@ data "aws_iam_policy_document" "training_transition_dbadmin_database_backups_rea
 }
 
 resource "aws_iam_policy" "training_publishing-api_dbadmin_database_backups_reader" {
-  count       = "${var.training_and_integration_only == true ? 1 : 0}"
+  count       = "${var.training_only == true ? 1 : 0}"
   name        = "govuk-training-publishing-api_dbadmin_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.training_publishing-api_dbadmin_database_backups_reader.json}"
   description = "Allows reading the publishing-api_dbadmin database_backups bucket"
@@ -193,7 +193,7 @@ data "aws_iam_policy_document" "training_publishing-api_dbadmin_database_backups
 }
 
 resource "aws_iam_policy" "training_email-alert-api_dbadmin_database_backups_reader" {
-  count       = "${var.training_and_integration_only == true ? 1 : 0}"
+  count       = "${var.training_only == true ? 1 : 0}"
   name        = "govuk-training-email-alert-api_dbadmin_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.training_email-alert-api_dbadmin_database_backups_reader.json}"
   description = "Allows reading the email-alert-api_dbadmin database_backups bucket"
@@ -217,7 +217,7 @@ data "aws_iam_policy_document" "training_email-alert-api_dbadmin_database_backup
 }
 
 resource "aws_iam_policy" "training_graphite_database_backups_reader" {
-  count       = "${var.training_and_integration_only == true ? 1 : 0}"
+  count       = "${var.training_only == true ? 1 : 0}"
   name        = "govuk-training-graphite_database_backups-reader-policy"
   policy      = "${data.aws_iam_policy_document.training_graphite_database_backups_reader.json}"
   description = "Allows reading the graphite database_backups bucket"


### PR DESCRIPTION
The govuk-integration-database-backups S3 Bucket has over 30TB of
data in it. As we do not need long term backups of Integration
databases this PR reduces the time they are stored for
(from 30 days to 3). This PR also disables Glacier Backups
in Integration. To do this, two new lifecycle rules have been added.
They will be created in all environments, but only enabled in Integration.