### PR TITLE
Increase root volume sizes to match Carrenza for Whitehall/Assets.

### DIFF
--- a/terraform/projects/app-asset-master/main.tf
+++ b/terraform/projects/app-asset-master/main.tf
@@ -94,7 +94,7 @@ module "asset-master" {
   asg_min_size                  = "1"
   asg_desired_capacity          = "1"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
-  root_block_device_volume_size = "30"
+  root_block_device_volume_size = "50"
 }
 
 module "alarms-autoscaling-asset-master" {

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -133,6 +133,7 @@ module "whitehall-backend" {
   asg_min_size                      = "${var.asg_size}"
   asg_desired_capacity              = "${var.asg_size}"
   asg_notification_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size     = "50"
 }
 
 # Outputs

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -138,6 +138,7 @@ module "whitehall-frontend" {
   asg_min_size                  = "${var.asg_size}"
   asg_desired_capacity          = "${var.asg_size}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "50"
 }
 
 module "alarms-elb-whitehall-frontend-internal" {


### PR DESCRIPTION
We don't want to introduce unnecessary risk to the AWS migration by shrinking resources at the same time.