### PR TITLE
Enable the DocumentDB slow query profiler.

### DIFF
--- a/terraform/projects/app-licensify-documentdb/README.md
+++ b/terraform/projects/app-licensify-documentdb/README.md
@@ -20,6 +20,8 @@ DocumentDB cluster for Licensify
 | instance\_type | Instance type used for Licensify DocumentDB resources | `string` | `"db.r5.large"` | no |
 | master\_password | Password of master user on Licensify DocumentDB cluster | `string` | n/a | yes |
 | master\_username | Username of master user on Licensify DocumentDB cluster | `string` | n/a | yes |
+| profiler | Whether to log slow queries to CloudWatch. Must be either 'enabled' or 'disabled'. | `string` | `"enabled"` | no |
+| profiler\_threshold\_ms | Queries which take longer than this number of milliseconds are logged to CloudWatch if profiler is enabled. Minimum is 50. | `string` | `"300"` | no |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |
 | remote\_state\_infra\_security\_groups\_key\_stack | Override infra\_security\_groups stackname path to infra\_vpc remote state | `string` | `""` | no |

--- a/terraform/projects/app-shared-documentdb/README.md
+++ b/terraform/projects/app-shared-documentdb/README.md
@@ -21,6 +21,8 @@ Shared DocumentDB to support the following apps:
 | instance\_type | Instance type used for DocumentDB resources | `string` | `"db.r5.large"` | no |
 | master\_password | Password of master user on DocumentDB cluster | `string` | n/a | yes |
 | master\_username | Username of master user on DocumentDB cluster | `string` | n/a | yes |
+| profiler | Whether to log slow queries to CloudWatch. Must be either 'enabled' or 'disabled'. | `string` | `"enabled"` | no |
+| profiler\_threshold\_ms | Queries which take longer than this number of milliseconds are logged to CloudWatch if profiler is enabled. Minimum is 50. | `string` | `"300"` | no |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_monitoring\_key\_stack | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |


### PR DESCRIPTION
* Enable slow query logs for the shared DocDB cluster in all environments.
* Enable slow query logs for the Licensify DocDB cluster in all environments.
* Make the profiler settings configurable via vars.

This can be rolled out now that https://github.com/terraform-providers/terraform-provider-aws/issues/10953 is fixed and we've upgraded to `terraform-provider-aws` 2.46.0.