### PR TITLE
Merge pull request #1235 from alphagov/scale-up-cache-and-calculators-frontend

### DIFF
--- a/terraform/projects/app-cache/README.md
+++ b/terraform/projects/app-cache/README.md
@@ -15,7 +15,7 @@ Cache application servers
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | app\_service\_records | List of application service names that get traffic via this loadbalancer | `list` | `[]` | no |
-| asg\_size | The autoscaling groups desired/max/min capacity | `string` | `"3"` | no |
+| asg\_size | The autoscaling groups desired/max/min capacity | `string` | `"6"` | no |
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | create\_external\_elb | Create the external ELB | `bool` | `true` | no |

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -44,7 +44,7 @@ variable "app_service_records" {
 variable "asg_size" {
   type        = "string"
   description = "The autoscaling groups desired/max/min capacity"
-  default     = "3"
+  default     = "6"
 }
 
 variable "external_zone_name" {

--- a/terraform/projects/app-calculators-frontend/README.md
+++ b/terraform/projects/app-calculators-frontend/README.md
@@ -15,7 +15,7 @@ Calculators Frontend application servers
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | app\_service\_records | List of application service names that get traffic via this loadbalancer | `list` | `[]` | no |
-| asg\_size | The autoscaling groups desired/max/min capacity | `string` | `"5"` | no |
+| asg\_size | The autoscaling groups desired/max/min capacity | `string` | `"10"` | no |
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -33,7 +33,7 @@ variable "elb_internal_certname" {
 variable "asg_size" {
   type        = "string"
   description = "The autoscaling groups desired/max/min capacity"
-  default     = "5"
+  default     = "10"
 }
 
 variable "app_service_records" {


### PR DESCRIPTION
This is a "better safe than sorry" change to scale up the number of
app-calculators-frontend machines from 5 to 10 and the number of
app-cache machines from 3 to 6. This is because we want to be able
to cope with the increased volume of traffic that Brexit will very
likely cause.

This applies to all environments and there is a [matching PR to delete the overrides](https://github.com/alphagov/govuk-aws-data/pull/679).


Trello card: https://trello.com/c/XVfE3PEn/1709-2-increase-server-capacity-in-advance-of-brexit