### PR TITLE
Enable storage autoscaling of RDS instances

### DIFF
--- a/terraform/modules/aws/rds_instance/README.md
+++ b/terraform/modules/aws/rds_instance/README.md
@@ -26,7 +26,7 @@ Create an RDS instance
 | instance\_class | The instance type of the RDS instance. | `string` | `"db.t1.micro"` | no |
 | instance\_name | The RDS Instance Name. | `string` | `""` | no |
 | maintenance\_window | The window to perform maintenance in. | `string` | `"Mon:04:00-Mon:06:00"` | no |
-| max\_allocated\_storage | current maximum storage in GB that AWS can autoscale the RDS storage to, 0 means disabled autoscaling | `string` | `"0"` | no |
+| max\_allocated\_storage | current maximum storage in GB that AWS can autoscale the RDS storage to, 0 means disabled autoscaling | `string` | `"100"` | no |
 | multi\_az | Specifies if the RDS instance is multi-AZ | `string` | `true` | no |
 | name | The common name for all the resources created by this module | `string` | n/a | yes |
 | parameter\_group\_name | Name of the parameter group to make the instance a member of. | `string` | `""` | no |

--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -53,7 +53,7 @@ variable "allocated_storage" {
 variable "max_allocated_storage" {
   type        = "string"
   description = "current maximum storage in GB that AWS can autoscale the RDS storage to, 0 means disabled autoscaling"
-  default     = "0"
+  default     = "100"
 }
 
 variable "storage_type" {

--- a/terraform/projects/app-content-data-api-postgresql/main.tf
+++ b/terraform/projects/app-content-data-api-postgresql/main.tf
@@ -132,23 +132,24 @@ resource "aws_db_parameter_group" "content_data_api" {
 }
 
 module "content-data-api-postgresql-primary_rds_instance" {
-  source               = "../../modules/aws/rds_instance"
-  name                 = "${var.stackname}-content-data-api-postgresql-primary"
-  parameter_group_name = "${aws_db_parameter_group.content_data_api.name}"
-  engine_name          = "postgres"
-  engine_version       = "9.6"
-  default_tags         = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "content_data_api_postgresql_primary")}"
-  subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
-  username             = "${var.username}"
-  password             = "${var.password}"
-  allocated_storage    = "1024"
-  instance_class       = "${var.instance_type}"
-  instance_name        = "${var.stackname}-content-data-api-postgresql-primary"
-  multi_az             = "${var.multi_az}"
-  security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_content-data-api-postgresql-primary_id}"]
-  event_sns_topic_arn  = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
-  skip_final_snapshot  = "${var.skip_final_snapshot}"
-  snapshot_identifier  = "${var.snapshot_identifier}"
+  source                = "../../modules/aws/rds_instance"
+  name                  = "${var.stackname}-content-data-api-postgresql-primary"
+  parameter_group_name  = "${aws_db_parameter_group.content_data_api.name}"
+  engine_name           = "postgres"
+  engine_version        = "9.6"
+  default_tags          = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "content_data_api_postgresql_primary")}"
+  subnet_ids            = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
+  username              = "${var.username}"
+  password              = "${var.password}"
+  allocated_storage     = "1024"
+  max_allocated_storage = "1100"
+  instance_class        = "${var.instance_type}"
+  instance_name         = "${var.stackname}-content-data-api-postgresql-primary"
+  multi_az              = "${var.multi_az}"
+  security_group_ids    = ["${data.terraform_remote_state.infra_security_groups.sg_content-data-api-postgresql-primary_id}"]
+  event_sns_topic_arn   = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot   = "${var.skip_final_snapshot}"
+  snapshot_identifier   = "${var.snapshot_identifier}"
 }
 
 resource "aws_route53_record" "service_record" {

--- a/terraform/projects/app-mysql/README.md
+++ b/terraform/projects/app-mysql/README.md
@@ -13,6 +13,7 @@ RDS Mysql Primary instance
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
+| allocated\_storage | Defines the AWS RDS storage capacity, in gigabytes. | `string` | `"100"` | no |
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | cloudwatch\_log\_retention | Number of days to retain Cloudwatch logs for | `string` | n/a | yes |
@@ -31,7 +32,6 @@ RDS Mysql Primary instance
 | skip\_final\_snapshot | Set to true to NOT create a final snapshot when the cluster is deleted. | `string` | n/a | yes |
 | snapshot\_identifier | Specifies whether or not to create the database from this snapshot | `string` | `""` | no |
 | stackname | Stackname | `string` | n/a | yes |
-| storage\_size | Defines the AWS RDS storage capacity, in gigabytes. | `string` | `"100"` | no |
 | username | Mysql username | `string` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -45,7 +45,7 @@ variable "snapshot_identifier" {
   default     = ""
 }
 
-variable "storage_size" {
+variable "allocated_storage" {
   type        = "string"
   description = "Defines the AWS RDS storage capacity, in gigabytes."
   default     = "100"
@@ -101,7 +101,7 @@ module "mysql_primary_rds_instance" {
   subnet_ids            = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
   username              = "${var.username}"
   password              = "${var.password}"
-  allocated_storage     = "${var.storage_size}"
+  allocated_storage     = "${var.allocated_storage}"
   max_allocated_storage = "${var.max_allocated_storage}"
   instance_class        = "${var.instance_type}"
   security_group_ids    = ["${data.terraform_remote_state.infra_security_groups.sg_mysql-primary_id}"]
@@ -161,7 +161,7 @@ module "mysql_replica_rds_instance" {
   source                     = "../../modules/aws/rds_instance"
   name                       = "${var.stackname}-mysql-replica"
   default_tags               = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mysql-replica")}"
-  allocated_storage          = "${var.storage_size}"
+  allocated_storage          = "${var.allocated_storage}"
   max_allocated_storage      = "${var.max_allocated_storage}"
   instance_class             = "${var.instance_type}"
   instance_name              = "${var.stackname}-mysql-replica"

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -102,22 +102,23 @@ resource "aws_db_parameter_group" "app_transition_pg" {
 module "transition-postgresql-primary_rds_instance" {
   source = "../../modules/aws/rds_instance"
 
-  name                 = "${var.stackname}-transition-postgresql-primary"
-  engine_name          = "postgres"
-  engine_version       = "9.6"
-  default_tags         = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "transition_postgresql_primary")}"
-  subnet_ids           = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
-  username             = "${var.username}"
-  password             = "${var.password}"
-  allocated_storage    = "120"
-  instance_class       = "${var.instance_type}"
-  instance_name        = "${var.stackname}-transition-postgresql-primary"
-  multi_az             = "${var.multi_az}"
-  security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_transition-postgresql-primary_id}"]
-  event_sns_topic_arn  = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
-  skip_final_snapshot  = "${var.skip_final_snapshot}"
-  snapshot_identifier  = "${var.snapshot_identifier}"
-  parameter_group_name = "${aws_db_parameter_group.app_transition_pg.name}"
+  name                  = "${var.stackname}-transition-postgresql-primary"
+  engine_name           = "postgres"
+  engine_version        = "9.6"
+  default_tags          = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "transition_postgresql_primary")}"
+  subnet_ids            = "${data.terraform_remote_state.infra_networking.private_subnet_rds_ids}"
+  username              = "${var.username}"
+  password              = "${var.password}"
+  allocated_storage     = "120"
+  max_allocated_storage = "150"
+  instance_class        = "${var.instance_type}"
+  instance_name         = "${var.stackname}-transition-postgresql-primary"
+  multi_az              = "${var.multi_az}"
+  security_group_ids    = ["${data.terraform_remote_state.infra_security_groups.sg_transition-postgresql-primary_id}"]
+  event_sns_topic_arn   = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
+  skip_final_snapshot   = "${var.skip_final_snapshot}"
+  snapshot_identifier   = "${var.snapshot_identifier}"
+  parameter_group_name  = "${aws_db_parameter_group.app_transition_pg.name}"
 }
 
 resource "aws_route53_record" "service_record" {
@@ -137,6 +138,8 @@ module "transition-postgresql-standby_rds_instance" {
   instance_name              = "${var.stackname}-transition-postgresql-standby"
   security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_transition-postgresql-standby_id}"]
   create_replicate_source_db = "1"
+  allocated_storage          = "120"
+  max_allocated_storage      = "150"
   replicate_source_db        = "${module.transition-postgresql-primary_rds_instance.rds_instance_id}"
   event_sns_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
   skip_final_snapshot        = "${var.skip_final_snapshot}"

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -139,7 +139,7 @@ module "transition-postgresql-standby_rds_instance" {
   security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_transition-postgresql-standby_id}"]
   create_replicate_source_db = "1"
   allocated_storage          = "120"
-  max_allocated_storage      = "150"
+  max_allocated_storage      = "500"
   replicate_source_db        = "${module.transition-postgresql-primary_rds_instance.rds_instance_id}"
   event_sns_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
   skip_final_snapshot        = "${var.skip_final_snapshot}"

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -110,7 +110,7 @@ module "transition-postgresql-primary_rds_instance" {
   username              = "${var.username}"
   password              = "${var.password}"
   allocated_storage     = "120"
-  max_allocated_storage = "150"
+  max_allocated_storage = "500"
   instance_class        = "${var.instance_type}"
   instance_name         = "${var.stackname}-transition-postgresql-primary"
   multi_az              = "${var.multi_az}"


### PR DESCRIPTION
This enables autoscaling of storage for compatible RDS instances.

This PR needs to be merged at the same time as: https://github.com/alphagov/govuk-aws-data/pull/695

Defining a default of 100GB for the upper limit for AWS to allow storage autoscaling growth, this needs to be set to instruct terraform to configure storage autoscaling.

- allocated_storage defines the initial provisioning size of the RDS instance
- max_allocated_storage defines the upper limit for AWS to allow autoscaling growth

Configure all existing RDS instances to support scalable storage

This requires max_allocated_storage to be defined to all instantiations of rds_instance

- define a max_allocated_storage for content-data-api-postgresql-primary_rds_instance
- apply terraform fmt to terraform/projects/app-content-data-api-postgresql/main.tf
- rename storage_size to allocated_storage in
  terraform/projects/app-mysql/main.tf to make it align with the rest of
  the terraform codebase
- apply sensible max_allocated_storage for transition-postgresql-primary_rds_instance
- apply terraform fmt to terraform/projects/app-transition-postgresql/main.tf
- apply sensible max_allocated_storage to transition-postgresql-standby_rds_instance
