### PR TITLE
Add an extra calculators_frontend machine

### DIFF
--- a/terraform/projects/app-calculators-frontend/README.md
+++ b/terraform/projects/app-calculators-frontend/README.md
@@ -8,7 +8,7 @@ Calculators Frontend application servers
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | app_service_records | List of application service names that get traffic via this loadbalancer | list | `<list>` | no |
-| asg_size | The autoscaling groups desired/max/min capacity | string | `4` | no |
+| asg_size | The autoscaling groups desired/max/min capacity | string | `5` | no |
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | elb_internal_certname | The ACM cert domain name to find the ARN of | string | - | yes |

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -33,7 +33,7 @@ variable "elb_internal_certname" {
 variable "asg_size" {
   type        = "string"
   description = "The autoscaling groups desired/max/min capacity"
-  default     = "4"
+  default     = "5"
 }
 
 variable "app_service_records" {


### PR DESCRIPTION
As we're seeing high CPU usage for Finder Frontend, so we probably
could do with a bit of extra capacity.