### PR TITLE
Use managed SageMaker full-access policy

### DIFF
--- a/terraform/projects/app-search/README.md
+++ b/terraform/projects/app-search/README.md
@@ -32,7 +32,7 @@ Search application servers
 
 | Name | Description |
 |------|-------------|
-| concourse\_role\_arn | Concourse LTR role ARN |
+| ltr\_role\_arn | LTR role ARN |
 | search\_elb\_dns\_name | DNS name to access the search service |
 | service\_dns\_name | DNS name to access the node service |
 


### PR DESCRIPTION
I've given up trying to find the minimal set of permissions, so use
this sledgehammer for now.  In the future we could try stripping this
down.

Also rename the role, because it's not just the role used by
Concourse, it's the role used by SageMaker too.

---

[Plan](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/3503/console)
[Trello card](https://trello.com/c/ZfXrYH46/1234-host-ltr-model-training-in-sagemaker-glue)