### PR TITLE
Update an AWS provider version in infra-monitoring.

### DIFF
--- a/terraform/projects/infra-monitoring/README.md
+++ b/terraform/projects/infra-monitoring/README.md
@@ -12,8 +12,8 @@ Create resources to manage infrastructure and app monitoring:
 
 | Name | Version |
 |------|---------|
-| aws | 2.46.0 2.33.0 |
-| aws.aws\_secondary | 2.46.0 2.33.0 |
+| aws | 2.46.0 2.46.0 |
+| aws.aws\_secondary | 2.46.0 2.46.0 |
 | template | n/a |
 
 ## Inputs

--- a/terraform/projects/infra-monitoring/secondary.tf
+++ b/terraform/projects/infra-monitoring/secondary.tf
@@ -16,7 +16,7 @@ variable "aws_secondary_region" {
 provider "aws" {
   alias   = "aws_secondary"
   region  = "${var.aws_secondary_region}"
-  version = "2.33.0"
+  version = "2.46.0"
 }
 
 data "template_file" "s3_aws_secondary_logging_policy_template" {


### PR DESCRIPTION
Missed this in #1232. There are no remaining occurrences of `2.33.0` in
the repo.