### PR TITLE
Allow ITHC access to CKAN and Email Alert

### DIFF
--- a/terraform/projects/infra-security-groups/ckan.tf
+++ b/terraform/projects/infra-security-groups/ckan.tf
@@ -119,3 +119,24 @@ resource "aws_security_group_rule" "ckan_ingress_db-admin_ssh" {
   security_group_id        = "${aws_security_group.ckan.id}"
   source_security_group_id = "${aws_security_group.db-admin.id}"
 }
+
+resource "aws_security_group" "ckan_ithc_access" {
+  count       = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  name        = "${var.stackname}_ckan_ithc_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Control access to ITHC SSH"
+
+  tags {
+    Name = "${var.stackname}_ckan_ithc_access"
+  }
+}
+
+resource "aws_security_group_rule" "ithc_ingress_ckan_ssh" {
+  count             = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  type              = "ingress"
+  to_port           = 22
+  from_port         = 22
+  protocol          = "tcp"
+  cidr_blocks       = "${var.ithc_access_ips}"
+  security_group_id = "${aws_security_group.ckan_ithc_access.id}"
+}

--- a/terraform/projects/infra-security-groups/email-alert-api.tf
+++ b/terraform/projects/infra-security-groups/email-alert-api.tf
@@ -112,3 +112,24 @@ resource "aws_security_group_rule" "email-alert-api-elb-external_egress_any_any"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.email-alert-api_elb_external.id}"
 }
+
+resource "aws_security_group" "email-alert-api_ithc_access" {
+  count       = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  name        = "${var.stackname}_email-alert-api_ithc_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Control access to ITHC SSH"
+
+  tags {
+    Name = "${var.stackname}_email-alert-api_ithc_access"
+  }
+}
+
+resource "aws_security_group_rule" "ithc_ingress_email-alert-api_ssh" {
+  count             = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  type              = "ingress"
+  to_port           = 22
+  from_port         = 22
+  protocol          = "tcp"
+  cidr_blocks       = "${var.ithc_access_ips}"
+  security_group_id = "${aws_security_group.email-alert-api_ithc_access.id}"
+}


### PR DESCRIPTION
Grants SSH access to ckan and email-alert-api boxes when `ithc_access_ips` is defined. Applying https://github.com/alphagov/govuk-aws/pull/1047 to more machines.