### PR TITLE
Add ability to monitor fastly_logs Athena databases

### DIFF
--- a/terraform/policies/fastly_logs_athena_monitoring_policy.tpl
+++ b/terraform/policies/fastly_logs_athena_monitoring_policy.tpl
@@ -1,0 +1,50 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+       "Effect":"Allow",
+       "Action":[
+          "athena:*"
+       ],
+       "Resource":[
+          "*"
+       ]
+    },
+    {
+       "Effect":"Allow",
+       "Action":[
+          "glue:GetTable",
+          "glue:GetPartition",
+          "glue:GetPartitions"
+       ],
+       "Resource":[
+          "*"
+       ]
+    },
+    {
+       "Effect":"Allow",
+       "Action":[
+          "s3:GetObject",
+          "s3:ListBucket"
+       ],
+       "Resource":[
+          "${in_bucket_arn}*"
+       ]
+    },
+    {
+       "Effect":"Allow",
+       "Action":[
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads",
+          "s3:ListMultipartUploadParts",
+          "s3:AbortMultipartUpload",
+          "s3:PutObject"
+       ],
+       "Resource":[
+          "${out_bucket_arn}*"
+       ]
+    }
+  ]
+}

--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -53,28 +53,6 @@ resource "aws_s3_bucket" "fastly_logs" {
   }
 }
 
-resource "aws_s3_bucket" "transition_fastly_logs" {
-  bucket = "govuk-${var.aws_environment}-transition-fastly-logs"
-
-  tags {
-    Name            = "govuk-${var.aws_environment}-transition-fastly-logs"
-    aws_environment = "${var.aws_environment}"
-  }
-
-  logging {
-    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-    target_prefix = "s3/govuk-${var.aws_environment}-transition-fastly-logs/"
-  }
-
-  lifecycle_rule {
-    enabled = true
-
-    expiration {
-      days = 30
-    }
-  }
-}
-
 # We require a user for Fastly to write to S3 buckets
 resource "aws_iam_user" "logs_writer" {
   name = "govuk-${var.aws_environment}-fastly-logs-writer"
@@ -98,30 +76,6 @@ data "template_file" "logs_writer_policy_template" {
   vars {
     aws_environment = "${var.aws_environment}"
     bucket          = "${aws_s3_bucket.fastly_logs.id}"
-  }
-}
-
-# We require a user for transition to read from S3 buckets
-resource "aws_iam_user" "transition_downloader" {
-  name = "govuk-${var.aws_environment}-transition-downloader"
-}
-
-resource "aws_iam_policy" "transition_downloader" {
-  name   = "fastly-logs-${var.aws_environment}-transition-downloader-policy"
-  policy = "${data.template_file.transition_downloader_policy_template.rendered}"
-}
-
-resource "aws_iam_policy_attachment" "transition_downloader" {
-  name       = "transition-downloader-policy-attachment"
-  users      = ["${aws_iam_user.transition_downloader.name}"]
-  policy_arn = "${aws_iam_policy.transition_downloader.arn}"
-}
-
-data "template_file" "transition_downloader_policy_template" {
-  template = "${file("${path.module}/../../policies/transition_downloader_policy.tpl")}"
-
-  vars {
-    bucket_arn = "${aws_s3_bucket.transition_fastly_logs.arn}"
   }
 }
 
@@ -722,6 +676,55 @@ resource "aws_glue_catalog_table" "bouncer" {
     classification  = "json"
     compressionType = "gzip"
     typeOfDate      = "file"
+  }
+}
+
+# Configuration for transition lambda function that loads data from fastly logs
+# Athena databases and saves it back into S3
+
+resource "aws_s3_bucket" "transition_fastly_logs" {
+  bucket = "govuk-${var.aws_environment}-transition-fastly-logs"
+
+  tags {
+    Name            = "govuk-${var.aws_environment}-transition-fastly-logs"
+    aws_environment = "${var.aws_environment}"
+  }
+
+  logging {
+    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    target_prefix = "s3/govuk-${var.aws_environment}-transition-fastly-logs/"
+  }
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
+}
+
+# We require a user for transition to read from S3 buckets
+resource "aws_iam_user" "transition_downloader" {
+  name = "govuk-${var.aws_environment}-transition-downloader"
+}
+
+resource "aws_iam_policy" "transition_downloader" {
+  name   = "fastly-logs-${var.aws_environment}-transition-downloader-policy"
+  policy = "${data.template_file.transition_downloader_policy_template.rendered}"
+}
+
+resource "aws_iam_policy_attachment" "transition_downloader" {
+  name       = "transition-downloader-policy-attachment"
+  users      = ["${aws_iam_user.transition_downloader.name}"]
+  policy_arn = "${aws_iam_policy.transition_downloader.arn}"
+}
+
+data "template_file" "transition_downloader_policy_template" {
+  template = "${file("${path.module}/../../policies/transition_downloader_policy.tpl")}"
+
+  vars {
+    bucket_arn = "${aws_s3_bucket.transition_fastly_logs.arn}"
   }
 }
 

--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -679,6 +679,56 @@ resource "aws_glue_catalog_table" "bouncer" {
   }
 }
 
+# Configuration for monitoring the fastly logs Athena databases continue to be
+# queryable. This requires a dedicated user that can query athena and save
+# the queries results
+
+resource "aws_s3_bucket" "fastly_logs_monitoring" {
+  bucket = "govuk-${var.aws_environment}-fastly-logs-monitoring"
+
+  tags {
+    Name            = "govuk-${var.aws_environment}-fastly-logs-monitoring"
+    aws_environment = "${var.aws_environment}"
+  }
+
+  logging {
+    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    target_prefix = "s3/govuk-${var.aws_environment}-fastly-logs-monitoring/"
+  }
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+  }
+}
+
+resource "aws_iam_user" "athena_monitoring" {
+  name = "govuk-${var.aws_environment}-fastly-logs-athena-monitoring"
+}
+
+resource "aws_iam_policy" "athena_monitoring" {
+  name   = "fastly-logs-${var.aws_environment}-fastly-logs-athena-monitoring-policy"
+  policy = "${data.template_file.athena_monitoring_policy_template.rendered}"
+}
+
+resource "aws_iam_policy_attachment" "athena_monitoring" {
+  name       = "fastly-logs-${var.aws_environment}-fastly-logs-athena-monitoring-policy-attachment"
+  users      = ["${aws_iam_user.athena_monitoring.name}"]
+  policy_arn = "${aws_iam_policy.athena_monitoring.arn}"
+}
+
+data "template_file" "athena_monitoring_policy_template" {
+  template = "${file("${path.module}/../../policies/fastly_logs_athena_monitoring_policy.tpl")}"
+
+  vars {
+    out_bucket_arn = "${aws_s3_bucket.fastly_logs_monitoring.arn}"
+    in_bucket_arn  = "${aws_s3_bucket.fastly_logs.arn}"
+  }
+}
+
 # Configuration for transition lambda function that loads data from fastly logs
 # Athena databases and saves it back into S3
 


### PR DESCRIPTION
Trello: https://trello.com/c/93jgKiUX/1329-set-up-a-smoke-test-that-athena-is-still-operating-on-new-data

We want to have the means to monitor whether our fastly_logs athena
databases continue to return results, this is in response to a bad
deploy a few months ago where we discovered that the database was no
longer queryable.

To monitor Athena we need a user that has access to Athena, to AWS Glue
to access table details, to have read access to the bucket the data is
in and to have write access to a bucket to store results. The intention
is that this users credentials will be stored within Jenkins and
periodically a job will run that makes a query to Athena. This job will
be deemed successful if results can be pulled from the database.

This PR adds a new IAM user for this monitoring and creates a bucket
where results can be stored. The bucket has a short retention of 7 days
as I don't anticipate we'll have much (if any) use for the data it returns once
the query is completed. It then applies a policy so that this user can
access all the necessary resources.

I've applied this terraform to the test environment and it worked successfully.