### PR TITLE
Allow https ingress to Elasticsearch

### DIFF
--- a/terraform/projects/infra-security-groups/elasticsearch6.tf
+++ b/terraform/projects/infra-security-groups/elasticsearch6.tf
@@ -2,8 +2,11 @@
 # == Manifest: Project: Security Groups: elasticsearch6
 #
 # The elasticsearch cluster needs to be accessible on ports:
-#   - 80 from 'calculators_frontend' (for licence-finder)
-#   - 80 from 'search' (for search-api)
+#   - 80 and 443 from 'calculators_frontend' (for licence-finder)
+#   - 80 and 443 from 'search' (for search-api)
+#
+# When both licence-finder and search-api are using https, the http
+# rule can be removed.
 #
 # === Variables:
 # stackname - string
@@ -35,10 +38,36 @@ resource "aws_security_group_rule" "elasticsearch6_ingress_calculators-frontend_
   source_security_group_id = "${aws_security_group.calculators-frontend.id}"
 }
 
+resource "aws_security_group_rule" "elasticsearch6_ingress_calculators-frontend_elasticsearch-api-https" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.elasticsearch6.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.calculators-frontend.id}"
+}
+
 resource "aws_security_group_rule" "elasticsearch6_ingress_search_elasticsearch-api" {
   type      = "ingress"
   from_port = 80
   to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.elasticsearch6.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.search.id}"
+}
+
+resource "aws_security_group_rule" "elasticsearch6_ingress_search_elasticsearch-api-https" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
   protocol  = "tcp"
 
   # Which security group is the rule assigned to


### PR DESCRIPTION
[Trello card](https://trello.com/c/P5Zs7zIg/1148-use-correct-elasticsearch-host-header)