### PR TITLE
Properly set up cross-account access to ECR repository

### DIFF
--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -366,6 +366,11 @@ resource "aws_iam_role_policy_attachment" "learntorank-sagemaker" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
 }
 
+resource "aws_iam_role_policy_attachment" "learntorank-ecr" {
+  role       = "${aws_iam_role.learntorank.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}
+
 # we might want to retire this in favour of a dedicated project
 resource "aws_ecr_repository" "repo" {
   name = "search"
@@ -392,8 +397,12 @@ data "aws_iam_policy_document" "ecr-usage" {
     ]
 
     principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.concourse_aws_account_id}:role/cd-govuk-tools-concourse-worker"]
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::${var.concourse_aws_account_id}:root",
+        "${aws_iam_role.learntorank.arn}",
+      ]
     }
 
     principals {


### PR DESCRIPTION
Based on instructions in
https://medium.com/miq-tech-and-analytics/cross-account-how-to-access-aws-container-registry-service-from-another-aws-account-using-iam-b372796ede14

---

[Plan](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/3527/console)
[Trello card](https://trello.com/c/ZfXrYH46/1234-host-ltr-model-training-in-sagemaker-glue)