### PR TITLE
Install zip utilities on Knowledge Graph machine

### DIFF
--- a/terraform/projects/app-knowledge-graph/userdata.tpl
+++ b/terraform/projects/app-knowledge-graph/userdata.tpl
@@ -28,6 +28,9 @@ sudo add-apt-repository ppa:deadsnakes/ppa -y && sudo apt-get update
 sudo apt-get install -y python3.6
 sudo apt install -y python3-pip
 
+# Install zip and unzip utilities
+sudo apt install -y zip unzip
+
 sudo su - ubuntu
 
 # Create Python 3.6 virtual environment


### PR DESCRIPTION
This PR installs `zip` and `unzip` on the Knowledge Graph machine. These will be used to unzip a JAR file, amend its contents, then re-zip back to a JAR file.