### PR TITLE
Give LTR role sagemaker:BatchGetImage permission

### DIFF
--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -387,6 +387,7 @@ data "aws_iam_policy_document" "concourse-permissions" {
 
     actions = [
       "iam:PassRole",
+      "sagemaker:BatchGetImage",
       "sagemaker:CreateEndpoint",
       "sagemaker:CreateEndpointConfig",
       "sagemaker:CreateEndpointConfig",


### PR DESCRIPTION
This is needed to deploy the endpoint.

---

[Trello card](https://trello.com/c/ZfXrYH46/1234-host-ltr-model-training-in-sagemaker-glue)