### PR TITLE
Add support for journey visualisation tool

### DIFF
--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -262,7 +262,7 @@ resource "aws_autoscaling_group" "knowledge-graph_asg" {
 resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-up" {
   autoscaling_group_name = "${aws_autoscaling_group.knowledge-graph_asg.name}"
   scheduled_action_name  = "knowledge-graph_schedule-spin-up"
-  recurrence             = "0 9 * * MON-FRI"
+  recurrence             = "0 9 * * MON-SUN"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 1
@@ -272,6 +272,15 @@ resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-down" {
   autoscaling_group_name = "${aws_autoscaling_group.knowledge-graph_asg.name}"
   scheduled_action_name  = "knowledge-graph_schedule-spin-down"
   recurrence             = "55 17 * * MON-FRI"
+  min_size               = -1
+  max_size               = -1
+  desired_capacity       = 0
+}
+
+resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-down-weekend" {
+  autoscaling_group_name = "${aws_autoscaling_group.knowledge-graph_asg.name}"
+  scheduled_action_name  = "knowledge-graph_schedule-spin-down-weekend"
+  recurrence             = "55 9 * * SAT-SUN"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 0

--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -300,6 +300,14 @@ resource "aws_elb" "knowledge-graph_elb_external" {
   }
 
   listener {
+    instance_port      = 3000
+    instance_protocol  = "http"
+    lb_port            = 443
+    lb_protocol        = "https"
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
+  }
+
+  listener {
     instance_port      = 7473
     instance_protocol  = "https"
     lb_port            = 7473

--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -109,6 +109,7 @@ data "aws_iam_policy_document" "knowledge-graph_read_ssm_policy_document" {
       "arn:aws:ssm:eu-west-1:${data.aws_caller_identity.current.account_id}:parameter/govuk_knowledge_graph_publishing_api_database",
       "arn:aws:ssm:eu-west-1:${data.aws_caller_identity.current.account_id}:parameter/govuk_knowledge_graph_publishing_api_user",
       "arn:aws:ssm:eu-west-1:${data.aws_caller_identity.current.account_id}:parameter/govuk_knowledge_graph_publishing_api_password",
+      "arn:aws:ssm:eu-west-1:${data.aws_caller_identity.current.account_id}:parameter/govuk_knowledge_graph_bolt_endpoint",
     ]
   }
 }

--- a/terraform/projects/app-knowledge-graph/userdata.tpl
+++ b/terraform/projects/app-knowledge-graph/userdata.tpl
@@ -61,3 +61,10 @@ chmod +x ./provision_knowledge_graph
 
 # Run provisioning script
 ./provision_knowledge_graph -i $instance_id -b ${database_backups_bucket_name} -d ${data_infrastructure_bucket_name} -r ${related_links_bucket_name}
+
+# Set correct permissions for user journey visualisation viewer script
+cd /var/data/github/govuk-knowledge-graph/src/visualization
+chmod +x ./start-journey-visualisation-viewer
+
+# Run journey visualisation viewer
+./start-journey-visualisation-viewer

--- a/terraform/projects/infra-security-groups/knowledge-graph.tf
+++ b/terraform/projects/infra-security-groups/knowledge-graph.tf
@@ -30,6 +30,17 @@ resource "aws_security_group_rule" "knowledge-graph_ingress_knowledge-graph-elb_
   security_group_id = "${aws_security_group.knowledge-graph.id}"
 }
 
+resource "aws_security_group_rule" "knowledge-graph_ingress_knowledge-graph-visualisation-elb_https" {
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 3000
+  to_port   = 3000
+
+  source_security_group_id = "${aws_security_group.knowledge-graph_elb_external.id}"
+
+  security_group_id = "${aws_security_group.knowledge-graph.id}"
+}
+
 resource "aws_security_group_rule" "knowledge-graph_ingress_knowledge-graph-elb_bolt" {
   type      = "ingress"
   protocol  = "tcp"
@@ -81,6 +92,16 @@ resource "aws_security_group_rule" "knowledge-graph-elb-external_ingress_office_
   security_group_id = "${aws_security_group.knowledge-graph_elb_external.id}"
 }
 
+resource "aws_security_group_rule" "knowledge-graph-visualisation-elb-external_ingress_office_https" {
+  type        = "ingress"
+  protocol    = "tcp"
+  from_port   = 443
+  to_port     = 443
+  cidr_blocks = ["${var.office_ips}"]
+
+  security_group_id = "${aws_security_group.knowledge-graph_elb_external.id}"
+}
+
 resource "aws_security_group_rule" "knowledge-graph-elb-external_ingress_office_bolt" {
   type        = "ingress"
   protocol    = "tcp"
@@ -106,6 +127,16 @@ resource "aws_security_group_rule" "knowledge-graph-elb-external_egress_any_http
   protocol    = "tcp"
   from_port   = 7473
   to_port     = 7473
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.knowledge-graph_elb_external.id}"
+}
+
+resource "aws_security_group_rule" "knowledge-graph-visualisation-elb-external_egress_any_https" {
+  type        = "egress"
+  protocol    = "tcp"
+  from_port   = 443
+  to_port     = 443
   cidr_blocks = ["0.0.0.0/0"]
 
   security_group_id = "${aws_security_group.knowledge-graph_elb_external.id}"


### PR DESCRIPTION
This PR adds support for the journey visualisation tool, hosted as part of the knowledge graph and using it to power searches of analytics between content pages. 

Specifically, this PR adds new rules to the knowledge graph SG and knowledge graph ELB SG, in addition to calling a new script within userdata to start the tool.

This PR also makes a small change to the ASG scheduled actions to ensure that we continue to generate base data at weekends.