### PR TITLE
Give search-api permission to invoke SageMaker endpoints

### DIFF
--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -246,6 +246,29 @@ data "aws_iam_policy_document" "sitemaps_bucket_policy" {
   }
 }
 
+resource "aws_iam_role_policy_attachment" "invoke_sagemaker" {
+  role       = "${module.search.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.invoke_sagemaker.arn}"
+}
+
+resource "aws_iam_policy" "invoke_sagemaker" {
+  name        = "govuk-${var.aws_environment}-search-invoke-sagemaker-policy"
+  policy      = "${data.aws_iam_policy_document.invoke_sagemaker.json}"
+  description = "Allows invoking SageMaker endpoints"
+}
+
+data "aws_iam_policy_document" "invoke_sagemaker" {
+  statement {
+    sid = "InvokeSagemaker"
+
+    actions = [
+      "sagemaker:InvokeEndpoint",
+    ]
+
+    resources = ["arn:aws:sagemaker:*"]
+  }
+}
+
 # s3 bucket for search relevancy
 
 resource "aws_s3_bucket" "search_relevancy_bucket" {


### PR DESCRIPTION
The actual endpoint won't be managed by terraform so, rather than have
names in three places which need to be kept in sync (sagemaker
management code in concourse, search-api config, terraform), just
grant access to all endpoints.  We only have one at the moment, and
this can be revisited if need be.

Related to https://github.com/alphagov/search-api/pull/1887

---

[Plan](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/3478/console)
[Trello card](https://trello.com/c/ugkVdcjW/1233-host-ltr-reranking-in-sagemaker)