### PR TITLE
Fix rds param groups postgres

### DIFF
--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -84,6 +84,21 @@ data "aws_route53_zone" "internal" {
   private_zone = true
 }
 
+resource "aws_db_parameter_group" "app_transition_pg" {
+  name_prefix = "app-transition-pg-"
+  family      = "postgres9.6"
+
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "10000"
+  }
+
+  parameter {
+    name  = "log_statement"
+    value = "all"
+  }
+}
+
 module "transition-postgresql-primary_rds_instance" {
   source = "../../modules/aws/rds_instance"
 
@@ -102,22 +117,7 @@ module "transition-postgresql-primary_rds_instance" {
   event_sns_topic_arn  = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
   skip_final_snapshot  = "${var.skip_final_snapshot}"
   snapshot_identifier  = "${var.snapshot_identifier}"
-  parameter_group_name = "${aws_db_parameter_group.parameter_group.name}"
-}
-
-resource "aws_db_parameter_group" "parameter_group" {
-  name   = "rds-pg"
-  family = "postgres9.6"
-
-  parameter {
-    name  = "log_min_duration_statement"
-    value = "10000"
-  }
-
-  parameter {
-    name  = "log_statement"
-    value = "all"
-  }
+  parameter_group_name = "${aws_db_parameter_group.app_transition_pg.name}"
 }
 
 resource "aws_route53_record" "service_record" {
@@ -140,7 +140,7 @@ module "transition-postgresql-standby_rds_instance" {
   replicate_source_db        = "${module.transition-postgresql-primary_rds_instance.rds_instance_id}"
   event_sns_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
   skip_final_snapshot        = "${var.skip_final_snapshot}"
-  parameter_group_name       = "${aws_db_parameter_group.parameter_group.name}"
+  parameter_group_name       = "${aws_db_parameter_group.app_transition_pg.name}"
 }
 
 resource "aws_route53_record" "replica_service_record" {


### PR DESCRIPTION
Fix param group settings for app-transition and app-postgresql RDS instances

- Remove generic parameter_group named parameter group
- Creating a shared parameter group for primary and secondary databases as we will want them to be the same

