### PR TITLE
Merge pull request #1236 from alphagov/revert-1233-add-shellcheck-concourse-task

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,15 @@ node ("terraform") {
       govuk.bundleApp()
     }
 
+    stage("Shellcheck") {
+      govuk.shellcheck([
+        "tools/*.sh",
+        "tools/govukcli",
+        "terraform/userdata/*",
+        "jenkins.sh",
+      ])
+    }
+
     stage("ADR check") {
       sh "tools/adr-check.sh"
     }

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -4,7 +4,7 @@
 #
 set -e
 
-if [[ ! $(command -v sops) ]]; then
+if [[ ! $(which sops) ]]; then
   echo "sops not installed, exiting"
   exit 1
 fi
@@ -35,7 +35,7 @@ if [[ $TERRAFORM_VERSION != '' ]]; then
   PATH=$(pwd)/$BIN:$PATH
   echo $PATH
 
-  echo "Terraform binary: $(command -v terraform)"
+  echo "Terraform binary: $(which terraform)"
 fi
 
 rm -rf govuk-aws-data

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -27,13 +27,13 @@ jobs:
           path: govuk-aws-pr
       - task: check-terraform-docs-updatedness
         timeout: 15m
-        config: &brew
+        config:
           platform: linux
           image_resource:
             type: docker-image
             source:
               repository: homebrew/brew
-              tag: 2.2.4
+              tag: 2.2.2
           inputs:
             - name: govuk-aws-pr
               path: repo
@@ -43,7 +43,6 @@ jobs:
             args:
             - -c
             - |
-              brew update-reset
               brew install terraform-docs
 
               echo "Checking the updatedness of README files..."
@@ -53,24 +52,6 @@ jobs:
                 echo "The documentation isn't up to date. You should run ./tools/update-docs.sh and commit the results."
                 exit 1
               fi
-      - task: shellcheck
-        timeout: 15m
-        config:
-          <<: *brew
-          inputs:
-            - name: govuk-aws-pr
-              path: repo
-          run:
-            path: bash
-            dir: repo
-            args:
-            - -c
-            - |
-              brew update-reset
-              brew install shellcheck
-
-              echo "Running shellcheck..."
-              shellcheck -e SC2086,SC1117 jenkins.sh tools/govukcli tools/*.sh terraform/userdata/*
     on_success:
       put: govuk-aws-pr
       params:
@@ -81,3 +62,4 @@ jobs:
       params:
         path: govuk-aws-pr
         status: failure
+

--- a/terraform/userdata/05-tag-mapit-volume
+++ b/terraform/userdata/05-tag-mapit-volume
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck shell=bash
+# shellcheck disable=SC2148
 #
 # Snippet: attach-volumes
 #

--- a/terraform/userdata/10-associate-eni
+++ b/terraform/userdata/10-associate-eni
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck shell=bash
+# shellcheck disable=SC2148
 #
 # Snippet: associate-eni
 #

--- a/terraform/userdata/10-attach-volumes
+++ b/terraform/userdata/10-attach-volumes
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck shell=bash
+# shellcheck disable=SC2148
 #
 # Snippet: attach-volumes
 #

--- a/terraform/userdata/10-db-admin
+++ b/terraform/userdata/10-db-admin
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck shell=bash
+# shellcheck disable=SC2148
 #
 # Snippet: db-admin
 #

--- a/terraform/userdata/20-puppet-client
+++ b/terraform/userdata/20-puppet-client
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck shell=bash
+# shellcheck disable=SC2148
 #
 # Snippet: puppet-client
 #

--- a/terraform/userdata/20-puppetmaster
+++ b/terraform/userdata/20-puppetmaster
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck shell=bash
+# shellcheck disable=SC2148
 #
 # Snippet: puppetmaster
 #
@@ -26,7 +26,7 @@ puppet apply -e 'notify { "Hello from Puppet": }'
 
 # Create a workdir
 mkdir -p /var/govuk
-cd /var/govuk || return
+cd /var/govuk
 
 # Get git and checkout govuk-aws
 apt-get -y install git

--- a/terraform/userdata/20-puppetmaster-integration
+++ b/terraform/userdata/20-puppetmaster-integration
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck shell=bash
+# shellcheck disable=SC2148
 #
 # Snippet: puppetmaster
 #
@@ -26,7 +26,7 @@ puppet apply -e 'notify { "Hello from Puppet": }'
 
 # Create a workdir
 mkdir -p /var/govuk
-cd /var/govuk || return
+cd /var/govuk
 
 # Get git and checkout govuk-aws
 apt-get -y install git

--- a/terraform/userdata/20-puppetmaster-production
+++ b/terraform/userdata/20-puppetmaster-production
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck shell=bash
+# shellcheck disable=SC2148
 #
 # Snippet: puppetmaster
 #
@@ -26,7 +26,7 @@ puppet apply -e 'notify { "Hello from Puppet": }'
 
 # Create a workdir
 mkdir -p /var/govuk
-cd /var/govuk || return
+cd /var/govuk
 
 # Get git and checkout govuk-aws
 apt-get -y install git

--- a/terraform/userdata/20-puppetmaster-staging
+++ b/terraform/userdata/20-puppetmaster-staging
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck shell=bash
+# shellcheck disable=SC2148
 #
 # Snippet: puppetmaster
 #
@@ -26,7 +26,7 @@ puppet apply -e 'notify { "Hello from Puppet": }'
 
 # Create a workdir
 mkdir -p /var/govuk
-cd /var/govuk || return
+cd /var/govuk
 
 # Get git and checkout govuk-aws
 apt-get -y install git

--- a/terraform/userdata/20-puppetmaster-training
+++ b/terraform/userdata/20-puppetmaster-training
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck shell=bash
+# shellcheck disable=SC2148
 #
 # Snippet: puppetmaster
 #
@@ -26,7 +26,7 @@ puppet apply -e 'notify { "Hello from Puppet": }'
 
 # Create a workdir
 mkdir -p /var/govuk
-cd /var/govuk || return
+cd /var/govuk
 
 # Get git and checkout govuk-aws
 apt-get -y install git

--- a/terraform/userdata/30-deploy-apps
+++ b/terraform/userdata/30-deploy-apps
@@ -1,5 +1,5 @@
 # This is a snippet so should not have a shebang
-# shellcheck shell=bash
+# shellcheck disable=SC2148
 #
 # Snippet: deploy-apps
 #

--- a/tools/build-terraform-project.sh
+++ b/tools/build-terraform-project.sh
@@ -74,7 +74,7 @@ SECRET_COMMON_PROJECT_DATA="${PROJECT_DATA_DIR}/common.secret.tfvars"
 STACK_PROJECT_DATA="${PROJECT_DATA_DIR}/${STACKNAME}.tfvars"
 SECRET_PROJECT_DATA="${PROJECT_DATA_DIR}/${STACKNAME}.secret.tfvars"
 
-if [[ -z $(command -v terraform) ]]; then
+if [[ -z $(which terraform) ]]; then
   log_error 'Terraform not found, please make sure it is installed.'
 fi
 
@@ -151,10 +151,10 @@ for TFVAR_FILE in "$COMMON_DATA" \
                   "$SECRET_PROJECT_DATA"
 do
   if [[ -f $TFVAR_FILE ]] &&
-     {
+     (
       [[ "$TFVAR_FILE" == "$SECRET_PROJECT_DATA" ]] ||
       [[ "$TFVAR_FILE" == "$SECRET_COMMON_PROJECT_DATA" ]]
-     } ; then
+     ) ; then
     TO_RUN="$TO_RUN -var-file <(sops -d $TFVAR_FILE)"
   elif [[ -f $TFVAR_FILE ]]; then
     TO_RUN="$TO_RUN -var-file $TFVAR_FILE"

--- a/tools/terraform-format.sh
+++ b/tools/terraform-format.sh
@@ -5,7 +5,7 @@ for file in "$@"; do
   lint=$(terraform fmt -write=false -diff=true -list=true "${file}")
   failed=""
 
-  if [ -n "${lint}" ]; then
+  if [ ! -z "${lint}" ]; then
     failed="yes"
     echo -e "Your code is not in a canonical format:\n"
     echo "${lint}"

--- a/tools/update-docs.sh
+++ b/tools/update-docs.sh
@@ -2,7 +2,7 @@
 #
 # Update docs across all projects and modules
 #
-if [[ ! $(command -v terraform-docs) ]]; then
+if [[ ! $(which terraform-docs) ]]; then
   echo "Must install terraform-docs: https://github.com/segmentio/terraform-docs"
   exit 1
 fi


### PR DESCRIPTION
Reverts alphagov/govuk-aws#1233

We can revert this revert later today or tomorrow.

Reverting now because we need to deploy #1235 to up the cache and calculators frontend instance count. The current terraform plan wants to update the launch configuration because the user data changed because of these shell check fixed. But this requires admin permissions. I would deploy this, but I don't currently have a work laptop with which to access AWS (they took it away again), and PowerUsers can't deploy IAM stuff. And there's no other admins on my team right now. For some reason UserData requires IAM?

So let's unblock cache instance scaling by reverting this temporarily. Then the only thing Terraform should try to do is increase the ASG size.

I fully expect Jenkins to fail because we're adding back shellchefk with this revert, but we removed it from govuk-jenkinslib. I hope to be able to override the required green check.