### PR TITLE
Stop Traffic Being Sent To New Backend Instances Before They Are Ready

### DIFF
--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -197,7 +197,7 @@ resource "aws_elb" "backend_elb_internal" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:80"
+    target              = "HTTP:80/_healthcheck"
     interval            = 30
   }
 


### PR DESCRIPTION
When new backend instances are created via the auto scaling group
they are receiving traffic too early from the internal load balancer.
This PR fixes this issue.