### PR TITLE
Migrate shellcheck CI check from Jenkins to Concourse

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,15 +15,6 @@ node ("terraform") {
       govuk.bundleApp()
     }
 
-    stage("Shellcheck") {
-      govuk.shellcheck([
-        "tools/*.sh",
-        "tools/govukcli",
-        "terraform/userdata/*",
-        "jenkins.sh",
-      ])
-    }
-
     stage("ADR check") {
       sh "tools/adr-check.sh"
     }

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -4,7 +4,7 @@
 #
 set -e
 
-if [[ ! $(which sops) ]]; then
+if [[ ! $(command -v sops) ]]; then
   echo "sops not installed, exiting"
   exit 1
 fi
@@ -35,7 +35,7 @@ if [[ $TERRAFORM_VERSION != '' ]]; then
   PATH=$(pwd)/$BIN:$PATH
   echo $PATH
 
-  echo "Terraform binary: $(which terraform)"
+  echo "Terraform binary: $(command -v terraform)"
 fi
 
 rm -rf govuk-aws-data

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -43,6 +43,7 @@ jobs:
             args:
             - -c
             - |
+              brew update-reset
               brew install terraform-docs
 
               echo "Checking the updatedness of README files..."
@@ -65,6 +66,7 @@ jobs:
             args:
             - -c
             - |
+              brew update-reset
               brew install shellcheck
 
               echo "Running shellcheck..."

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -33,7 +33,7 @@ jobs:
             type: docker-image
             source:
               repository: homebrew/brew
-              tag: 2.2.2
+              tag: 2.2.4
           inputs:
             - name: govuk-aws-pr
               path: repo

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -27,7 +27,7 @@ jobs:
           path: govuk-aws-pr
       - task: check-terraform-docs-updatedness
         timeout: 15m
-        config:
+        config: &brew
           platform: linux
           image_resource:
             type: docker-image
@@ -52,6 +52,23 @@ jobs:
                 echo "The documentation isn't up to date. You should run ./tools/update-docs.sh and commit the results."
                 exit 1
               fi
+      - task: shellcheck
+        timeout: 15m
+        config:
+          <<: *brew
+          inputs:
+            - name: govuk-aws-pr
+              path: repo
+          run:
+            path: bash
+            dir: repo
+            args:
+            - -c
+            - |
+              brew install shellcheck
+
+              echo "Running shellcheck..."
+              shellcheck -e SC2086,SC1117 jenkins.sh tools/govukcli tools/*.sh terraform/userdata/*
     on_success:
       put: govuk-aws-pr
       params:
@@ -62,4 +79,3 @@ jobs:
       params:
         path: govuk-aws-pr
         status: failure
-

--- a/terraform/userdata/05-tag-mapit-volume
+++ b/terraform/userdata/05-tag-mapit-volume
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck disable=SC2148
+# shellcheck shell=bash
 #
 # Snippet: attach-volumes
 #

--- a/terraform/userdata/10-associate-eni
+++ b/terraform/userdata/10-associate-eni
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck disable=SC2148
+# shellcheck shell=bash
 #
 # Snippet: associate-eni
 #

--- a/terraform/userdata/10-attach-volumes
+++ b/terraform/userdata/10-attach-volumes
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck disable=SC2148
+# shellcheck shell=bash
 #
 # Snippet: attach-volumes
 #

--- a/terraform/userdata/10-db-admin
+++ b/terraform/userdata/10-db-admin
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck disable=SC2148
+# shellcheck shell=bash
 #
 # Snippet: db-admin
 #

--- a/terraform/userdata/20-puppet-client
+++ b/terraform/userdata/20-puppet-client
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck disable=SC2148
+# shellcheck shell=bash
 #
 # Snippet: puppet-client
 #

--- a/terraform/userdata/20-puppetmaster
+++ b/terraform/userdata/20-puppetmaster
@@ -26,7 +26,7 @@ puppet apply -e 'notify { "Hello from Puppet": }'
 
 # Create a workdir
 mkdir -p /var/govuk
-cd /var/govuk
+cd /var/govuk || return
 
 # Get git and checkout govuk-aws
 apt-get -y install git

--- a/terraform/userdata/20-puppetmaster
+++ b/terraform/userdata/20-puppetmaster
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck disable=SC2148
+# shellcheck shell=bash
 #
 # Snippet: puppetmaster
 #

--- a/terraform/userdata/20-puppetmaster-integration
+++ b/terraform/userdata/20-puppetmaster-integration
@@ -26,7 +26,7 @@ puppet apply -e 'notify { "Hello from Puppet": }'
 
 # Create a workdir
 mkdir -p /var/govuk
-cd /var/govuk
+cd /var/govuk || return
 
 # Get git and checkout govuk-aws
 apt-get -y install git

--- a/terraform/userdata/20-puppetmaster-integration
+++ b/terraform/userdata/20-puppetmaster-integration
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck disable=SC2148
+# shellcheck shell=bash
 #
 # Snippet: puppetmaster
 #

--- a/terraform/userdata/20-puppetmaster-production
+++ b/terraform/userdata/20-puppetmaster-production
@@ -26,7 +26,7 @@ puppet apply -e 'notify { "Hello from Puppet": }'
 
 # Create a workdir
 mkdir -p /var/govuk
-cd /var/govuk
+cd /var/govuk || return
 
 # Get git and checkout govuk-aws
 apt-get -y install git

--- a/terraform/userdata/20-puppetmaster-production
+++ b/terraform/userdata/20-puppetmaster-production
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck disable=SC2148
+# shellcheck shell=bash
 #
 # Snippet: puppetmaster
 #

--- a/terraform/userdata/20-puppetmaster-staging
+++ b/terraform/userdata/20-puppetmaster-staging
@@ -26,7 +26,7 @@ puppet apply -e 'notify { "Hello from Puppet": }'
 
 # Create a workdir
 mkdir -p /var/govuk
-cd /var/govuk
+cd /var/govuk || return
 
 # Get git and checkout govuk-aws
 apt-get -y install git

--- a/terraform/userdata/20-puppetmaster-staging
+++ b/terraform/userdata/20-puppetmaster-staging
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck disable=SC2148
+# shellcheck shell=bash
 #
 # Snippet: puppetmaster
 #

--- a/terraform/userdata/20-puppetmaster-training
+++ b/terraform/userdata/20-puppetmaster-training
@@ -26,7 +26,7 @@ puppet apply -e 'notify { "Hello from Puppet": }'
 
 # Create a workdir
 mkdir -p /var/govuk
-cd /var/govuk
+cd /var/govuk || return
 
 # Get git and checkout govuk-aws
 apt-get -y install git

--- a/terraform/userdata/20-puppetmaster-training
+++ b/terraform/userdata/20-puppetmaster-training
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck disable=SC2148
+# shellcheck shell=bash
 #
 # Snippet: puppetmaster
 #

--- a/terraform/userdata/30-deploy-apps
+++ b/terraform/userdata/30-deploy-apps
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck disable=SC2148
+# shellcheck shell=bash
 #
 # Snippet: deploy-apps
 #

--- a/tools/build-terraform-project.sh
+++ b/tools/build-terraform-project.sh
@@ -74,7 +74,7 @@ SECRET_COMMON_PROJECT_DATA="${PROJECT_DATA_DIR}/common.secret.tfvars"
 STACK_PROJECT_DATA="${PROJECT_DATA_DIR}/${STACKNAME}.tfvars"
 SECRET_PROJECT_DATA="${PROJECT_DATA_DIR}/${STACKNAME}.secret.tfvars"
 
-if [[ -z $(which terraform) ]]; then
+if [[ -z $(command -v terraform) ]]; then
   log_error 'Terraform not found, please make sure it is installed.'
 fi
 
@@ -151,10 +151,10 @@ for TFVAR_FILE in "$COMMON_DATA" \
                   "$SECRET_PROJECT_DATA"
 do
   if [[ -f $TFVAR_FILE ]] &&
-     (
+     {
       [[ "$TFVAR_FILE" == "$SECRET_PROJECT_DATA" ]] ||
       [[ "$TFVAR_FILE" == "$SECRET_COMMON_PROJECT_DATA" ]]
-     ) ; then
+     } ; then
     TO_RUN="$TO_RUN -var-file <(sops -d $TFVAR_FILE)"
   elif [[ -f $TFVAR_FILE ]]; then
     TO_RUN="$TO_RUN -var-file $TFVAR_FILE"

--- a/tools/terraform-format.sh
+++ b/tools/terraform-format.sh
@@ -5,7 +5,7 @@ for file in "$@"; do
   lint=$(terraform fmt -write=false -diff=true -list=true "${file}")
   failed=""
 
-  if [ ! -z "${lint}" ]; then
+  if [ -n "${lint}" ]; then
     failed="yes"
     echo -e "Your code is not in a canonical format:\n"
     echo "${lint}"

--- a/tools/update-docs.sh
+++ b/tools/update-docs.sh
@@ -2,7 +2,7 @@
 #
 # Update docs across all projects and modules
 #
-if [[ ! $(which terraform-docs) ]]; then
+if [[ ! $(command -v terraform-docs) ]]; then
   echo "Must install terraform-docs: https://github.com/segmentio/terraform-docs"
   exit 1
 fi


### PR DESCRIPTION
- This is hopefully easier to follow than having to [go to another repo and understand 35 lines of code](https://github.com/alphagov/govuk-jenkinslib/blob/60a7e9c3b6be83eead36987d7a9c04eaa90d7b09/vars/govuk.groovy#L1083-L1118).
- Use some YAML anchoring to avoid specifying the `homebrew/brew` Docker `image_resource` twice.

- Also some performance improvements in the Concourse pipeline, and a version bump.