### PR TITLE
Import the govuk-developer-docs resources from the old Terraform repo

### DIFF
--- a/terraform/projects/app-developer-docs/README.md
+++ b/terraform/projects/app-developer-docs/README.md
@@ -1,0 +1,19 @@
+## Project: app-developer-docs
+
+Creates S3 bucket for govuk-developer-docs
+
+Migrated from:
+https://github.com/alphagov/govuk-terraform-provisioning/tree/master/projects/developer_docs
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws_environment | AWS Environment | string | - | yes |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| aws_replica_region | AWS region | string | `eu-west-2` | no |
+| bucket_name |  | string | `govuk-developer-documentation` | no |
+| stackname | Stackname | string | - | yes |
+

--- a/terraform/projects/app-developer-docs/main.tf
+++ b/terraform/projects/app-developer-docs/main.tf
@@ -1,0 +1,84 @@
+/**
+* ## Project: app-developer-docs
+*
+* Creates S3 bucket for govuk-developer-docs
+*
+* Migrated from:
+* https://github.com/alphagov/govuk-terraform-provisioning/tree/master/projects/developer_docs
+*
+*/
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "stackname" {
+  type        = "string"
+  description = "Stackname"
+}
+
+variable "aws_environment" {
+  type        = "string"
+  description = "AWS Environment"
+}
+
+variable "bucket_name" {
+  type    = "string"
+  default = "govuk-developer-documentation"
+}
+
+variable "aws_replica_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-2"
+}
+
+# Resources
+# --------------------------------------------------------------
+
+terraform {
+  backend          "s3"             {}
+  required_version = "= 0.11.14"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "2.33.0"
+}
+
+resource "aws_iam_user" "developer-docs-user" {
+  name = "${var.bucket_name}_user"
+}
+
+data "template_file" "developer_docs_automated_read_write" {
+  template = "${file("templates/read_write_user.tpl")}"
+
+  vars {
+    bucket_name     = "${var.bucket_name}"
+    aws_environment = "${var.aws_environment}"
+    owner           = "Finding Things"
+  }
+}
+
+resource "aws_iam_policy" "developer_docs_automated_read_write" {
+  name        = "${var.bucket_name}_user_policy"
+  description = "${var.bucket_name} allows read/write"
+  policy      = "${data.template_file.developer_docs_automated_read_write.rendered}"
+}
+
+resource "aws_iam_policy_attachment" "developer_docs_attachment" {
+  name       = "${var.bucket_name}_user_attachment_policy"
+  users      = ["${aws_iam_user.developer-docs-user.name}"]
+  policy_arn = "${aws_iam_policy.developer_docs_automated_read_write.arn}"
+}
+
+resource "aws_s3_bucket" "developer_docs" {
+  bucket = "${var.bucket_name}-${var.aws_environment}"
+  acl    = "public-read"
+
+  website {
+    index_document = "index.html"
+    error_document = "error.html"
+  }
+}

--- a/terraform/projects/app-developer-docs/production.govuk.backend
+++ b/terraform/projects/app-developer-docs/production.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "govuk/app-developer-docs.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/app-developer-docs/templates/read_write_user.tpl
+++ b/terraform/projects/app-developer-docs/templates/read_write_user.tpl
@@ -1,0 +1,42 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListAllMyBuckets"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::*"
+      ]
+    },
+    {
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketVersions"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${aws_environment}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectACL",
+        "s3:PutObject",
+        "s3:PutObjectACL",
+        "S3:DeleteObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${aws_environment}/*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- These should live here as they're currently used.

No idea if this works, but raising for visibility.