### PR TITLE
Enable connection draining

### DIFF
--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -289,8 +289,9 @@ resource "aws_route53_record" "knowledge_graph_service_record_external" {
 }
 
 resource "aws_elb" "knowledge-graph_elb_external" {
-  name     = "${var.stackname}-knowledge-graph-external"
-  internal = false
+  name                = "${var.stackname}-knowledge-graph-external"
+  internal            = false
+  connection_draining = true
 
   listener {
     instance_port     = 22


### PR DESCRIPTION
The load balancer should allow the connection to finish before terminating
the instance. This was raised by Trusted advisor and this change makes thie ELB match
all of our other ones.