### PR TITLE
Update docs for terraform-docs 0.8.2

### DIFF
--- a/terraform/modules/aws/alarms/alb/README.md
+++ b/terraform/modules/aws/alarms/alb/README.md
@@ -3,9 +3,9 @@
 This module creates the following CloudWatch alarms in the  
 AWS/ApplicationELB namespace:
 
-  - HTTPCode\_Target\_4XX\_Count greater than or equal to threshold  
-  - HTTPCode\_Target\_5XX\_Count greater than or equal to threshold  
-  - HTTPCode\_ELB\_4XX\_Count greater than or equal to threshold  
+  - HTTPCode\_Target\_4XX\_Count greater than or equal to threshold
+  - HTTPCode\_Target\_5XX\_Count greater than or equal to threshold
+  - HTTPCode\_ELB\_4XX\_Count greater than or equal to threshold
   - HTTPCode\_ELB\_5XX\_Count greater than or equal to threshold
 
 All metrics are measured during a period of 60 seconds and evaluated  

--- a/terraform/modules/aws/alarms/ec2/README.md
+++ b/terraform/modules/aws/alarms/ec2/README.md
@@ -3,8 +3,8 @@
 This module creates the following CloudWatch alarms in the  
 AWS/EC2 namespace:
 
-  - CPUUtilization greater than or equal to threshold threshold  
-  - StatusCheckFailed\_Instance greater than or equal to 1 (instance status  
+  - CPUUtilization greater than or equal to threshold threshold
+  - StatusCheckFailed\_Instance greater than or equal to 1 (instance status
     check failed)
 
 Alarms are created for all the instances that belong to a given  

--- a/terraform/modules/aws/alarms/elasticache/README.md
+++ b/terraform/modules/aws/alarms/elasticache/README.md
@@ -3,7 +3,7 @@
 This module creates the following CloudWatch alarms in the  
 AWS/ElastiCache namespace:
 
-  - CPUUtilization greater than or equal to threshold  
+  - CPUUtilization greater than or equal to threshold
   - FreeableMemory less than threshold
 
 All metrics are measured during a period of 60 seconds and evaluated  

--- a/terraform/modules/aws/alarms/elb/README.md
+++ b/terraform/modules/aws/alarms/elb/README.md
@@ -3,24 +3,24 @@
 This module creates the following CloudWatch alarms in the  
 AWS/ELB namespace:
 
-  - HTTPCode\_Backend\_4XX greater than or equal to threshold  
-  - HTTPCode\_Backend\_5XX greater than or equal to threshold  
-  - HTTPCode\_ELB\_4XX greater than or equal to threshold  
-  - HTTPCode\_ELB\_5XX greater than or equal to threshold  
-  - SurgeQueueLength greater than or equal to threshold  
+  - HTTPCode\_Backend\_4XX greater than or equal to threshold
+  - HTTPCode\_Backend\_5XX greater than or equal to threshold
+  - HTTPCode\_ELB\_4XX greater than or equal to threshold
+  - HTTPCode\_ELB\_5XX greater than or equal to threshold
+  - SurgeQueueLength greater than or equal to threshold
   - HealthyHostCount less than threshold
 
 All metrics are measured during a period of 60 seconds and evaluated  
 during 5 consecutive periods.
 
-HTTPCode\_\* metrics are only reported for HTTP listeners. These metrics  
+HTTPCode\_* metrics are only reported for HTTP listeners. These metrics  
 should encapsulate errors caused by high SurgeQueueLength values and  
 lack of healthy backends.
 
 For HTTP listeners we can disable SurgeQueueLength and HealthyHostCount  
-alarms. For TCP listeners, we should disable HTTPCode\_\* alarms.
+alarms. For TCP listeners, we should disable HTTPCode\_* alarms.
 
-To disable HTTPCode\_\* alarms, set the `httpcode_*_threshold` parameters to 0.  
+To disable HTTPCode\_* alarms, set the `httpcode_*_threshold` parameters to 0.  
 To disable the SurgeQueueLength alarm, set the `surgequeuelength_threshold`  
 parameter to 0.  
 To disable the HealthyHostCount alarm, set the `healthyhostcount_threshold`  

--- a/terraform/modules/aws/alarms/natgateway/README.md
+++ b/terraform/modules/aws/alarms/natgateway/README.md
@@ -3,7 +3,7 @@
 This module creates the following CloudWatch alarms in the  
 AWS/NATGateway namespace:
 
-  - ErrorPortAllocation greater than or equal to threshold  
+  - ErrorPortAllocation greater than or equal to threshold
   - PacketsDropCount greater than or equal to threshold
 
 All metrics are measured during a period of 60 seconds and evaluated  

--- a/terraform/modules/aws/alarms/rds/README.md
+++ b/terraform/modules/aws/alarms/rds/README.md
@@ -3,9 +3,9 @@
 This module creates the following CloudWatch alarms in the  
 AWS/RDS namespace:
 
-  - CPUUtilization greater than or equal to threshold  
-  - FreeableMemory less than threshold  
-  - FreeStorageSpace less than threshold  
+  - CPUUtilization greater than or equal to threshold
+  - FreeableMemory less than threshold
+  - FreeStorageSpace less than threshold
   - ReplicaLag greater than or equal to threshold
 
 All metrics are measured during a period of 60 seconds and evaluated  

--- a/terraform/modules/aws/cloudwatch_log_exporter/README.md
+++ b/terraform/modules/aws/cloudwatch_log_exporter/README.md
@@ -6,10 +6,10 @@ function and Kinesis Firehose.
 The lambda function filename needs to be provided and the  
 module will create a permission to listen to Log events and  
 a subscription to the specified log group. This function  
-should:  
-  - decompress the Cloudwatch log  
+should:
+  - decompress the Cloudwatch log
   - format the data, if needed, so the log entry can later be  
-parsed by a Logstash filter  
+parsed by a Logstash filter
   - send the log event to a Kinesis Firehose stream, that will  
 be configured to store the events in a S3 bucket
 

--- a/terraform/modules/aws/elasticache_redis_cluster/README.md
+++ b/terraform/modules/aws/elasticache_redis_cluster/README.md
@@ -13,7 +13,7 @@ Create a redis replication cluster and elasticache subnet group
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | default\_tags | Additional resource tags | `map` | `{}` | no |
-| elasticache\_node\_type | The node type to use. Must not be t.\* in order to use failover. | `string` | `"cache.m3.medium"` | no |
+| elasticache\_node\_type | The node type to use. Must not be t.* in order to use failover. | `string` | `"cache.m3.medium"` | no |
 | enable\_clustering | Set to true to enable clustering mode | `string` | `true` | no |
 | name | The common name for all the resources created by this module | `string` | n/a | yes |
 | security\_group\_ids | Security group IDs to apply to this cluster | `list` | n/a | yes |

--- a/terraform/modules/aws/iam/role_user/README.md
+++ b/terraform/modules/aws/iam/role_user/README.md
@@ -8,7 +8,7 @@ For instance, the following parameters allow the users 'user1' and 'user2'
 from the account ID 123456789000 to use the AWS Security Token Service  
 AssumeRole API action to gain AdministratorAccess permissions on our account:
 
-\*```
+```
 "role_name" = "myadmins"
 
 "role_policy_arns" = [
@@ -19,7 +19,6 @@ AssumeRole API action to gain AdministratorAccess permissions on our account:
   "arn:aws:iam::123456789000:user/user1",
   "arn:aws:iam::123456789000:user/user2",
 ]
-*
 ```
 
 ## Providers

--- a/terraform/modules/aws/iam/role_user/README.md
+++ b/terraform/modules/aws/iam/role_user/README.md
@@ -8,7 +8,7 @@ For instance, the following parameters allow the users 'user1' and 'user2'
 from the account ID 123456789000 to use the AWS Security Token Service  
 AssumeRole API action to gain AdministratorAccess permissions on our account:
 
-```
+\*```
 "role_name" = "myadmins"
 
 "role_policy_arns" = [
@@ -19,6 +19,7 @@ AssumeRole API action to gain AdministratorAccess permissions on our account:
   "arn:aws:iam::123456789000:user/user1",
   "arn:aws:iam::123456789000:user/user2",
 ]
+*
 ```
 
 ## Providers

--- a/terraform/modules/aws/iam/role_user/main.tf
+++ b/terraform/modules/aws/iam/role_user/main.tf
@@ -9,7 +9,7 @@
 * from the account ID 123456789000 to use the AWS Security Token Service
 * AssumeRole API action to gain AdministratorAccess permissions on our account:
 *
-*```
+* ```
 * "role_name" = "myadmins"
 *
 * "role_policy_arns" = [
@@ -20,7 +20,7 @@
 *   "arn:aws:iam::123456789000:user/user1",
 *   "arn:aws:iam::123456789000:user/user2",
 * ]
-*```
+* ```
 */
 variable "role_name" {
   type        = "string"

--- a/terraform/modules/aws/lb/README.md
+++ b/terraform/modules/aws/lb/README.md
@@ -7,17 +7,20 @@ The listeners and default actions are configured in the `listener_action`
 map. The keys are the listeners PROTOCOL:PORT parameters, and the values  
 are the PROTOCOL:PORT parameters of the default target group of that listener.
 
-```
+\*```
 listener_action = {
   "HTTP:80"   = "HTTP:8080"
   "HTTPS:443" = "HTTP:8080"
 }
-```This module creates the following CloudWatch alarms in the  
+*
+```
+
+This module creates the following CloudWatch alarms in the  
 AWS/ApplicationELB namespace:
 
-  - HTTPCode\_Target\_4XX\_Count greater than or equal to threshold  
-  - HTTPCode\_Target\_5XX\_Count greater than or equal to threshold  
-  - HTTPCode\_ELB\_4XX\_Count greater than or equal to threshold  
+  - HTTPCode\_Target\_4XX\_Count greater than or equal to threshold
+  - HTTPCode\_Target\_5XX\_Count greater than or equal to threshold
+  - HTTPCode\_ELB\_4XX\_Count greater than or equal to threshold
   - HTTPCode\_ELB\_5XX\_Count greater than or equal to threshold
 
 All metrics are measured during a period of 60 seconds and evaluated  

--- a/terraform/modules/aws/lb/README.md
+++ b/terraform/modules/aws/lb/README.md
@@ -7,12 +7,11 @@ The listeners and default actions are configured in the `listener_action`
 map. The keys are the listeners PROTOCOL:PORT parameters, and the values  
 are the PROTOCOL:PORT parameters of the default target group of that listener.
 
-\*```
+```
 listener_action = {
   "HTTP:80"   = "HTTP:8080"
   "HTTPS:443" = "HTTP:8080"
 }
-*
 ```
 
 This module creates the following CloudWatch alarms in the  

--- a/terraform/modules/aws/lb/main.tf
+++ b/terraform/modules/aws/lb/main.tf
@@ -8,12 +8,12 @@
 * map. The keys are the listeners PROTOCOL:PORT parameters, and the values
 * are the PROTOCOL:PORT parameters of the default target group of that listener.
 *
-*```
+* ```
 * listener_action = {
 *   "HTTP:80"   = "HTTP:8080"
 *   "HTTPS:443" = "HTTP:8080"
 * }
-*```
+* ```
 *
 * This module creates the following CloudWatch alarms in the
 * AWS/ApplicationELB namespace:

--- a/terraform/modules/aws/lb_listener_rules/README.md
+++ b/terraform/modules/aws/lb_listener_rules/README.md
@@ -6,11 +6,11 @@ an existing listener resource.
 If the parameter `autoscaling_group_name` is non empty, the module also creates an attachment  
 from each target group to the ASG with the specified name.
 
-Limitations:  
+Limitations:
  - The target group deregistration\_delay, health\_check\_interval and health\_check\_timeout  
-values can be configured with variables, but will be the same for all the target groups  
+values can be configured with variables, but will be the same for all the target groups
  - With Terraform we can't provide a 'count' or list for listener\_rule condition blocks,  
-so at the moment only one condition can be specified per rule  
+so at the moment only one condition can be specified per rule
  - At the moment this module only implements Host Header based rules
 
 ## Providers

--- a/terraform/modules/aws/network/private_subnet/README.md
+++ b/terraform/modules/aws/network/private_subnet/README.md
@@ -10,7 +10,7 @@ subnet and must be the same in both maps.
 For instance, to create two private subnets named "my\_subnet\_a"  
 and "my\_subnet\_b" on eu-west-1a and eu-west-1b, you can do:
 
-\*```
+```
 subnet_cidrs = {
   "my_subnet_a" = "10.0.0.0/24"
   "my_subnet_b" = "10.0.1.0/24"
@@ -20,7 +20,6 @@ subnet_availability_zones = {
   "my_subnet_a" = "eu-west-1a"
   "my_subnet_b" = "eu-west-1b"
 }
-*
 ```
 
 You can optionally provide a subnet\_nat\_gateways variable, indicating  

--- a/terraform/modules/aws/network/private_subnet/README.md
+++ b/terraform/modules/aws/network/private_subnet/README.md
@@ -3,14 +3,14 @@
 This module creates AWS private subnets on a given VPC, each one  
 with a route table and route table association.
 
-Subnet CIDR and AZ are specified in the maps `subnet_cidrs` and  
+Subnet CIDR and AZ are specified in the maps `subnet_cidrs` and
 `subnet_availability_zones`, where the key is the name of the  
 subnet and must be the same in both maps.
 
 For instance, to create two private subnets named "my\_subnet\_a"  
 and "my\_subnet\_b" on eu-west-1a and eu-west-1b, you can do:
 
-```
+\*```
 subnet_cidrs = {
   "my_subnet_a" = "10.0.0.0/24"
   "my_subnet_b" = "10.0.1.0/24"
@@ -20,7 +20,10 @@ subnet_availability_zones = {
   "my_subnet_a" = "eu-west-1a"
   "my_subnet_b" = "eu-west-1b"
 }
-```You can optionally provide a subnet\_nat\_gateways variable, indicating  
+*
+```
+
+You can optionally provide a subnet\_nat\_gateways variable, indicating  
 the NAT Gateway ID that a subnet can use. If specified, then a  
 route will also be added by this module, enabling Internet access. The  
 keys in subnet\_nat\_gateways that identify the subnet name must match the  
@@ -28,7 +31,7 @@ keys provided in subnet\_cidrs and subnet\_availability\_zones.
 
 If you provide subnet\_nat\_gateways, then subnet\_nat\_gateways\_length  
 must also be provided with the number of elements in the subnet\_nat\_gateways  
-map. This is necessary to get around a Terraform issue that prevents a  
+map. This is necessary to get around a Terraform issue that prevents a
 "count" from evaluating computed values. Probably referenced here:  
 https://github.com/hashicorp/terraform/issues/10857
 

--- a/terraform/modules/aws/network/private_subnet/main.tf
+++ b/terraform/modules/aws/network/private_subnet/main.tf
@@ -11,7 +11,7 @@
 * For instance, to create two private subnets named "my_subnet_a"
 * and "my_subnet_b" on eu-west-1a and eu-west-1b, you can do:
 *
-*```
+* ```
 * subnet_cidrs = {
 *   "my_subnet_a" = "10.0.0.0/24"
 *   "my_subnet_b" = "10.0.1.0/24"
@@ -21,7 +21,7 @@
 *   "my_subnet_a" = "eu-west-1a"
 *   "my_subnet_b" = "eu-west-1b"
 * }
-*```
+* ```
 *
 * You can optionally provide a subnet_nat_gateways variable, indicating
 * the NAT Gateway ID that a subnet can use. If specified, then a

--- a/terraform/modules/aws/network/public_subnet/README.md
+++ b/terraform/modules/aws/network/public_subnet/README.md
@@ -10,7 +10,7 @@ subnet and must be the same in both maps.
 For instance, to create two public subnets named "my\_subnet\_a"  
 and "my\_subnet\_b" on eu-west-1a and eu-west-1b, you can do:
 
-\*```
+```
 subnet_cidrs = {
   "my_subnet_a" = "10.0.0.0/24"
   "my_subnet_b" = "10.0.1.0/24"
@@ -20,7 +20,6 @@ subnet_availability_zones = {
   "my_subnet_a" = "eu-west-1a"
   "my_subnet_b" = "eu-west-1b"
 }
-*
 ```
 
 ## Providers

--- a/terraform/modules/aws/network/public_subnet/README.md
+++ b/terraform/modules/aws/network/public_subnet/README.md
@@ -3,14 +3,14 @@
 This module creates all resources necessary for an AWS public  
 subnet.
 
-Subnet CIDR and AZ are specified in the maps `subnet_cidrs` and  
+Subnet CIDR and AZ are specified in the maps `subnet_cidrs` and
 `subnet_availability_zones`, where the key is the name of the  
 subnet and must be the same in both maps.
 
 For instance, to create two public subnets named "my\_subnet\_a"  
 and "my\_subnet\_b" on eu-west-1a and eu-west-1b, you can do:
 
-```
+\*```
 subnet_cidrs = {
   "my_subnet_a" = "10.0.0.0/24"
   "my_subnet_b" = "10.0.1.0/24"
@@ -20,6 +20,7 @@ subnet_availability_zones = {
   "my_subnet_a" = "eu-west-1a"
   "my_subnet_b" = "eu-west-1b"
 }
+*
 ```
 
 ## Providers

--- a/terraform/modules/aws/network/public_subnet/main.tf
+++ b/terraform/modules/aws/network/public_subnet/main.tf
@@ -11,7 +11,7 @@
 * For instance, to create two public subnets named "my_subnet_a"
 * and "my_subnet_b" on eu-west-1a and eu-west-1b, you can do:
 *
-*```
+* ```
 * subnet_cidrs = {
 *   "my_subnet_a" = "10.0.0.0/24"
 *   "my_subnet_b" = "10.0.1.0/24"
@@ -21,7 +21,7 @@
 *   "my_subnet_a" = "eu-west-1a"
 *   "my_subnet_b" = "eu-west-1b"
 * }
-*```
+* ```
 */
 
 variable "default_tags" {

--- a/terraform/modules/aws/node_group/README.md
+++ b/terraform/modules/aws/node_group/README.md
@@ -32,7 +32,7 @@ to use with Application Load Balancers with the `instance_target_group_arns` var
 | asg\_max\_size | The autoscaling groups max\_size | `string` | `"1"` | no |
 | asg\_min\_size | The autoscaling groups max\_size | `string` | `"1"` | no |
 | asg\_notification\_topic\_arn | The Topic ARN for Autoscaling Group notifications to be sent to | `string` | `""` | no |
-| asg\_notification\_types | A list of Notification Types that trigger Autoscaling Group notifications. Acceptable values are documented in https://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_NotificationConfiguration.html | `list` | <pre>[<br>  "autoscaling:EC2_INSTANCE_LAUNCH",<br>  "autoscaling:EC2_INSTANCE_TERMINATE",<br>  "autoscaling:EC2_INSTANCE_LAUNCH_ERROR"<br>]<br></pre> | no |
+| asg\_notification\_types | A list of Notification Types that trigger Autoscaling Group notifications. Acceptable values are documented in https://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_NotificationConfiguration.html | `list` | <pre>[<br>  "autoscaling:EC2_INSTANCE_LAUNCH",<br>  "autoscaling:EC2_INSTANCE_TERMINATE",<br>  "autoscaling:EC2_INSTANCE_LAUNCH_ERROR"<br>]</pre> | no |
 | create\_asg\_notifications | Enable Autoscaling Group notifications | `string` | `true` | no |
 | create\_instance\_key | Whether to create a key pair for the instance launch configuration | `string` | `false` | no |
 | default\_tags | Additional resource tags | `map` | `{}` | no |

--- a/terraform/modules/aws/rds_instance/README.md
+++ b/terraform/modules/aws/rds_instance/README.md
@@ -21,7 +21,7 @@ Create an RDS instance
 | default\_tags | Additional resource tags | `map` | `{}` | no |
 | engine\_name | RDS engine (eg mysql, postgresql) | `string` | `""` | no |
 | engine\_version | Which version of MySQL to use (eg 5.5.46) | `string` | `""` | no |
-| event\_categories | A list of event categories for a SourceType that you want to subscribe to. See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide//USER_Events.html | `list` | <pre>[<br>  "availability",<br>  "deletion",<br>  "failure",<br>  "low storage"<br>]<br></pre> | no |
+| event\_categories | A list of event categories for a SourceType that you want to subscribe to. See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide//USER_Events.html | `list` | <pre>[<br>  "availability",<br>  "deletion",<br>  "failure",<br>  "low storage"<br>]</pre> | no |
 | event\_sns\_topic\_arn | The SNS topic to send events to. | `string` | `""` | no |
 | instance\_class | The instance type of the RDS instance. | `string` | `"db.t1.micro"` | no |
 | instance\_name | The RDS Instance Name. | `string` | `""` | no |

--- a/terraform/projects/app-elasticsearch6/README.md
+++ b/terraform/projects/app-elasticsearch6/README.md
@@ -5,17 +5,17 @@ Managed Elasticsearch 6 cluster
 This project has two gotchas, where we work around things terraform  
 doesn't support:
 
-- Deploying the cluster across 3 availability zones: terraform has  
-  some built-in validation which rejects using 3 master nodes and 3  
-  data nodes across 3 availability zones.  To provision a new  
-  cluster, only use two of everything, then bump the numbers in the  
-  AWS console and in the terraform variables - it won't complain  
+- Deploying the cluster across 3 availability zones: terraform has
+  some built-in validation which rejects using 3 master nodes and 3
+  data nodes across 3 availability zones.  To provision a new
+  cluster, only use two of everything, then bump the numbers in the
+  AWS console and in the terraform variables - it won't complain
   when you next plan.
 
   https://github.com/terraform-providers/terraform-provider-aws/issues/7504
 
-- Configuring a snapshot repository: terraform doesn't support this,  
-  and as far as I can tell doesn't have any plans to.  There's a  
+- Configuring a snapshot repository: terraform doesn't support this,
+  and as far as I can tell doesn't have any plans to.  There's a
   Python script in this directory which sets those up.
 
 ## Providers

--- a/terraform/projects/app-shared-documentdb/README.md
+++ b/terraform/projects/app-shared-documentdb/README.md
@@ -1,6 +1,6 @@
 ## Project: app-shared-documentdb
 
-Shared DocumentDB to support the following apps:  
+Shared DocumentDB to support the following apps:
   1. asset-manager
 
 ## Providers

--- a/terraform/projects/infra-artefact-bucket/README.md
+++ b/terraform/projects/infra-artefact-bucket/README.md
@@ -12,12 +12,12 @@ to write to "deployed-to-environment" branches
 
 artefact\_reader: used by instances to fetch artefacts
 
-This module creates the following.  
-     - AWS SNS topic  
-     - AWS S3 Bucket event  
-     - AWS S3 Bucket policy.  
-     - AWS Lambda function.  
-     - AWS SNS subscription  
+This module creates the following.
+     - AWS SNS topic
+     - AWS S3 Bucket event
+     - AWS S3 Bucket policy.
+     - AWS Lambda function.
+     - AWS SNS subscription
      - AWS IAM roles and polisis for SNS and Lambda.
 
 ## Providers

--- a/terraform/projects/infra-artefact-bucket/main.tf
+++ b/terraform/projects/infra-artefact-bucket/main.tf
@@ -1,5 +1,5 @@
 /**
-*  ## Project: artefact-bucket
+* ## Project: artefact-bucket
 *
 * This creates 3 S3 buckets:
 *

--- a/terraform/projects/infra-govuk-cdn-logs-monitor-bucket/README.md
+++ b/terraform/projects/infra-govuk-cdn-logs-monitor-bucket/README.md
@@ -1,6 +1,6 @@
 ## Project: infra-govuk-cdn-logs-monitor-bucket
 
-Stores data that is being archived due to the retirement of  
+Stores data that is being archived due to the retirement of
 [govuk-cdn-logs-monitor](https://github.com/alphagov/govuk-cdn-logs-monitor).  
 The intention is for this to be temporary and data won't be added to this  
 after archiving. So if you're reading this in June 2019 this is pretty safe  

--- a/terraform/projects/infra-monitoring/README.md
+++ b/terraform/projects/infra-monitoring/README.md
@@ -1,11 +1,11 @@
 ## Module: projects/infra-monitoring
 
-Create resources to manage infrastructure and app monitoring:  
-  - Create an S3 bucket which allows AWS infrastructure to send logs to, for  
-    instance, ELB logs  
-  - Create resources to export CloudWatch log groups to S3 via Lambda-Kinesis\_Firehose  
-  - Create SNS topic to send infrastructure alerts, and a SQS queue that subscribes to  
-    the topic  
+Create resources to manage infrastructure and app monitoring:
+  - Create an S3 bucket which allows AWS infrastructure to send logs to, for
+    instance, ELB logs
+  - Create resources to export CloudWatch log groups to S3 via Lambda-Kinesis\_Firehose
+  - Create SNS topic to send infrastructure alerts, and a SQS queue that subscribes to
+    the topic
   - Create an IAM user which allows Terraboard to read Terraform state files from S3
 
 ## Providers

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -1,7 +1,7 @@
 ## Project: infra-public-services
 
-This project adds global resources for app components:  
-  - public facing LBs and DNS entries  
+This project adds global resources for app components:
+  - public facing LBs and DNS entries
   - internal DNS entries
 
 ## Providers

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -20,7 +20,7 @@ Manage the security groups for the entire infrastructure
 | carrenza\_env\_ips | An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox. | `list` | `[]` | no |
 | carrenza\_integration\_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | `list` | n/a | yes |
 | carrenza\_production\_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | `list` | n/a | yes |
-| carrenza\_rabbitmq\_ips | An array of CIDR blocks that will be allowed to federate with the rabbitmq nodes. | `list` | <pre>[<br>  ""<br>]<br></pre> | no |
+| carrenza\_rabbitmq\_ips | An array of CIDR blocks that will be allowed to federate with the rabbitmq nodes. | `list` | <pre>[<br>  ""<br>]</pre> | no |
 | carrenza\_staging\_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | `list` | n/a | yes |
 | carrenza\_vpn\_subnet\_cidr | The Carrenza VPN subnet CIDR | `list` | `[]` | no |
 | concourse\_aws\_account\_id | AWS account ID which contains the Concourse role | `string` | n/a | yes |

--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -1,10 +1,10 @@
 ## Module: projects/infra-security
 
-Infrastructure security settings:  
- - Create admin role for trusted users from GDS proxy account  
- - Create users role for trusted users from GDS proxy account  
- - Default IAM password policy  
- - Default SSH key  
+Infrastructure security settings:
+ - Create admin role for trusted users from GDS proxy account
+ - Create users role for trusted users from GDS proxy account
+ - Default IAM password policy
+ - Default SSH key
  - SOPS KMS key
 
 ## Providers

--- a/terraform/projects/infra-stack-dns-zones/README.md
+++ b/terraform/projects/infra-stack-dns-zones/README.md
@@ -5,7 +5,7 @@ This module creates the internal and external DNS zones used by our stacks.
 When we select to create a DNS zone, the domain name and ID of the zone that  
 manages the root domain needs to be provided to register the DNS delegation  
 and NS servers of the created zone. The domain name of the new zone is created  
-from the variables provided as <stackname>.<root\_domain\_internal\|external\_name>
+from the variables provided as <stackname>.<root\_domain\_internal|external\_name>
 
 We can't create a internal DNS zone per stack because on AWS we can't overlap  
 internal domain names. Instead we use the same internal zone for all the sacks  


### PR DESCRIPTION
In #1245 I'm seeing a failed build due to docs not matching expected output. This failure seems to be because terraform-docs has had a new release (0.8.2) rather the PR contents so this is a separate commit to fix the issues we have with the new version.

/cc @sarahseewhy @sengi 