### PR TITLE
Add an external-facing load balancer for whitehall-frontend.

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -113,6 +113,7 @@ This project adds global resources for app components:
 | whitehall\_backend\_public\_service\_cnames | n/a | `list` | `[]` | no |
 | whitehall\_backend\_public\_service\_names | n/a | `list` | `[]` | no |
 | whitehall\_frontend\_internal\_service\_names | n/a | `list` | `[]` | no |
+| whitehall\_frontend\_public\_service\_names | n/a | `list` | `[]` | no |
 
 ## Outputs
 

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -214,6 +214,11 @@ variable "whitehall_backend_public_service_cnames" {
   default = []
 }
 
+variable "whitehall_frontend_public_service_names" {
+  type    = "list"
+  default = []
+}
+
 variable "asset_master_internal_service_names" {
   type    = "list"
   default = []
@@ -2289,8 +2294,73 @@ resource "aws_autoscaling_attachment" "whitehall_backend_asg_attachment_alb" {
 }
 
 #
-# whitehall_frontend
+# whitehall-frontend
 #
+
+# whitehall_frontend_public_lb exists only to serve Worldwide API to client
+# apps in Carrenza. Once the last consumer of Worldwide API is moved to AWS,
+# this LB should be decommissioned.
+module "whitehall_frontend_public_lb" {
+  source                                     = "../../modules/aws/lb"
+  name                                       = "${var.stackname}-whitehall-public"
+  internal                                   = false
+  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix                  = "elb/${var.stackname}-whitehall-frontend-public-elb"
+  listener_certificate_domain_name           = "${var.elb_public_certname}"
+  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
+
+  listener_action = {
+    "HTTPS:443" = "HTTP:80"
+  }
+
+  target_group_health_check_path = "/_healthcheck_whitehall-frontend"
+  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-frontend_external_elb_id}"]
+  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+
+  default_tags = {
+    Project         = "${var.stackname}"
+    aws_migration   = "whitehall_frontend"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
+resource "aws_wafregional_web_acl_association" "whitehall_frontend_public_lb" {
+  resource_arn = "${module.whitehall_frontend_public_lb.lb_id}"
+  web_acl_id   = "${aws_wafregional_web_acl.default.id}"
+}
+
+resource "aws_route53_record" "whitehall_frontend_public_service_names" {
+  count   = "${length(var.whitehall_frontend_public_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.whitehall_frontend_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${module.whitehall_frontend_public_lb.lb_dns_name}"
+    zone_id                = "${module.whitehall_frontend_public_lb.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+data "aws_autoscaling_groups" "whitehall_frontend" {
+  filter {
+    name   = "key"
+    values = ["Name"]
+  }
+
+  filter {
+    name   = "value"
+    values = ["blue-whitehall-frontend"]
+  }
+}
+
+resource "aws_autoscaling_attachment" "whitehall_frontend_asg_attachment_alb" {
+  count                  = "${length(data.aws_autoscaling_groups.whitehall_frontend.names) > 0 ? 1 : 0}"
+  autoscaling_group_name = "${element(data.aws_autoscaling_groups.whitehall_frontend.names, 0)}"
+  alb_target_group_arn   = "${element(module.whitehall_frontend_public_lb.target_group_arns, 0)}"
+}
 
 # draft_whitehall internal names are actually alias for whitehall internal names
 resource "aws_route53_record" "draft_whitehall_frontend_internal_service_names" {

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -140,5 +140,6 @@ Manage the security groups for the entire infrastructure
 | sg\_whitehall-backend\_id | n/a |
 | sg\_whitehall-backend\_internal\_elb\_id | n/a |
 | sg\_whitehall-frontend\_elb\_id | n/a |
+| sg\_whitehall-frontend\_external\_elb\_id | n/a |
 | sg\_whitehall-frontend\_id | n/a |
 

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -394,6 +394,10 @@ output "sg_whitehall-frontend_elb_id" {
   value = "${aws_security_group.whitehall-frontend_elb.id}"
 }
 
+output "sg_whitehall-frontend_external_elb_id" {
+  value = "${aws_security_group.whitehall-frontend_external_elb.id}"
+}
+
 output "sg_whitehall-frontend_id" {
   value = "${aws_security_group.whitehall-frontend.id}"
 }

--- a/terraform/projects/infra-security-groups/whitehall-frontend.tf
+++ b/terraform/projects/infra-security-groups/whitehall-frontend.tf
@@ -34,6 +34,19 @@ resource "aws_security_group_rule" "whitehall-frontend_ingress_whitehall-fronten
   source_security_group_id = "${aws_security_group.whitehall-frontend_elb.id}"
 }
 
+resource "aws_security_group_rule" "whitehall-frontend_ingress_whitehall-frontend-external-elb_http" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.whitehall-frontend.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.whitehall-frontend_external_elb.id}"
+}
+
 resource "aws_security_group" "whitehall-frontend_elb" {
   name        = "${var.stackname}_whitehall-frontend_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
@@ -62,4 +75,35 @@ resource "aws_security_group_rule" "whitehall-frontend-elb_egress_any_any" {
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.whitehall-frontend_elb.id}"
+}
+
+# whitehall-frontend-external-elb exists only to serve Worldwide API to apps in
+# Carrenza. (Traffic from end users to whitehall-frontend is proxied via the
+# Router app to the internal-facing whitehall-frontend-internal-elb.)
+resource "aws_security_group" "whitehall-frontend_external_elb" {
+  name        = "${var.stackname}_whitehall-frontend_external_elb_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access to the whitehall-frontend external ELB, for Worldwide API clients in Carrenza."
+
+  tags {
+    Name = "${var.stackname}_whitehall-frontend_external_elb_access"
+  }
+}
+
+resource "aws_security_group_rule" "whitehall-frontend-external-elb_ingress_public_https" {
+  type              = "ingress"
+  to_port           = 443
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.whitehall-frontend_external_elb.id}"
+  cidr_blocks       = ["${var.carrenza_env_ips}", "${var.office_ips}"]
+}
+
+resource "aws_security_group_rule" "whitehall-frontend-external-elb_egress_any_any" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.whitehall-frontend_external_elb.id}"
 }


### PR DESCRIPTION
This is needed because we moved Worldwide API from `whitehall-admin` to
`whitehall-frontend`. Client apps in Carrenza will be connecting to AWS over
the Internet once Whitehall moves to AWS.

Tips for reviewing:

* Please check that I haven't made any copy-paste errors, for example that there aren't any references to `backend` or `admin`. (I've checked this myself but please double-check.)
* Please check that the ACLs make sense to you.
* If the intent of this change isn't completely clear to you, please say so, because that in itself indicates a bug :)