### PR TITLE
Change the PostgreSQL instance type m5.2xlarge -> m5.4xlarge

### DIFF
--- a/terraform/projects/app-postgresql/README.md
+++ b/terraform/projects/app-postgresql/README.md
@@ -17,7 +17,7 @@ RDS PostgreSQL instances
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | cloudwatch\_log\_retention | Number of days to retain Cloudwatch logs for | `string` | n/a | yes |
-| instance\_type | Instance type used for RDS resources | `string` | `"db.m5.2xlarge"` | no |
+| instance\_type | Instance type used for RDS resources | `string` | `"db.m5.4xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | max\_allocated\_storage | current maximum storage in GB that AWS can autoscale the RDS storage to | `string` | `"500"` | no |

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -64,7 +64,7 @@ variable "internal_domain_name" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for RDS resources"
-  default     = "db.m5.2xlarge"
+  default     = "db.m5.4xlarge"
 }
 
 variable "allocated_storage" {


### PR DESCRIPTION
The equivalent machine in Carrenza had 16 cores, so up the AWS
instance to match.

App improvements to the Publishing API and Email Alert API would be
welcome, but this is more of a quick workaround to high CPU usage.