### PR TITLE
Disable Unnecessary Replication in Integration for S3 Buckets To Save Costs

### DIFF
--- a/terraform/projects/infra-artefact-bucket/README.md
+++ b/terraform/projects/infra-artefact-bucket/README.md
@@ -37,7 +37,9 @@ This module creates the following.
 | create_sns_topic | Indicates whether to create an SNS Topic | string | `false` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | - | yes |
 | remote_state_infra_monitoring_key_stack | Override stackname path to infra_monitoring remote state | string | `` | no |
+| replication_setting | Whether replication is Enabled or Disabled | string | `Enabled` | no |
 | stackname | Stackname | string | - | yes |
+| whole_bucket_lifecycle_rule_integration_enabled | Set to true in Integration data to only apply these rules for Integration | string | `false` | no |
 
 ## Outputs
 

--- a/terraform/projects/infra-artefact-bucket/main.tf
+++ b/terraform/projects/infra-artefact-bucket/main.tf
@@ -88,6 +88,18 @@ variable "remote_state_infra_monitoring_key_stack" {
   default     = ""
 }
 
+variable "whole_bucket_lifecycle_rule_integration_enabled" {
+  type        = "string"
+  description = "Set to true in Integration data to only apply these rules for Integration"
+  default     = "false"
+}
+
+variable "replication_setting" {
+  type        = "string"
+  description = "Whether replication is Enabled or Disabled"
+  default     = "Enabled"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -132,6 +144,20 @@ resource "aws_s3_bucket" "artefact_replication_destination" {
   versioning {
     enabled = true
   }
+
+  lifecycle_rule {
+    id      = "whole_bucket_lifecycle_rule_integration"
+    prefix  = ""
+    enabled = "${var.whole_bucket_lifecycle_rule_integration_enabled}"
+
+    expiration {
+      days = "7"
+    }
+
+    noncurrent_version_expiration {
+      days = "1"
+    }
+  }
 }
 
 # Main bucket
@@ -158,7 +184,7 @@ resource "aws_s3_bucket" "artefact" {
 
     rules {
       id     = "govuk-artefact-replication-whole-bucket-rule"
-      status = "Enabled"
+      status = "${var.replication_setting}"
       prefix = ""
 
       destination {

--- a/terraform/projects/infra-content-publisher/README.md
+++ b/terraform/projects/infra-content-publisher/README.md
@@ -17,5 +17,7 @@ Stores ActiveStorage blobs uploaded via Content Publisher.
 | remote_state_infra_security_groups_key_stack | Override infra_security_groups stackname path to infra_vpc remote state | string | `` | no |
 | remote_state_infra_stack_dns_zones_key_stack | Override stackname path to infra_stack_dns_zones remote state | string | `` | no |
 | remote_state_infra_vpc_key_stack | Override infra_vpc remote state path | string | `` | no |
+| replication_setting | Whether replication is Enabled or Disabled | string | `Enabled` | no |
 | stackname | Stackname | string | - | yes |
+| whole_bucket_lifecycle_rule_integration_enabled | Set to true in Integration data to only apply these rules for Integration | string | `false` | no |
 

--- a/terraform/projects/infra-content-publisher/main.tf
+++ b/terraform/projects/infra-content-publisher/main.tf
@@ -26,6 +26,18 @@ variable "stackname" {
   description = "Stackname"
 }
 
+variable "whole_bucket_lifecycle_rule_integration_enabled" {
+  type        = "string"
+  description = "Set to true in Integration data to only apply these rules for Integration"
+  default     = "false"
+}
+
+variable "replication_setting" {
+  type        = "string"
+  description = "Whether replication is Enabled or Disabled"
+  default     = "Enabled"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -67,7 +79,7 @@ resource "aws_s3_bucket" "activestorage" {
     rules {
       id     = "govuk-content-publisher-activestorage-replication-whole-bucket-rule"
       prefix = ""
-      status = "Enabled"
+      status = "${var.replication_setting}"
 
       destination {
         bucket        = "${aws_s3_bucket.activestorage_replica.arn}"
@@ -89,6 +101,20 @@ resource "aws_s3_bucket" "activestorage_replica" {
 
   versioning {
     enabled = true
+  }
+
+  lifecycle_rule {
+    id      = "whole_bucket_lifecycle_rule_integration"
+    prefix  = ""
+    enabled = "${var.whole_bucket_lifecycle_rule_integration_enabled}"
+
+    expiration {
+      days = "7"
+    }
+
+    noncurrent_version_expiration {
+      days = "1"
+    }
   }
 }
 


### PR DESCRIPTION
Disable replication of the govuk-integration-content-publisher-activestorage
S3 bucket, as it is not needed.

Disable replication of the govuk-integration-artefact S3 bucket, as it is not
needed.

Add lifecycle rules to buckets to ensure old objects are permanently deleted.