### PR TITLE
Abort deploy script if an invalid project is given

### DIFF
--- a/tools/deploy.rb
+++ b/tools/deploy.rb
@@ -11,17 +11,19 @@ stack, project, environment, command, *rest= ARGV
 abort("too many arguments: #{rest}") unless rest.empty?
 
 # Valid values for each field
-valid_commands = %w(plan apply plan-destroy destroy).freeze
-valid_environments = %w(integration staging production test tools training).freeze
 valid_stacks = %w(blue green govuk).freeze
+valid_projects = Dir.chdir("#{Dir.home}/govuk/govuk-aws/terraform/projects") { Dir.glob('*').select { |f| File.directory? f } }.freeze
+valid_environments = %w(integration staging production test tools training).freeze
+valid_commands = %w(plan apply plan-destroy destroy).freeze
 
 usage = 'Usage: GITHUB_USERNAME=... GITHUB_TOKEN=... ruby deploy.rb <stack> <project> <environment> <command>'
 
 abort("GITHUB_USERNAME environment variable must be set\n#{usage}") unless ENV.has_key?('GITHUB_USERNAME')
 abort("GITHUB_TOKEN environment variable must be set\n#{usage}") unless ENV.has_key?('GITHUB_TOKEN')
-abort("command must be one of #{valid_commands.join(', ')}\n#{usage}") unless valid_commands.include?(command)
-abort("environment must be one of #{valid_environments.join(', ')}\n#{usage}") unless valid_environments.include?(environment)
 abort("stack must be one of #{valid_stacks.join(', ')}\n#{usage}") unless valid_stacks.include?(stack)
+abort("project must be one of #{valid_projects.join(', ')}\n#{usage}") unless valid_projects.include?(project)
+abort("environment must be one of #{valid_environments.join(', ')}\n#{usage}") unless valid_environments.include?(environment)
+abort("command must be one of #{valid_commands.join(', ')}\n#{usage}") unless valid_commands.include?(command)
 
 # Make sure the user is happy to go ahead
 puts "You're about to #{command} the #{stack}/#{project} project in #{environment}"


### PR DESCRIPTION
The `deploy` script accepts four fields: `stack`, `project`,
`environment` and `command`. For each of them, there are only specific
possible values.

For the `stack`, `environment` and `command` fields, these values were
specified in the script and there was logic to abort if different values
were given.

This introduces the same logic for the `project` field.

I also reordered the variables and the `abort` statements to reflect the
order in which the fields must be given in the command line.