### PR TITLE
Set default ASG size to 3 for cache instances

### DIFF
--- a/terraform/projects/app-cache/README.md
+++ b/terraform/projects/app-cache/README.md
@@ -8,7 +8,7 @@ Cache application servers
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| asg_size | The autoscaling groups desired/max/min capacity | string | `2` | no |
+| asg_size | The autoscaling groups desired/max/min capacity | string | `3` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | create_external_elb | Create the external ELB | string | `true` | no |

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -44,7 +44,7 @@ variable "app_service_records" {
 variable "asg_size" {
   type        = "string"
   description = "The autoscaling groups desired/max/min capacity"
-  default     = "2"
+  default     = "3"
 }
 
 variable "external_zone_name" {


### PR DESCRIPTION
- Staging and Production are reverting to pre-spike instance numbers.
  This was 3 in both environments. It makes the default 3, with
  integration the outlier with 2 instances which we set in
  govuk-aws-data.