### PR TITLE
Add an ECR repository for the SageMaker training image

### DIFF
--- a/terraform/projects/app-search/README.md
+++ b/terraform/projects/app-search/README.md
@@ -32,6 +32,7 @@ Search application servers
 
 | Name | Description |
 |------|-------------|
+| ecr\_repository\_url | URL of the ECR repository |
 | ltr\_role\_arn | LTR role ARN |
 | search\_elb\_dns\_name | DNS name to access the search service |
 | service\_dns\_name | DNS name to access the node service |


### PR DESCRIPTION
SageMaker *requires* its training images to be in ECR.  Docker Hub won't work.

---

[Plan](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/3524/console)
[Trello card](https://trello.com/c/ZfXrYH46/1234-host-ltr-model-training-in-sagemaker-glue)