### PR TITLE
Allow monitoring to list (but not read) Fastly logs.

### DIFF
--- a/terraform/projects/app-monitoring/main.tf
+++ b/terraform/projects/app-monitoring/main.tf
@@ -261,6 +261,32 @@ resource "aws_iam_role_policy_attachment" "monitoring_iam_role_policy_attachment
   policy_arn = "${aws_iam_policy.monitoring-iam_policy.arn}"
 }
 
+resource "aws_iam_policy" "list_fastly_logs" {
+  name        = "fastly-logs-${var.aws_environment}-logs-lister-policy"
+  description = "Allows listing (but not reading) the fastly-logs buckets. For use by monitoring."
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": [
+                "arn:aws:s3:::govuk-${var.aws_environment}-fastly-logs",
+                "arn:aws:s3:::govuk-${var.aws_environment}-transition-fastly-logs"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "monitoring_can_list_fastly_logs" {
+  role       = "${module.monitoring.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.list_fastly_logs.arn}"
+}
+
 resource "aws_route53_record" "external_service_record" {
   zone_id = "${data.aws_route53_zone.external.zone_id}"
   name    = "alert.${var.external_domain_name}"


### PR DESCRIPTION
This is for alphagov/govuk-puppet#10113.

Relevant plan output (using Staging as an example):

```
  + aws_iam_policy.list_fastly_logs
      id:                                        <computed>
      arn:                                       <computed>
      description:                               "Allows listing (but not reading) the fastly-logs buckets. For use by monitoring."
      name:                                      "fastly-logs-staging-logs-lister-policy"
      path:                                      "/"
      policy:                                    "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": \"s3:ListBucket\",\n            \"Resource\": [\n                \"arn:aws:s3:::govuk-staging-fastly-logs\",\n                \"arn:aws:s3:::govuk-staging-transition-fastly-logs\"\n            ]\n        }\n    ]\n}\n"

  + aws_iam_role_policy_attachment.monitoring_can_list_fastly_logs
      id:                                        <computed>
      policy_arn:                                "${aws_iam_policy.list_fastly_logs.arn}"
      role:                                      "blue-monitoring"
```

The contents of the `policy` field in the above diff looks like this when unescaped:

```
{
    "Version": "2012-10-17",
    "Statement": [ 
        {
            "Effect": "Allow",
            "Action": "s3:ListBucket",
            "Resource": [ 
                "arn:aws:s3:::govuk-staging-fastly-logs",
                "arn:aws:s3:::govuk-staging-transition-fastly-logs"
            ]
        }
    ]
}
```