### PR TITLE
Add Role To Policy Attachment / Update Terraform Code To Match Present State of AWS

### DIFF
--- a/terraform/projects/infra-artefact-bucket/main.tf
+++ b/terraform/projects/infra-artefact-bucket/main.tf
@@ -390,6 +390,7 @@ resource "aws_iam_policy_attachment" "artefact_writer" {
   name       = "artefact-writer-policy-attachment"
   users      = ["${aws_iam_user.artefact_writer.name}"]
   policy_arn = "${aws_iam_policy.artefact_writer.arn}"
+  roles      = ["blue-deploy"]
 }
 
 data "template_file" "artefact_writer_policy_template" {


### PR DESCRIPTION
This setting was present in all environments but was not present in
the terraform code. The role appears to be essential.