### PR TITLE
Fix internal load balancer healthcheck for whitehall-frontend.

### DIFF
--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -99,7 +99,7 @@ resource "aws_elb" "whitehall-frontend_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:80"
+    target              = "HTTP:80/_healthcheck_whitehall-frontend"
     interval            = 30
   }
 


### PR DESCRIPTION
This changes the load balancer healthcheck for whitehall-frontend to
talk to the app itself rather than the nginx reverse proxy in front of
the app (which always returns healthy even if the app is down).

See https://github.com/alphagov/govuk-aws/blob/master/doc/architecture/decisions/0037-alb-health-checks.md