### PR TITLE
Update Node.js lambdas to the nodejs10.x runtime.

### DIFF
--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -493,6 +493,6 @@ resource "aws_lambda_function" "url_rewrite" {
   function_name = "url_rewrite"
   role          = "${aws_iam_role.basic_lambda_role.arn}"
   handler       = "index.handler"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs10.x"
   provider      = "aws.aws_cloudfront_certificate"
 }

--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -154,7 +154,7 @@ resource "aws_lambda_function" "aws_waf_log_trimmer" {
   source_code_hash = "${data.archive_file.aws_waf_log_trimmer.output_base64sha256}"
   role             = "${aws_iam_role.aws_waf_log_trimmer.arn}"
   handler          = "lambda.handler"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs10.x"
   timeout          = 190
 }
 


### PR DESCRIPTION
The `nodejs8.10` runtime reaches end of life on Dec 31.