### PR TITLE
Use combined TLS cert for licensify-admin, to work with non-SNI clients.

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -65,6 +65,7 @@ This project adds global resources for app components:
 | graphite_internal_service_names |  | list | `<list>` | no |
 | graphite_public_service_names |  | list | `<list>` | no |
 | jumpbox_public_service_names |  | list | `<list>` | no |
+| licensify_backend_elb_public_certname | Domain name (CN) of the ACM cert to use for licensify_backend. | string | - | yes |
 | licensify_backend_public_service_names |  | list | `<list>` | no |
 | licensify_frontend_internal_service_cnames |  | list | `<list>` | no |
 | licensify_frontend_internal_service_names |  | list | `<list>` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -179,6 +179,11 @@ variable "licensify_backend_public_service_names" {
   default = []
 }
 
+variable "licensify_backend_elb_public_certname" {
+  type        = "string"
+  description = "Domain name (CN) of the ACM cert to use for licensify_backend."
+}
+
 variable "mapit_public_service_names" {
   type    = "list"
   default = []
@@ -1682,15 +1687,14 @@ resource "aws_route53_record" "licensify_frontend_internal_service_cnames" {
 #
 
 module "licensify_backend_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "licensify-backend-public"
-  internal                                   = false
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/licensify-backend-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-  target_group_health_check_path             = "/healthcheck"
+  source                           = "../../modules/aws/lb"
+  name                             = "licensify-backend-public"
+  internal                         = false
+  vpc_id                           = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix        = "elb/licensify-backend-public-elb"
+  listener_certificate_domain_name = "${var.licensify_backend_elb_public_certname}"
+  target_group_health_check_path   = "/healthcheck"
 
   listener_action = {
     "HTTPS:443" = "HTTP:80"


### PR DESCRIPTION
Unfortunately licensify-admin has some clients which don't support SNI and can't upgrade yet. This allows them to continue working for now.

Using the combined cert is less messy that swapping the primary and secondary certs.