### PR TITLE
Add policies for data science access

### DIFF
--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -16,6 +16,8 @@ Infrastructure security settings:
 | aws_region | AWS region | string | `eu-west-1` | no |
 | role_admin_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |
 | role_admin_user_arns | List of ARNs of external users that can assume the role | list | `<list>` | no |
+| role_datascienceuser_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |
+| role_datascienceuser_user_arns | List of ARNs of external users that can assume the role | list | `<list>` | no |
 | role_internal_admin_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |
 | role_internal_admin_user_arns | List of ARNs of external users that can assume the role | list | `<list>` | no |
 | role_platformhealth_poweruser_policy_arns | List of ARNs of policies to attach to the role | list | `<list>` | no |


### PR DESCRIPTION
This PR adds a new role `govuk-datascienceusers` to allow data scientists to assume access integration. This role has the same level of access as govuk-users, but with additional permissions to create, update and delete resources in AWS Glue (related to jobs for running ETL on our databases) and AWS SageMaker (related to Jupyter notebook instances for experimentation).

We plan to test the new role with data scientists to ensure that it provides them with access to everything they need, specifically within AWS Glue and AWS SageMaker, so it is likely that we will be amending the associated policies once we know any additional permissions that are required.