### PR TITLE
Add life cycle rules to the mirror replica

### DIFF
--- a/terraform/projects/infra-mirror-bucket/README.md
+++ b/terraform/projects/infra-mirror-bucket/README.md
@@ -31,6 +31,8 @@ The primary bucket should be in London and the backup in Ireland.
 | cloudfront\_enable | Enable Cloudfront distributions. | `bool` | `false` | no |
 | cloudfront\_www\_certificate\_domain | The domain of the WWW CloudFront certificate to look up. | `string` | `""` | no |
 | cloudfront\_www\_distribution\_aliases | Extra CNAMEs (alternate domain names), if any, for the WWW CloudFront distribution. | `list` | `[]` | no |
+| lifecycle\_government\_uploads | Number of days for the lifecycle rule for the mirror in the case where the prefix path is www.gov.uk/government/uploads/ | `string` | `"8"` | no |
+| lifecycle\_main | Number of days for the lifecycle rule for the mirror | `string` | `"5"` | no |
 | office\_ips | An array of CIDR blocks that will be allowed offsite access. | `list` | n/a | yes |
 | remote\_state\_app\_mirrorer\_key\_stack | stackname path to app\_mirrorer remote state | `string` | `""` | no |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |

--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -86,6 +86,18 @@ variable "cloudfront_assets_certificate_domain" {
   default     = ""
 }
 
+variable "lifecycle_main" {
+  type        = "string"
+  description = "Number of days for the lifecycle rule for the mirror"
+  default     = "5"
+}
+
+variable "lifecycle_government_uploads" {
+  type        = "string"
+  description = "Number of days for the lifecycle rule for the mirror in the case where the prefix path is www.gov.uk/government/uploads/"
+  default     = "8"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -158,7 +170,7 @@ resource "aws_s3_bucket" "govuk-mirror" {
     prefix = ""
 
     noncurrent_version_expiration {
-      days = 5
+      days = "${var.lifecycle_main}"
     }
   }
 
@@ -169,7 +181,7 @@ resource "aws_s3_bucket" "govuk-mirror" {
     prefix = "www.gov.uk/government/uploads/"
 
     noncurrent_version_expiration {
-      days = 8
+      days = "${var.lifecycle_government_uploads}"
     }
   }
 
@@ -213,6 +225,28 @@ resource "aws_s3_bucket" "govuk-mirror-replica" {
 
   versioning {
     enabled = true
+  }
+
+  lifecycle_rule {
+    id      = "main"
+    enabled = true
+
+    prefix = ""
+
+    noncurrent_version_expiration {
+      days = "${var.lifecycle_main}"
+    }
+  }
+
+  lifecycle_rule {
+    id      = "government_uploads"
+    enabled = true
+
+    prefix = "www.gov.uk/government/uploads/"
+
+    noncurrent_version_expiration {
+      days = "${var.lifecycle_government_uploads}"
+    }
   }
 }
 


### PR DESCRIPTION
We have life cycle for the mirror bucket but not for its replica,
 it doesn't really make sense to keep all this data.