### PR TITLE
Set up permissions and security groups for Concourse to orchestrate daily LTR

### DIFF
--- a/terraform/projects/app-search/README.md
+++ b/terraform/projects/app-search/README.md
@@ -12,6 +12,7 @@ Search application servers
 | asg\_min\_size | The minimum size of the autoscaling group | string | `"2"` | no |
 | aws\_environment | AWS Environment | string | n/a | yes |
 | aws\_region | AWS region | string | `"eu-west-1"` | no |
+| concourse\_aws\_account\_id | AWS account ID which contains the Concourse role | string | n/a | yes |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | string | n/a | yes |
 | instance\_ami\_filter\_name | Name to use to find AMI images | string | `""` | no |
 | instance\_type | Instance type used for EC2 resources | string | `"c5.large"` | no |
@@ -31,6 +32,7 @@ Search application servers
 
 | Name | Description |
 |------|-------------|
+| concourse\_role\_arn | Concourse LTR role ARN |
 | search\_elb\_dns\_name | DNS name to access the search service |
 | service\_dns\_name | DNS name to access the node service |
 

--- a/terraform/projects/infra-security-groups/search-api.tf
+++ b/terraform/projects/infra-security-groups/search-api.tf
@@ -20,7 +20,7 @@ resource "aws_security_group" "search-api_external_elb" {
   }
 }
 
-resource "aws_security_group_rule" "search-api_ingress_external-elb_https" {
+resource "aws_security_group_rule" "search-api_ingress_carrenza_external-elb_https" {
   count     = "${length(var.carrenza_env_ips) > 0 ? 1 : 0}"
   type      = "ingress"
   from_port = 443
@@ -29,6 +29,17 @@ resource "aws_security_group_rule" "search-api_ingress_external-elb_https" {
 
   security_group_id = "${aws_security_group.search-api_external_elb.id}"
   cidr_blocks       = ["${var.carrenza_env_ips}"]
+}
+
+resource "aws_security_group_rule" "search-api_ingress_concourse_external-elb_https" {
+  count     = "${length(var.concourse_ips) > 0 ? 1 : 0}"
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id = "${aws_security_group.search-api_external_elb.id}"
+  cidr_blocks       = ["${var.concourse_ips}"]
 }
 
 resource "aws_security_group_rule" "search-api_egress_external_elb_any_any" {


### PR DESCRIPTION
This grants Concourse the permissions and access it needs for https://github.com/alphagov/search-api/pull/1871 to work.

---

[Plan (app-search)](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/3479/console)
[Plan (infra-security-groups)](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/3480/console)
[Trello card](https://trello.com/c/ZfXrYH46/1234-host-ltr-model-training-in-sagemaker-glue)