### PR TITLE
Deprecate `govukcli aws` functionality and signpost users to the GDS CLI

### DIFF
--- a/tools/govukcli
+++ b/tools/govukcli
@@ -28,7 +28,6 @@ function usage {
   list-contexts            Show the available contexts.
 
   ssh [options]            Run "$0 ssh help" for details.
-  aws [options]            Run "$0 aws help" for details.
 
   help                     Show this help.
 
@@ -65,19 +64,20 @@ EOF
 
 function aws_usage {
   cat << EOF
-  Usage: govukcli aws [options]
+    DEPRECATED: Use the gds-cli instead.
 
-  Gets a temporary session for the requested context, including asking for
-  your MFA token if needed. By default, passes arguments to the "aws" CLI tool.
-  Use the "invoke" command to set up the credentials then invoke another tool.
+    - Run "brew install alphagov/gds/gds-cli"
+    - Read the setup and usage instructions at https://docs.publishing.service.gov.uk/manual/gds-cli.html.
 
-  Requires your AWS credentials to be set up as in the GOV.UK Developer Docs:
-  https://docs.publishing.service.gov.uk/manual/user-management-in-aws.html#storing-credentials-on-disk
+    Examples:
 
-  Examples:
-    govukcli aws s3 ls
-    govukcli aws invoke gof3r get ...
+    - To assume-role into GOV.UK Integration as a PowerUser and get an AWS Console:
+        gds aws govuk-integration-poweruser -l
 
+    - To assume-role into GOV.UK Production as a PlatformHealthPowerUser and export some access keys for Terraform:
+        gds aws govuk-production-platformhealth-poweruser -e
+
+    - Read the README or play around for more command examples!
 EOF
 }
 
@@ -278,80 +278,6 @@ function run_aws {
     aws_usage
     exit
   fi
-
-  function _check_credentials {
-    ! ([ -z "${AWS_ACCESS_KEY_ID-}" ] || \
-    [ -z "${AWS_SECRET_ACCESS_KEY-}" ] || \
-    [ -z "${AWS_SESSION_TOKEN-}" ] || \
-    [ -z "${AWS_EXPIRATION-}" ] || \
-    [ "$(ruby -r time -e 'puts (Time.parse(ENV["AWS_EXPIRATION"]) - Time.now).floor')" -lt 300 ])
-  }
-
-  function _get_aws_config {
-    PROFILE=$1
-    KEY=$2
-    awk "/profile ${PROFILE}/ {profile=1} /${KEY}/ && profile==1 {print \$3; exit}" ~/.aws/config
-  }
-
-  function _session_name {
-    echo "$(whoami)-$(date +%d-%m-%y_%H-%M)"
-  }
-
-  function _write_credentials_file {
-    function _get_credentials_key {
-      echo ${CREDENTIALS} | ruby -e "require 'json'; c = JSON.parse(STDIN.read)['Credentials']; STDOUT << c['$1']"
-    }
-
-    FILE=$1
-    cat <<- EOF > ${FILE}
-    export AWS_ACCESS_KEY_ID=$(_get_credentials_key AccessKeyId)
-    export AWS_SECRET_ACCESS_KEY=$(_get_credentials_key SecretAccessKey)
-    export AWS_SESSION_TOKEN=$(_get_credentials_key SessionToken)
-    export AWS_EXPIRATION=$(_get_credentials_key Expiration)
-EOF
-  }
-
-  unset AWS_SESSION_TOKEN
-
-  check_context
-  get_context
-  GOVUK_ENV="$CONTEXT"
-
-  GOVUK_SESSION=~/.aws/gds/govuk/${GOVUK_ENV}
-  mkdir -p ~/.aws/gds/govuk
-  test -f ${GOVUK_SESSION} && source ${GOVUK_SESSION}
-
-  if ! _check_credentials; then
-    unset AWS_SESSION_TOKEN
-
-    # setup AWS access
-    SESSION_NAME=$(whoami)-$(date +%d-%m-%y_%H-%M)
-    MFA_SERIAL=$(_get_aws_config gds mfa_serial)
-    ROLE_ARN=$(_get_aws_config govuk-${GOVUK_ENV} role_arn)
-
-    prompt='Enter MFA token: '
-    if [ ! -z "${AWS_EXPIRATION-}" ]; then
-      prompt="Your AWS session has expired. ${prompt}"
-    fi
-    read -rp "${prompt}" MFA_TOKEN
-
-    CREDENTIALS=$(aws \
-                  --profile gds \
-                  sts assume-role \
-                  --role-session-name $SESSION_NAME \
-                  --role-arn $ROLE_ARN \
-                  --serial-number $MFA_SERIAL \
-                  --duration-seconds 28800 \
-                  --token-code $MFA_TOKEN) || exit $?
-
-    _write_credentials_file ${GOVUK_SESSION}
-    source ${GOVUK_SESSION}
-  fi
-
-  case $1 in
-    'invoke') shift; "$@";;
-    *) aws "$@";;
-  esac
 }
 
 COMMAND=$1


### PR DESCRIPTION
- As part of the working group on developer tooling, and as part of an
  ongoing approach to standardize tooling and make things more secure and
  better for new people joining GOV.UK, we are standardising on the GDS
  CLI for *AWS*-related tasks (signing into the Console, generating
  access keys for Terraform runs, etc).
- It's a CLI that's developed by RE and is secure in its approach to
  dealing with AWS credentials. It's substantially less code for *us* to
  maintain, and doesn't involve copying and pasting credentials into
  `~/.aws/config` and `~/.aws/credentials` files as part of an
  onboarding process. Credential rotation is also easier in the event of
  a compromise.
- We don't anticipate this to cause much friction (famous last words)
  given that most developers on GOV.UK don't interact with AWS very
  often.

(The working group leads are myself, Ben Thorner and Chris Baines. Come
and talk to us if you have any questions!)

- Related issues and PRs: #1159 and https://github.com/alphagov/govuk-developer-docs/pull/2129.
- The slides for the talk I'm giving at Tech Fortnightly tomorrow are
  [on Google Drive](https://docs.google.com/presentation/d/1ifPCXe9KwqYcjzfP2v7V2iU4BFahteH3wRYdtk3wrr8/edit).