### PR TITLE
Set default ASG size to 4 for calculators_frontend instances

### DIFF
--- a/terraform/projects/app-calculators-frontend/README.md
+++ b/terraform/projects/app-calculators-frontend/README.md
@@ -8,7 +8,7 @@ Calculators Frontend application servers
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| asg_size | The autoscaling groups desired/max/min capacity | string | `5` | no |
+| asg_size | The autoscaling groups desired/max/min capacity | string | `4` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -33,7 +33,7 @@ variable "elb_internal_certname" {
 variable "asg_size" {
   type        = "string"
   description = "The autoscaling groups desired/max/min capacity"
-  default     = "5"
+  default     = "4"
 }
 
 variable "app_service_records" {


### PR DESCRIPTION
- Brexit is delayed, so we're restoring to pre-spike ASG sizings.
- The pre-spike production instance size was 4, defined in
  `govuk-aws-data` for each environment. Let's bump the default down to
  4 for fewer lines of code to have to find to do things consistently.

https://trello.com/c/Ndw3s8Jj/1502-2-reduce-number-of-machines-to-pre-brexit-resilience-levels