### PR TITLE
Adding slow query to postgres

### DIFF
--- a/terraform/projects/app-content-data-api-postgresql/main.tf
+++ b/terraform/projects/app-content-data-api-postgresql/main.tf
@@ -137,6 +137,22 @@ module "content-data-api-postgresql-primary_rds_instance" {
   event_sns_topic_arn  = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
   skip_final_snapshot  = "${var.skip_final_snapshot}"
   snapshot_identifier  = "${var.snapshot_identifier}"
+  parameter_group_name = "${aws_db_parameter_group.parameter_group.name}"
+}
+
+resource "aws_db_parameter_group" "parameter_group" {
+  name   = "rds-pg"
+  family = "postgres9.6"
+
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "10000"
+  }
+
+  parameter {
+    name  = "log_statement"
+    value = "all"
+  }
 }
 
 resource "aws_route53_record" "service_record" {

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -115,6 +115,22 @@ module "postgresql-primary_rds_instance" {
   event_sns_topic_arn   = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
   skip_final_snapshot   = "${var.skip_final_snapshot}"
   snapshot_identifier   = "${var.snapshot_identifier}"
+  parameter_group_name  = "${aws_db_parameter_group.parameter_group.name}"
+}
+
+resource "aws_db_parameter_group" "parameter_group" {
+  name   = "rds-pg"
+  family = "postgres9.6"
+
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "10000"
+  }
+
+  parameter {
+    name  = "log_statement"
+    value = "all"
+  }
 }
 
 resource "aws_route53_record" "service_record" {

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -155,6 +155,7 @@ module "postgresql-standby_rds_instance" {
   replicate_source_db        = "${module.postgresql-primary_rds_instance.rds_instance_id}"
   event_sns_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
   skip_final_snapshot        = "${var.skip_final_snapshot}"
+  parameter_group_name       = "${aws_db_parameter_group.parameter_group.name}"
 }
 
 resource "aws_route53_record" "replica_service_record" {

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -140,6 +140,7 @@ module "transition-postgresql-standby_rds_instance" {
   replicate_source_db        = "${module.transition-postgresql-primary_rds_instance.rds_instance_id}"
   event_sns_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
   skip_final_snapshot        = "${var.skip_final_snapshot}"
+  parameter_group_name       = "${aws_db_parameter_group.parameter_group.name}"
 }
 
 resource "aws_route53_record" "replica_service_record" {

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -87,21 +87,37 @@ data "aws_route53_zone" "internal" {
 module "transition-postgresql-primary_rds_instance" {
   source = "../../modules/aws/rds_instance"
 
-  name                = "${var.stackname}-transition-postgresql-primary"
-  engine_name         = "postgres"
-  engine_version      = "9.6"
-  default_tags        = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "transition_postgresql_primary")}"
-  subnet_ids          = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
-  username            = "${var.username}"
-  password            = "${var.password}"
-  allocated_storage   = "120"
-  instance_class      = "${var.instance_type}"
-  instance_name       = "${var.stackname}-transition-postgresql-primary"
-  multi_az            = "${var.multi_az}"
-  security_group_ids  = ["${data.terraform_remote_state.infra_security_groups.sg_transition-postgresql-primary_id}"]
-  event_sns_topic_arn = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
-  skip_final_snapshot = "${var.skip_final_snapshot}"
-  snapshot_identifier = "${var.snapshot_identifier}"
+  name                 = "${var.stackname}-transition-postgresql-primary"
+  engine_name          = "postgres"
+  engine_version       = "9.6"
+  default_tags         = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "transition_postgresql_primary")}"
+  subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
+  username             = "${var.username}"
+  password             = "${var.password}"
+  allocated_storage    = "120"
+  instance_class       = "${var.instance_type}"
+  instance_name        = "${var.stackname}-transition-postgresql-primary"
+  multi_az             = "${var.multi_az}"
+  security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_transition-postgresql-primary_id}"]
+  event_sns_topic_arn  = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot  = "${var.skip_final_snapshot}"
+  snapshot_identifier  = "${var.snapshot_identifier}"
+  parameter_group_name = "${aws_db_parameter_group.parameter_group.name}"
+}
+
+resource "aws_db_parameter_group" "parameter_group" {
+  name   = "rds-pg"
+  family = "postgres9.6"
+
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "10000"
+  }
+
+  parameter {
+    name  = "log_statement"
+    value = "all"
+  }
 }
 
 resource "aws_route53_record" "service_record" {


### PR DESCRIPTION
Enable slow query logging on:

- content data api
- postgresql primary
- postgresql standby
- transition primary
- transition standby

This well log queries which run longer than 10 seconds, which will aid in diagnosis of problems.  This feature existed in pre-aws migration environments

Pair: @smford & @sarahseewhy 