### PR TITLE
Bump the Fastly logs S3 bucket retention period

### DIFF
--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -48,7 +48,7 @@ resource "aws_s3_bucket" "fastly_logs" {
     enabled = true
 
     expiration {
-      days = 30
+      days = 60
     }
   }
 }


### PR DESCRIPTION
- We need to temporarily keep more logs.