### PR TITLE
Delete Objects In Integration Backups Bucket After 3 Days

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -229,8 +229,18 @@ resource "aws_s3_bucket" "database_backups" {
       days = "${var.expiration_time}"
     }
   }
+  # Integration Rules for whole bucket
+  lifecycle_rule {
+    id      = "whole_bucket_lifecycle_rule_integration"
+    prefix  = ""
+    enabled = "${var.integration_only}"
 
-  # Integraion lifecycle specific rules END
+    expiration {
+      days = "${var.expiration_time}"
+    }
+  }
+
+  # Integration lifecycle specific rules END
 
   versioning {
     enabled = true


### PR DESCRIPTION
Add Lifecycle Rule to entire "govuk-integration-database-backups" S3
bucket that deletes any objects that are not matched by more specific
rules after 3 days.