### PR TITLE
BatchGetImage is an ecr: permission, not a sagemaker: one

### DIFF
--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -386,8 +386,8 @@ data "aws_iam_policy_document" "concourse-permissions" {
     sid = "LearnToRank"
 
     actions = [
+      "ecr:BatchGetImage",
       "iam:PassRole",
-      "sagemaker:BatchGetImage",
       "sagemaker:CreateEndpoint",
       "sagemaker:CreateEndpointConfig",
       "sagemaker:CreateEndpointConfig",


### PR DESCRIPTION
The error message doesn't give the full name of the permission it's
missing, only the suffix.

Also, the AWS API will happily let you assign a permission which doesn't
exist.

---

[Plan](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/3501/console)
[Trello card](https://trello.com/c/ZfXrYH46/1234-host-ltr-model-training-in-sagemaker-glue)