### PR TITLE
Increase log retention to 120 days

### DIFF
--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -48,7 +48,7 @@ resource "aws_s3_bucket" "fastly_logs" {
     enabled = true
 
     expiration {
-      days = 60
+      days = 120
     }
   }
 }


### PR DESCRIPTION
We need to increase the retention period for fastly logs

[Trello](https://trello.com/c/HdqgecUO/1658-increase-retention-period-for-fastly-logs-to-120-days)