### PR TITLE
Customise EBS volume size between environments

### DIFF
--- a/terraform/projects/app-apt/README.md
+++ b/terraform/projects/app-apt/README.md
@@ -18,6 +18,7 @@ Apt node
 | aws\_environment | AWS environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | ebs\_encrypted | Whether or not the EBS volume is encrypted | `string` | n/a | yes |
+| ebs\_volume\_size | EBS volume size | `string` | `"40"` | no |
 | elb\_external\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | external\_domain\_name | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -71,6 +71,12 @@ variable "instance_type" {
   default     = "t2.medium"
 }
 
+variable "ebs_volume_size" {
+  type        = "string"
+  description = "EBS volume size"
+  default     = "40"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -182,7 +188,7 @@ module "apt" {
 resource "aws_ebs_volume" "apt" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.apt_1_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = 40
+  size              = "${var.ebs_volume_size}"
   type              = "gp2"
 
   tags {


### PR DESCRIPTION
* We needed to increase the volume size in production as part of the Aptly migration.
* Aptly has more packages in Carrenza than in AWS and required a larger EBS volume to achieve feature parity.