### PR TITLE
Prometheus to scrape router metrics

### DIFF
--- a/terraform/projects/infra-security-groups/cache.tf
+++ b/terraform/projects/infra-security-groups/cache.tf
@@ -173,3 +173,17 @@ resource "aws_security_group_rule" "ithc_ingress_cache_ssh" {
   cidr_blocks       = "${var.ithc_access_ips}"
   security_group_id = "${aws_security_group.cache_ithc_access.id}"
 }
+
+# Allow the prometheus instances to scrape router's metrics
+resource "aws_security_group_rule" "cache_ingress_prometheus_router" {
+  type      = "ingress"
+  from_port = 3055
+  to_port   = 3055
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.cache.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.prometheus.id}"
+}


### PR DESCRIPTION
What
---

We have [instrumented the router application](https://github.com/alphagov/router/pull/148)

We want prometheus to scrape it in integration, as this is where we will deploy our instrumented build of router

This PR adds a job to Prometheus, representing the router app. The job will exist in all environments but the service discovery will only find instances in the integration environment.

How to review
---

Code review

Check that 3055 is the correct port