### PR TITLE
Change instance type to r4.2xlarge

### DIFF
--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -215,7 +215,7 @@ resource "aws_launch_template" "knowledge-graph_launch_template" {
   name     = "knowledge-graph_launch-template"
   image_id = "${data.aws_ami.neo4j_community_ami.id}"
 
-  instance_type = "m5.2xlarge"
+  instance_type = "r4.2xlarge"
 
   vpc_security_group_ids = ["${data.terraform_remote_state.infra_security_groups.sg_knowledge-graph_id}"]
 


### PR DESCRIPTION
The Knowledge Graph is running out of memory on start-up when it generates the data it needs. Changing the instance type from `m5.2xlarge` to `r4.2xlarge` doubles the amount of RAM available (from 32GB to 64GB), whilst minimally increasing cost.