### PR TITLE
Reduce number of cache boxes to pre-Brexit levels

### DIFF
--- a/terraform/projects/app-cache/README.md
+++ b/terraform/projects/app-cache/README.md
@@ -15,7 +15,7 @@ Cache application servers
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | app\_service\_records | List of application service names that get traffic via this loadbalancer | `list` | `[]` | no |
-| asg\_size | The autoscaling groups desired/max/min capacity | `string` | `"2"` | no |
+| asg\_size | The autoscaling groups desired/max/min capacity | `string` | `"3"` | no |
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | create\_external\_elb | Create the external ELB | `bool` | `true` | no |

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -44,7 +44,7 @@ variable "app_service_records" {
 variable "asg_size" {
   type        = "string"
   description = "The autoscaling groups desired/max/min capacity"
-  default     = "2"
+  default     = "3"
 }
 
 variable "external_zone_name" {


### PR DESCRIPTION
This is to make sure we have 3 cache machines in all environments.
The values were overridden on a per-environment basis in
https://github.com/alphagov/govuk-aws-data/tree/master/data/app-cache
and
https://github.com/alphagov/govuk-aws-data/tree/master/data/app-draft-cache

Since we want the same value for all environments, there is no need to
apply them separately for each one in the files present in the
directories linked above because we can use the general values here
instead.

This PR goes together with https://github.com/alphagov/govuk-aws-data/pull/674.

Trello card: https://trello.com/c/mEXejdjd/1683-2-reduce-the-number-of-cache-boxes-to-pre-brexit-levels