### PR TITLE
Update knowledge graph scheduled action start times

### DIFF
--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -261,7 +261,7 @@ resource "aws_autoscaling_group" "knowledge-graph_asg" {
 resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-up" {
   autoscaling_group_name = "${aws_autoscaling_group.knowledge-graph_asg.name}"
   scheduled_action_name  = "knowledge-graph_schedule-spin-up"
-  recurrence             = "0 8 * * MON-FRI"
+  recurrence             = "0 9 * * MON-FRI"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 1
@@ -270,7 +270,7 @@ resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-up" {
 resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-down" {
   autoscaling_group_name = "${aws_autoscaling_group.knowledge-graph_asg.name}"
   scheduled_action_name  = "knowledge-graph_schedule-spin-down"
-  recurrence             = "55 16 * * MON-FRI"
+  recurrence             = "55 17 * * MON-FRI"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 0


### PR DESCRIPTION
This PR updates the knowledge graph scheduled action start times, which control when the instance is spin up and spun down. This is necessary to maintain the current availability of the knowledge graph given the recent switch from BST to GMT.