### PR TITLE
Update Knowledge Graph SSM policy to read HTTPS endpoint

### DIFF
--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -110,6 +110,7 @@ data "aws_iam_policy_document" "knowledge-graph_read_ssm_policy_document" {
       "arn:aws:ssm:eu-west-1:${data.aws_caller_identity.current.account_id}:parameter/govuk_knowledge_graph_publishing_api_user",
       "arn:aws:ssm:eu-west-1:${data.aws_caller_identity.current.account_id}:parameter/govuk_knowledge_graph_publishing_api_password",
       "arn:aws:ssm:eu-west-1:${data.aws_caller_identity.current.account_id}:parameter/govuk_knowledge_graph_bolt_endpoint",
+      "arn:aws:ssm:eu-west-1:${data.aws_caller_identity.current.account_id}:parameter/govuk_knowledge_graph_https_endpoint",
     ]
   }
 }


### PR DESCRIPTION
This PR updates the Knowledge Graph SSM policy to read the HTTPS endpoint. This is used when rendering the custom GOV.UK guide on the Neo4j start page.