### PR TITLE
Delete Non Current Version Of Backups After 7 Days

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -252,6 +252,16 @@ resource "aws_s3_bucket" "database_backups" {
 
   # Integration lifecycle specific rules END
 
+  # Lifecycle rule for production and staging
+  lifecycle_rule {
+    id      = "whole_bucket_lifecycle_rule_${var.aws_environment}"
+    prefix  = ""
+    enabled = "${var.integration_only == "false" ? true : false }"
+
+    noncurrent_version_expiration {
+      days = "7"
+    }
+  }
   versioning {
     enabled = true
   }


### PR DESCRIPTION
At the moment previous versions of an object are not
being deleted. This commit changes the behaviour of the
bucket so any non current object in the production-database-backups
and staging-database-backups buckets are deleted after 7 days.