### PR TITLE
Upgrade MySQL RDS instances from m4 to m5.

### DIFF
--- a/terraform/projects/app-mysql/README.md
+++ b/terraform/projects/app-mysql/README.md
@@ -10,7 +10,7 @@ RDS Mysql Primary instance
 | aws_environment | AWS Environment | string | - | yes |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | cloudwatch_log_retention | Number of days to retain Cloudwatch logs for | string | - | yes |
-| instance_type | Instance type used for RDS resources | string | `db.m4.xlarge` | no |
+| instance_type | Instance type used for RDS resources | string | `db.m5.xlarge` | no |
 | internal_domain_name | The domain name of the internal DNS records, it could be different from the zone name | string | - | yes |
 | internal_zone_name | The name of the Route53 zone that contains internal records | string | - | yes |
 | max_allocated_storage | Maximum size in GB up to which AWS can autoscale the RDS storage. | string | `800` | no |

--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -70,7 +70,7 @@ variable "internal_domain_name" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for RDS resources"
-  default     = "db.m4.xlarge"
+  default     = "db.m5.xlarge"
 }
 
 # Resources


### PR DESCRIPTION
`m5`s provide better performance for slightly less money. Doing this
before the Whitehall migration is easier than doing it after.

Changing the default rather than overriding per environment because
we'll be upgrading all the environments within a day or so.