### PR TITLE
Increase AWS root volumes for email-alert-api/publishing-api.

### DIFF
--- a/terraform/projects/app-email-alert-api/main.tf
+++ b/terraform/projects/app-email-alert-api/main.tf
@@ -138,6 +138,7 @@ module "email-alert-api" {
   asg_min_size                  = "${var.asg_size}"
   asg_desired_capacity          = "${var.asg_size}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "50"
 }
 
 module "alarms-elb-email-alert-api-internal" {

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -245,6 +245,7 @@ module "publishing-api" {
   asg_min_size                  = "${var.asg_size}"
   asg_desired_capacity          = "${var.asg_size}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "50"
 }
 
 module "alarms-elb-publishing-api-internal" {


### PR DESCRIPTION
Make these match what's in Carrenza. We don't want the migration to
increase the risk of running out of disk space.