### PR TITLE
Concourse CI: Use Homebrew 2.2.5 that has sped up `brew update`

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -33,7 +33,7 @@ jobs:
             type: docker-image
             source:
               repository: homebrew/brew
-              tag: 2.2.4
+              tag: 2.2.5
           inputs:
             - name: govuk-aws-pr
               path: repo


### PR DESCRIPTION
- Homebrew 2.2.5 has improvements that reduce the time that `brew update(-reset)` takes from 2 minutes waiting for git to unshallow the clone of Homebrew/linuxbrew-core: https://github.com/Homebrew/brew/commit/243e703700fd0c06aea982e5b2b7f45b6dedcabb