### PR TITLE
Fix router-api LB healthchecks to check the app itself.

### DIFF
--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -145,7 +145,7 @@ resource "aws_elb" "router_api_elb" {
     unhealthy_threshold = 2
     timeout             = 3
 
-    target   = "TCP:80"
+    target   = "HTTP:80/_healthcheck_router-api"
     interval = 30
   }
 


### PR DESCRIPTION
Load balancer healthchecks for router-api were checking the default
vhost config on the nginx instead of being routed through to the app
itself.

See https://github.com/alphagov/govuk-aws/blob/master/doc/architecture/decisions/0037-alb-health-checks.md