### PR TITLE
Switch `backend` internal LB to ALB and remove classic ELBs.

### DIFF
--- a/terraform/projects/app-backend/README.md
+++ b/terraform/projects/app-backend/README.md
@@ -18,11 +18,7 @@ Backend node
 | asg\_size | The autoscaling groups desired/max/min capacity | `string` | `"2"` | no |
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
-| create\_external\_elb | Create the external ELB | `bool` | `true` | no |
-| elb\_external\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
-| external\_domain\_name | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
-| external\_zone\_name | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | instance\_ami\_filter\_name | Name to use to find AMI images | `string` | `""` | no |
 | instance\_type | Instance type used for EC2 resources | `string` | `"m5.2xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
@@ -41,10 +37,7 @@ Backend node
 
 | Name | Description |
 |------|-------------|
-| app\_service\_records\_external\_dns\_name | DNS name to access the app service records |
 | app\_service\_records\_internal\_dns\_name | DNS name to access the app service records |
-| backend\_elb\_external\_address | AWS' external DNS name for the backend ELB |
 | backend\_elb\_internal\_address | AWS' internal DNS name for the backend ELB |
-| service\_dns\_name\_external | DNS name to access the node service |
 | service\_dns\_name\_internal | DNS name to access the node service |
 

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -30,11 +30,6 @@ variable "elb_internal_certname" {
   description = "The ACM cert domain name to find the ARN of"
 }
 
-variable "elb_external_certname" {
-  type        = "string"
-  description = "The ACM cert domain name to find the ARN of"
-}
-
 variable "app_service_records" {
   type        = "list"
   description = "List of application service names that get traffic via this loadbalancer"
@@ -47,16 +42,6 @@ variable "asg_size" {
   default     = "2"
 }
 
-variable "external_zone_name" {
-  type        = "string"
-  description = "The name of the Route53 zone that contains external records"
-}
-
-variable "external_domain_name" {
-  type        = "string"
-  description = "The domain name of the external DNS records, it could be different from the zone name"
-}
-
 variable "internal_zone_name" {
   type        = "string"
   description = "The name of the Route53 zone that contains internal records"
@@ -65,11 +50,6 @@ variable "internal_zone_name" {
 variable "internal_domain_name" {
   type        = "string"
   description = "The domain name of the internal DNS records, it could be different from the zone name"
-}
-
-variable "create_external_elb" {
-  description = "Create the external ELB"
-  default     = true
 }
 
 variable "instance_type" {
@@ -90,86 +70,14 @@ provider "aws" {
   version = "2.46.0"
 }
 
-data "aws_route53_zone" "external" {
-  name         = "${var.external_zone_name}"
-  private_zone = false
-}
-
 data "aws_route53_zone" "internal" {
   name         = "${var.internal_zone_name}"
   private_zone = true
 }
 
-data "aws_acm_certificate" "elb_external_cert" {
-  domain   = "${var.elb_external_certname}"
-  statuses = ["ISSUED"]
-}
-
 data "aws_acm_certificate" "elb_internal_cert" {
   domain   = "${var.elb_internal_certname}"
   statuses = ["ISSUED"]
-}
-
-resource "aws_elb" "backend_elb_external" {
-  count = "${var.create_external_elb}"
-
-  name            = "${var.stackname}-backend-external"
-  subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_backend_elb_external_id}"]
-  internal        = "false"
-
-  access_logs {
-    bucket        = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-    bucket_prefix = "elb/${var.stackname}-backend-external-elb"
-    interval      = 60
-  }
-
-  listener {
-    instance_port     = "80"
-    instance_protocol = "http"
-    lb_port           = "443"
-    lb_protocol       = "https"
-
-    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
-  }
-
-  health_check {
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-    timeout             = 3
-    target              = "TCP:80"
-    interval            = 30
-  }
-
-  cross_zone_load_balancing   = true
-  idle_timeout                = 400
-  connection_draining         = true
-  connection_draining_timeout = 400
-
-  tags = "${map("Name", "${var.stackname}-backend", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend")}"
-}
-
-resource "aws_route53_record" "service_record_external" {
-  count = "${var.create_external_elb}"
-
-  zone_id = "${data.aws_route53_zone.external.zone_id}"
-  name    = "backend.${var.external_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${aws_elb.backend_elb_external.dns_name}"
-    zone_id                = "${aws_elb.backend_elb_external.zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_route53_record" "app_service_records_external" {
-  count   = "${length(var.app_service_records)}"
-  zone_id = "${data.aws_route53_zone.external.zone_id}"
-  name    = "${element(var.app_service_records, count.index)}.${var.external_domain_name}"
-  type    = "CNAME"
-  records = ["backend.${var.external_domain_name}."]
-  ttl     = "300"
 }
 
 module "internal_lb" {
@@ -212,43 +120,6 @@ module "internal_lb_rules" {
   }
 }
 
-resource "aws_elb" "backend_elb_internal" {
-  name            = "${var.stackname}-backend-internal"
-  subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_backend_elb_internal_id}"]
-  internal        = "true"
-
-  access_logs {
-    bucket        = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-    bucket_prefix = "elb/${var.stackname}-backend-internal-elb"
-    interval      = 60
-  }
-
-  listener {
-    instance_port     = "80"
-    instance_protocol = "http"
-    lb_port           = "443"
-    lb_protocol       = "https"
-
-    ssl_certificate_id = "${data.aws_acm_certificate.elb_internal_cert.arn}"
-  }
-
-  health_check {
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-    timeout             = 3
-    target              = "HTTP:80/_healthcheck"
-    interval            = 30
-  }
-
-  cross_zone_load_balancing   = true
-  idle_timeout                = 400
-  connection_draining         = true
-  connection_draining_timeout = 400
-
-  tags = "${map("Name", "${var.stackname}-backend", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend")}"
-}
-
 resource "aws_route53_record" "service_record_internal" {
   zone_id = "${data.aws_route53_zone.internal.zone_id}"
   name    = "backend.${var.internal_domain_name}"
@@ -270,11 +141,6 @@ resource "aws_route53_record" "app_service_records_internal" {
   ttl     = "300"
 }
 
-locals {
-  instance_elb_ids_length = "${var.create_external_elb ? 2 : 1}"
-  instance_elb_ids        = "${compact(list(join("", aws_elb.backend_elb_external.*.id), aws_elb.backend_elb_internal.id))}"
-}
-
 module "backend" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-backend"
@@ -283,46 +149,12 @@ module "backend" {
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}", "${data.terraform_remote_state.infra_security_groups.sg_aws-vpn_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
-  instance_elb_ids_length       = "${local.instance_elb_ids_length}"
-  instance_elb_ids              = ["${local.instance_elb_ids}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "${var.asg_size}"
   asg_min_size                  = "${var.asg_size}"
   asg_desired_capacity          = "${var.asg_size}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
   root_block_device_volume_size = "60"
-}
-
-locals {
-  elb_httpcode_backend_5xx_threshold = "${var.create_external_elb ? 100 : 0}"
-  elb_httpcode_elb_4xx_threshold     = "${var.create_external_elb ? 100 : 0}"
-  elb_httpcode_elb_5xx_threshold     = "${var.create_external_elb ? 100 : 0}"
-}
-
-module "alarms-elb-backend-internal" {
-  source                         = "../../modules/aws/alarms/elb"
-  name_prefix                    = "${var.stackname}-backend-internal"
-  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  elb_name                       = "${aws_elb.backend_elb_internal.name}"
-  httpcode_backend_4xx_threshold = "0"
-  httpcode_backend_5xx_threshold = "${local.elb_httpcode_backend_5xx_threshold}"
-  httpcode_elb_4xx_threshold     = "${local.elb_httpcode_elb_4xx_threshold}"
-  httpcode_elb_5xx_threshold     = "${local.elb_httpcode_elb_5xx_threshold}"
-  surgequeuelength_threshold     = "0"
-  healthyhostcount_threshold     = "0"
-}
-
-module "alarms-elb-backend-external" {
-  source                         = "../../modules/aws/alarms/elb"
-  name_prefix                    = "${var.stackname}-backend-external"
-  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  elb_name                       = "${aws_elb.backend_elb_external.name}"
-  httpcode_backend_4xx_threshold = "0"
-  httpcode_backend_5xx_threshold = "100"
-  httpcode_elb_4xx_threshold     = "100"
-  httpcode_elb_5xx_threshold     = "100"
-  surgequeuelength_threshold     = "0"
-  healthyhostcount_threshold     = "0"
 }
 
 # Outputs
@@ -340,20 +172,5 @@ output "service_dns_name_internal" {
 
 output "app_service_records_internal_dns_name" {
   value       = "${aws_route53_record.app_service_records_internal.*.name}"
-  description = "DNS name to access the app service records"
-}
-
-output "backend_elb_external_address" {
-  value       = "${join("", aws_elb.backend_elb_external.*.dns_name)}"
-  description = "AWS' external DNS name for the backend ELB"
-}
-
-output "service_dns_name_external" {
-  value       = "${join("", aws_route53_record.service_record_external.*.name)}"
-  description = "DNS name to access the node service"
-}
-
-output "app_service_records_external_dns_name" {
-  value       = "${aws_route53_record.app_service_records_external.*.name}"
   description = "DNS name to access the app service records"
 }

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -255,8 +255,8 @@ resource "aws_route53_record" "service_record_internal" {
   type    = "A"
 
   alias {
-    name                   = "${aws_elb.backend_elb_internal.dns_name}"
-    zone_id                = "${aws_elb.backend_elb_internal.zone_id}"
+    name                   = "${module.internal_lb.lb_dns_name}"
+    zone_id                = "${module.internal_lb.lb_zone_id}"
     evaluate_target_health = true
   }
 }
@@ -329,7 +329,7 @@ module "alarms-elb-backend-external" {
 # --------------------------------------------------------------
 
 output "backend_elb_internal_address" {
-  value       = "${aws_elb.backend_elb_internal.dns_name}"
+  value       = "${module.internal_lb.lb_dns_name}"
   description = "AWS' internal DNS name for the backend ELB"
 }
 


### PR DESCRIPTION
* Add an internal-facing Application Load Balancer (ALB/L7LB) for the `backend` apps, with per-app healthchecks configured.
* Switch `backend.*.govuk-internal` DNS names to point to the new internal ALB instead of the classic ELB.
* Remove the classic ELBs `blue-backend-external` and `blue-backend-internal` and their associated resources.

We need to use an ALB instead of a classic ELB in order to configure healthchecks correctly for each app, per https://github.com/alphagov/govuk-aws/blob/master/doc/architecture/decisions/0037-alb-health-checks.md. The same set of `backend` machines hosts many different apps whose instances need to be healthchecked independently in order to handle the failure of individual app instances correctly.

The motivation for addressing this healthcheck issue now is that we'll soon be migrating the publisher apps to AWS in production.

The `blue-backend-external` classic ELB is no longer used. Its request logs consist entirely of AWS Security Scanner and bogus traffic where the Host header doesn't match any of the services. `govuk_uptime_collector` used to use it, but that was fixed in alphagov/govuk-puppet#10234.

The aws/lb module for the replacement ALBs creates the associated resources like CloudWatch alarms for us, hence we no longer need to define those explicitly in `app-backend/main.tf`.

#### Testing

The `blue-backend-external` classic ELB has already been removed in Staging to verify that nothing depends on it. I also checked its request logs and I couldn't find any legitimate-looking traffic.

Terraform plans:

* [Integration](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4064/console)
* [Staging](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4065/console)
* [Prod](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4066/console)

#### Tips for reviewing

This is probably easiest to review commit-by-commit. The overall diff comes out in a less than entirely helpful way because Git's diff heuristics munge some of the stanzas together.