### PR TITLE
Change Policy To Allow DocDB Data Sync To Work in Integration and Staging

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/writer.tf
+++ b/terraform/projects/infra-database-backups-bucket/writer.tf
@@ -291,6 +291,7 @@ data "aws_iam_policy_document" "dbadmin_database_backups_writer" {
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mongo-licensing*",
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mysql*",
       "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*postgres*",
+      "arn:aws:s3:::${aws_s3_bucket.database_backups.id}/*mongo-normal*",
     ]
   }
 }


### PR DESCRIPTION
In order for the DocumentDB Asset Manager data sync to function correctly
we need the "blue-db-admin" role to be able to write to the "mongo-normal" prefix.