### PR TITLE
Pass data bucket name to provisioning script

### DIFF
--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -53,7 +53,7 @@ provider "aws" {
   version = "1.40.0"
 }
 
-resource "aws_s3_bucket" "s3_bucket" {
+resource "aws_s3_bucket" "data_infrastructure_bucket" {
   bucket = "${local.data_infrastructure_bucket_name}"
 
   versioning {
@@ -202,9 +202,10 @@ data "template_file" "knowledge-graph_userdata" {
   template = "${file("${path.module}/userdata.tpl")}"
 
   vars {
-    elb_name                     = "${aws_elb.knowledge-graph_elb_external.name}"
-    database_backups_bucket_name = "${data.terraform_remote_state.infra_database_backups_bucket.s3_database_backups_bucket_name}"
-    related_links_bucket_name    = "govuk-related-links-${var.aws_environment}"
+    elb_name                        = "${aws_elb.knowledge-graph_elb_external.name}"
+    database_backups_bucket_name    = "${data.terraform_remote_state.infra_database_backups_bucket.s3_database_backups_bucket_name}"
+    data_infrastructure_bucket_name = "${aws_s3_bucket.data_infrastructure_bucket.id}"
+    related_links_bucket_name       = "govuk-related-links-${var.aws_environment}"
   }
 }
 

--- a/terraform/projects/app-knowledge-graph/userdata.tpl
+++ b/terraform/projects/app-knowledge-graph/userdata.tpl
@@ -60,4 +60,4 @@ cd govuk-knowledge-graph
 chmod +x ./provision_knowledge_graph
 
 # Run provisioning script
-./provision_knowledge_graph -i $instance_id -d ${database_backups_bucket_name} -r ${related_links_bucket_name}
+./provision_knowledge_graph -i $instance_id -b ${database_backups_bucket_name} -d ${data_infrastructure_bucket_name} -r ${related_links_bucket_name}


### PR DESCRIPTION
This PR passes the data infrastructure bucket name as a parameter to the Knowledge Graph provisioning script, which will be used to store data generated as part of the graph provisioning on a daily basis.