### PR TITLE
update terraform aws plugin and set progresql autoscale

### DIFF
--- a/terraform/modules/aws/rds_instance/README.md
+++ b/terraform/modules/aws/rds_instance/README.md
@@ -21,6 +21,7 @@ Create an RDS instance
 | instance_class | The instance type of the RDS instance. | string | `db.t1.micro` | no |
 | instance_name | The RDS Instance Name. | string | `` | no |
 | maintenance_window | The window to perform maintenance in. | string | `Mon:04:00-Mon:06:00` | no |
+| max_allocated_storage | current maximum storage in GB that AWS can autoscale the RDS storage to, 0 means disabled autoscaling | string | `0` | no |
 | multi_az | Specifies if the RDS instance is multi-AZ | string | `true` | no |
 | name | The common name for all the resources created by this module | string | - | yes |
 | parameter_group_name | Name of the parameter group to make the instance a member of. | string | `` | no |

--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -50,6 +50,12 @@ variable "allocated_storage" {
   default     = "10"
 }
 
+variable "max_allocated_storage" {
+  type        = "string"
+  description = "current maximum storage in GB that AWS can autoscale the RDS storage to, 0 means disabled autoscaling"
+  default     = "0"
+}
+
 variable "storage_type" {
   type        = "string"
   description = "One of standard (magnetic), gp2 (general purpose SSD), or io1 (provisioned IOPS SSD). The default is gp2"
@@ -217,6 +223,7 @@ resource "aws_db_instance" "db_instance" {
   username                = "${var.username}"
   password                = "${var.password}"
   allocated_storage       = "${var.allocated_storage}"
+  max_allocated_storage   = "${var.max_allocated_storage}"
   instance_class          = "${var.instance_class}"
   identifier              = "${var.instance_name}"
   storage_type            = "${var.storage_type}"

--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -80,7 +80,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "external" {

--- a/terraform/projects/app-asset-master/main.tf
+++ b/terraform/projects/app-asset-master/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-backend-redis/main.tf
+++ b/terraform/projects/app-backend-redis/main.tf
@@ -44,7 +44,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -87,7 +87,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "external" {

--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -56,7 +56,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -87,7 +87,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "external" {

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -84,7 +84,7 @@ data "aws_route53_zone" "internal" {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/app-ckan/main.tf
+++ b/terraform/projects/app-ckan/main.tf
@@ -66,7 +66,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-content-data-api-db-admin/main.tf
+++ b/terraform/projects/app-content-data-api-db-admin/main.tf
@@ -40,7 +40,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 module "content-data-api-db-admin" {

--- a/terraform/projects/app-content-data-api-postgresql/main.tf
+++ b/terraform/projects/app-content-data-api-postgresql/main.tf
@@ -66,7 +66,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_db_parameter_group" "content_data_api" {

--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -91,7 +91,7 @@ data "aws_route53_zone" "external" {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_acm_certificate" "elb_external_cert" {

--- a/terraform/projects/app-custom-formats-mapit-storage/main.tf
+++ b/terraform/projects/app-custom-formats-mapit-storage/main.tf
@@ -45,13 +45,13 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 provider "aws" {
   region  = "${var.aws_replica_region}"
   alias   = "aws_replica"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_s3_bucket" "custom_formats_mapit" {

--- a/terraform/projects/app-data-science/main.tf
+++ b/terraform/projects/app-data-science/main.tf
@@ -53,7 +53,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_security_group" "data-science" {

--- a/terraform/projects/app-db-admin/main.tf
+++ b/terraform/projects/app-db-admin/main.tf
@@ -58,7 +58,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -103,7 +103,7 @@ data "terraform_remote_state" "artefact_bucket" {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "external" {

--- a/terraform/projects/app-docker-management/main.tf
+++ b/terraform/projects/app-docker-management/main.tf
@@ -55,7 +55,7 @@ data "aws_route53_zone" "internal" {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_elb" "docker_management_etcd_elb" {

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -87,7 +87,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "external" {

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -81,7 +81,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "external" {

--- a/terraform/projects/app-draft-frontend/main.tf
+++ b/terraform/projects/app-draft-frontend/main.tf
@@ -79,7 +79,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-elasticsearch5/main.tf
+++ b/terraform/projects/app-elasticsearch5/main.tf
@@ -45,7 +45,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 # managed elasticsearch snapshots can't be given a prefix, so they

--- a/terraform/projects/app-elasticsearch6/main.tf
+++ b/terraform/projects/app-elasticsearch6/main.tf
@@ -126,7 +126,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_region" "current" {}

--- a/terraform/projects/app-email-alert-api/main.tf
+++ b/terraform/projects/app-email-alert-api/main.tf
@@ -66,7 +66,7 @@ data "aws_route53_zone" "internal" {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -84,7 +84,7 @@ data "aws_route53_zone" "internal" {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/app-gatling/main.tf
+++ b/terraform/projects/app-gatling/main.tf
@@ -83,7 +83,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "external" {

--- a/terraform/projects/app-graphite/main.tf
+++ b/terraform/projects/app-graphite/main.tf
@@ -91,7 +91,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "external" {

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -55,7 +55,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "external" {

--- a/terraform/projects/app-licensify-backend/main.tf
+++ b/terraform/projects/app-licensify-backend/main.tf
@@ -57,7 +57,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-licensify-documentdb/main.tf
+++ b/terraform/projects/app-licensify-documentdb/main.tf
@@ -62,7 +62,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_docdb_subnet_group" "licensify_cluster_subnet" {

--- a/terraform/projects/app-licensify-frontend/main.tf
+++ b/terraform/projects/app-licensify-frontend/main.tf
@@ -87,7 +87,7 @@ data "aws_route53_zone" "external" {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -91,7 +91,7 @@ data "aws_route53_zone" "internal" {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -56,7 +56,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 module "mirrorer" {

--- a/terraform/projects/app-mongo/main.tf
+++ b/terraform/projects/app-mongo/main.tf
@@ -106,7 +106,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -80,7 +80,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -76,7 +76,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-postgresql/README.md
+++ b/terraform/projects/app-postgresql/README.md
@@ -7,12 +7,14 @@ RDS PostgreSQL instances
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| allocated_storage | current set minimum storage in GB for the RDS | string | `300` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
 | instance_type | Instance type used for RDS resources | string | `db.m5.2xlarge` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
+| max_allocated_storage | current maximum storage in GB that AWS can autoscale the RDS storage to | string | `500` | no |
 | multi_az | Enable multi-az. | string | `true` | no |
 | password | DB password | string | - | yes |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -67,6 +67,18 @@ variable "instance_type" {
   default     = "db.m5.2xlarge"
 }
 
+variable "allocated_storage" {
+  type        = "string"
+  description = "current set minimum storage in GB for the RDS"
+  default     = "300"
+}
+
+variable "max_allocated_storage" {
+  type        = "string"
+  description = "current maximum storage in GB that AWS can autoscale the RDS storage to"
+  default     = "500"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -76,7 +88,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {
@@ -87,21 +99,22 @@ data "aws_route53_zone" "internal" {
 module "postgresql-primary_rds_instance" {
   source = "../../modules/aws/rds_instance"
 
-  name                = "${var.stackname}-postgresql-primary"
-  engine_name         = "postgres"
-  engine_version      = "9.6"
-  default_tags        = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "postgresql_primary")}"
-  subnet_ids          = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
-  username            = "${var.username}"
-  password            = "${var.password}"
-  allocated_storage   = "209"
-  instance_class      = "${var.instance_type}"
-  instance_name       = "${var.stackname}-postgresql-primary"
-  multi_az            = "${var.multi_az}"
-  security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]
-  event_sns_topic_arn = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
-  skip_final_snapshot = "${var.skip_final_snapshot}"
-  snapshot_identifier = "${var.snapshot_identifier}"
+  name                  = "${var.stackname}-postgresql-primary"
+  engine_name           = "postgres"
+  engine_version        = "9.6"
+  default_tags          = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "postgresql_primary")}"
+  subnet_ids            = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
+  username              = "${var.username}"
+  password              = "${var.password}"
+  allocated_storage     = "${var.allocated_storage}"
+  max_allocated_storage = "${var.max_allocated_storage}"
+  instance_class        = "${var.instance_type}"
+  instance_name         = "${var.stackname}-postgresql-primary"
+  multi_az              = "${var.multi_az}"
+  security_group_ids    = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]
+  event_sns_topic_arn   = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot   = "${var.skip_final_snapshot}"
+  snapshot_identifier   = "${var.snapshot_identifier}"
 }
 
 resource "aws_route53_record" "service_record" {

--- a/terraform/projects/app-prometheus/main.tf
+++ b/terraform/projects/app-prometheus/main.tf
@@ -47,7 +47,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 module "prometheus-1" {

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -96,7 +96,7 @@ data "aws_route53_zone" "external_without_stack" {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-puppetmaster/main.tf
+++ b/terraform/projects/app-puppetmaster/main.tf
@@ -61,7 +61,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {

--- a/terraform/projects/app-rabbitmq/main.tf
+++ b/terraform/projects/app-rabbitmq/main.tf
@@ -92,7 +92,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -106,7 +106,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -84,7 +84,7 @@ data "aws_route53_zone" "internal" {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -76,7 +76,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-ubuntu-test/main.tf
+++ b/terraform/projects/app-ubuntu-test/main.tf
@@ -34,7 +34,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_elb" "ubuntutest_external_elb" {

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -57,7 +57,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_route53_zone" "internal" {

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -66,7 +66,7 @@ data "aws_route53_zone" "internal" {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_acm_certificate" "elb_cert" {

--- a/terraform/projects/infra-artefact-bucket/main.tf
+++ b/terraform/projects/infra-artefact-bucket/main.tf
@@ -97,19 +97,19 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 provider "aws" {
   alias   = "secondary"
   region  = "${var.aws_secondary_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 provider "aws" {
   alias   = "subscription"
   region  = "${var.aws_subscription_account_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/projects/infra-assets/main.tf
+++ b/terraform/projects/infra-assets/main.tf
@@ -35,7 +35,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_s3_bucket" "assets" {

--- a/terraform/projects/infra-carrenza-vpn/main.tf
+++ b/terraform/projects/infra-carrenza-vpn/main.tf
@@ -63,7 +63,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "terraform_remote_state" "infra_networking" {

--- a/terraform/projects/infra-certificates/main.tf
+++ b/terraform/projects/infra-certificates/main.tf
@@ -55,7 +55,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "terraform_remote_state" "infra_root_dns_zones" {

--- a/terraform/projects/infra-content-data-admin/main.tf
+++ b/terraform/projects/infra-content-data-admin/main.tf
@@ -29,7 +29,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_s3_bucket" "content_data_csvs" {

--- a/terraform/projects/infra-content-publisher/main.tf
+++ b/terraform/projects/infra-content-publisher/main.tf
@@ -35,13 +35,13 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 provider "aws" {
   region  = "${var.aws_replica_region}"
   alias   = "aws_replica"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_s3_bucket" "activestorage" {

--- a/terraform/projects/infra-csw/main.tf
+++ b/terraform/projects/infra-csw/main.tf
@@ -25,7 +25,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 module "csw_inspector_role" {

--- a/terraform/projects/infra-cyber-security-audit/main.tf
+++ b/terraform/projects/infra-cyber-security-audit/main.tf
@@ -23,7 +23,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 module "cyber_security_audit_role" {

--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -84,13 +84,13 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 provider "aws" {
   alias   = "eu-london"
   region  = "${var.aws_backup_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {

--- a/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
@@ -47,7 +47,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {

--- a/terraform/projects/infra-datagovuk-static-bucket/main.tf
+++ b/terraform/projects/infra-datagovuk-static-bucket/main.tf
@@ -47,7 +47,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {

--- a/terraform/projects/infra-dev_vm/main.tf
+++ b/terraform/projects/infra-dev_vm/main.tf
@@ -49,7 +49,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_s3_bucket" "bucket" {

--- a/terraform/projects/infra-email-alert-api-archive/main.tf
+++ b/terraform/projects/infra-email-alert-api-archive/main.tf
@@ -30,7 +30,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_s3_bucket" "email_alert_api_archive" {

--- a/terraform/projects/infra-env-sync-and-backup/main.tf
+++ b/terraform/projects/infra-env-sync-and-backup/main.tf
@@ -29,7 +29,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_iam_user" "env_sync_and_backup" {

--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -28,7 +28,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_s3_bucket" "fastly_logs" {

--- a/terraform/projects/infra-govuk-cdn-logs-monitor-bucket/main.tf
+++ b/terraform/projects/infra-govuk-cdn-logs-monitor-bucket/main.tf
@@ -33,7 +33,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_s3_bucket" "cdn_logs_monitor" {

--- a/terraform/projects/infra-govuk-csp-forwarder/main.tf
+++ b/terraform/projects/infra-govuk-csp-forwarder/main.tf
@@ -22,7 +22,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_lambda_function" "govuk_csp_forwarder_lambda_function" {

--- a/terraform/projects/infra-govuk-repo-mirror/main.tf
+++ b/terraform/projects/infra-govuk-repo-mirror/main.tf
@@ -43,7 +43,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_iam_user" "govuk_codecommit_user" {

--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -97,19 +97,19 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 provider "aws" {
   region  = "${var.aws_replica_region}"
   alias   = "aws_replica"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 provider "aws" {
   region  = "us-east-1"
   alias   = "aws_cloudfront_certificate"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/projects/infra-mongodb-backup/main.tf
+++ b/terraform/projects/infra-mongodb-backup/main.tf
@@ -31,7 +31,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "template_file" "readwrite_policy_file" {

--- a/terraform/projects/infra-monitoring/main.tf
+++ b/terraform/projects/infra-monitoring/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_elb_service_account" "main" {}

--- a/terraform/projects/infra-monitoring/secondary.tf
+++ b/terraform/projects/infra-monitoring/secondary.tf
@@ -16,7 +16,7 @@ variable "aws_secondary_region" {
 provider "aws" {
   alias   = "aws_secondary"
   region  = "${var.aws_secondary_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "template_file" "s3_aws_secondary_logging_policy_template" {

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -118,7 +118,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "terraform_remote_state" "infra_vpc" {

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -469,7 +469,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 #

--- a/terraform/projects/infra-root-dns-zones/main.tf
+++ b/terraform/projects/infra-root-dns-zones/main.tf
@@ -64,7 +64,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "terraform_remote_state" "infra_vpc" {

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -19,7 +19,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 # used by the fastly ip ranges provider.

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -101,7 +101,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/projects/infra-splunk/main.tf
+++ b/terraform/projects/infra-splunk/main.tf
@@ -19,7 +19,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_iam_role" "splunk_aws_ro_role" {

--- a/terraform/projects/infra-stack-dns-zones/main.tf
+++ b/terraform/projects/infra-stack-dns-zones/main.tf
@@ -64,7 +64,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "terraform_remote_state" "infra_vpc" {

--- a/terraform/projects/infra-support-api/main.tf
+++ b/terraform/projects/infra-support-api/main.tf
@@ -29,7 +29,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 resource "aws_s3_bucket" "support_api_csvs" {

--- a/terraform/projects/infra-ukcloud-vpn/main.tf
+++ b/terraform/projects/infra-ukcloud-vpn/main.tf
@@ -74,7 +74,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "terraform_remote_state" "infra_networking" {

--- a/terraform/projects/infra-vpc/main.tf
+++ b/terraform/projects/infra-vpc/main.tf
@@ -59,7 +59,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "2.16.0"
+  version = "2.33.0"
 }
 
 data "terraform_remote_state" "infra_monitoring" {


### PR DESCRIPTION
set rds postgresql to autoscale up to a maximum limit.
We need to update the aws provider version to use this
functionality.

data PR: https://github.com/alphagov/govuk-aws-data/pull/612