### PR TITLE
Bump the email-alert-api machines to m5.xlarge

### DIFF
--- a/terraform/projects/app-email-alert-api/README.md
+++ b/terraform/projects/app-email-alert-api/README.md
@@ -11,7 +11,7 @@ email-alert-api node
 | aws\_region | AWS region | string | `"eu-west-1"` | no |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | string | n/a | yes |
 | instance\_ami\_filter\_name | Name to use to find AMI images | string | `""` | no |
-| instance\_type | Instance type used for EC2 resources | string | `"m5.large"` | no |
+| instance\_type | Instance type used for EC2 resources | string | `"m5.xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | string | n/a | yes |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | string | n/a | yes |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | string | n/a | yes |

--- a/terraform/projects/app-email-alert-api/main.tf
+++ b/terraform/projects/app-email-alert-api/main.tf
@@ -49,7 +49,7 @@ variable "internal_domain_name" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for EC2 resources"
-  default     = "m5.large"
+  default     = "m5.xlarge"
 }
 
 # Resources


### PR DESCRIPTION
From m5.large machines. Before the migration to AWS, the 3 machines in
Carrenza had 8 cores. The m5.large machines just have 2, so double the
number of cores to 4 as we're seeing high load on the machines when
lots of delivery receipts are being received from Notify.