### PR TITLE
Increase RDS max storage for content-data-api-postgresql

### DIFF
--- a/terraform/projects/app-content-data-api-postgresql/main.tf
+++ b/terraform/projects/app-content-data-api-postgresql/main.tf
@@ -142,7 +142,7 @@ module "content-data-api-postgresql-primary_rds_instance" {
   username              = "${var.username}"
   password              = "${var.password}"
   allocated_storage     = "1024"
-  max_allocated_storage = "1100"
+  max_allocated_storage = "1300"
   instance_class        = "${var.instance_type}"
   instance_name         = "${var.stackname}-content-data-api-postgresql-primary"
   multi_az              = "${var.multi_az}"


### PR DESCRIPTION
The value needs to be increased to allow autoscaling to occur properly.