### PR TITLE
postgresql: Bump production database instance size to db.m5.8xlarge

### DIFF
--- a/terraform/projects/app-postgresql/README.md
+++ b/terraform/projects/app-postgresql/README.md
@@ -17,7 +17,7 @@ RDS PostgreSQL instances
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | cloudwatch\_log\_retention | Number of days to retain Cloudwatch logs for | `string` | n/a | yes |
-| instance\_type | Instance type used for RDS resources | `string` | `"db.m5.4xlarge"` | no |
+| instance\_type | Instance type used for RDS resources | `string` | `"db.m5.8xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | max\_allocated\_storage | current maximum storage in GB that AWS can autoscale the RDS storage to | `string` | `"500"` | no |

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -64,7 +64,7 @@ variable "internal_domain_name" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for RDS resources"
-  default     = "db.m5.4xlarge"
+  default     = "db.m5.8xlarge"
 }
 
 variable "allocated_storage" {


### PR DESCRIPTION
- We're seeing spiky CPU usage, going up to 99%, when scheduled publishing occurs at 0930, and emails are sent out at various points during the day.
- Tuning the apps would take longer and maybe not even be feasible as scheduled publishing has to happen, and so does sending urgent emails.
- We could investigate splitting the databases out into `publishing-api-postgresql` and `email-alert-api-postgresql`, but we attempted that before and [resolved to not do it](https://github.com/alphagov/govuk-aws/commit/c51e8bbf879dd867b73bec4f71ba7271703e1909) (also for [publishing-api](https://github.com/alphagov/govuk-aws/pull/1086/commits/3f7cc071b4361e5df15ac1dfb2a1e3c565bb8678)).
- According to https://www.ec2instances.info/rds/?region=eu-west-1&cost_duration=monthly, base cost for the old instance type is ~$1150/month. The bigger instance type specified here costs ~$2300/month. That's an increase of $1150 / month, or $13,800 / year.

https://trello.com/c/JuO6EDwH/1781-5-investigate-postgres-blue-postgresql-primary-hitting-maximum-cpu-utilization