### PR TITLE
Revert "Switch `backend` internal LB to ALB and remove classic ELBs."

### DIFF
--- a/terraform/projects/app-backend/README.md
+++ b/terraform/projects/app-backend/README.md
@@ -18,7 +18,11 @@ Backend node
 | asg\_size | The autoscaling groups desired/max/min capacity | `string` | `"2"` | no |
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
+| create\_external\_elb | Create the external ELB | `bool` | `true` | no |
+| elb\_external\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| external\_domain\_name | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
+| external\_zone\_name | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | instance\_ami\_filter\_name | Name to use to find AMI images | `string` | `""` | no |
 | instance\_type | Instance type used for EC2 resources | `string` | `"m5.2xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
@@ -37,7 +41,10 @@ Backend node
 
 | Name | Description |
 |------|-------------|
+| app\_service\_records\_external\_dns\_name | DNS name to access the app service records |
 | app\_service\_records\_internal\_dns\_name | DNS name to access the app service records |
+| backend\_elb\_external\_address | AWS' external DNS name for the backend ELB |
 | backend\_elb\_internal\_address | AWS' internal DNS name for the backend ELB |
+| service\_dns\_name\_external | DNS name to access the node service |
 | service\_dns\_name\_internal | DNS name to access the node service |
 

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -30,6 +30,11 @@ variable "elb_internal_certname" {
   description = "The ACM cert domain name to find the ARN of"
 }
 
+variable "elb_external_certname" {
+  type        = "string"
+  description = "The ACM cert domain name to find the ARN of"
+}
+
 variable "app_service_records" {
   type        = "list"
   description = "List of application service names that get traffic via this loadbalancer"
@@ -42,6 +47,16 @@ variable "asg_size" {
   default     = "2"
 }
 
+variable "external_zone_name" {
+  type        = "string"
+  description = "The name of the Route53 zone that contains external records"
+}
+
+variable "external_domain_name" {
+  type        = "string"
+  description = "The domain name of the external DNS records, it could be different from the zone name"
+}
+
 variable "internal_zone_name" {
   type        = "string"
   description = "The name of the Route53 zone that contains internal records"
@@ -50,6 +65,11 @@ variable "internal_zone_name" {
 variable "internal_domain_name" {
   type        = "string"
   description = "The domain name of the internal DNS records, it could be different from the zone name"
+}
+
+variable "create_external_elb" {
+  description = "Create the external ELB"
+  default     = true
 }
 
 variable "instance_type" {
@@ -70,9 +90,19 @@ provider "aws" {
   version = "2.46.0"
 }
 
+data "aws_route53_zone" "external" {
+  name         = "${var.external_zone_name}"
+  private_zone = false
+}
+
 data "aws_route53_zone" "internal" {
   name         = "${var.internal_zone_name}"
   private_zone = true
+}
+
+data "aws_acm_certificate" "elb_external_cert" {
+  domain   = "${var.elb_external_certname}"
+  statuses = ["ISSUED"]
 }
 
 data "aws_acm_certificate" "elb_internal_cert" {
@@ -80,44 +110,103 @@ data "aws_acm_certificate" "elb_internal_cert" {
   statuses = ["ISSUED"]
 }
 
-module "internal_lb" {
-  source                           = "../../modules/aws/lb"
-  name                             = "govuk-backend-internal"
-  internal                         = true
-  vpc_id                           = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  access_logs_bucket_name          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-  access_logs_bucket_prefix        = "elb/govuk-backend-internal-elb"
-  listener_certificate_domain_name = "${var.elb_internal_certname}"
+resource "aws_elb" "backend_elb_external" {
+  count = "${var.create_external_elb}"
 
-  listener_action = {
-    "HTTPS:443" = "HTTP:80"
+  name            = "${var.stackname}-backend-external"
+  subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_backend_elb_external_id}"]
+  internal        = "false"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    bucket_prefix = "elb/${var.stackname}-backend-external-elb"
+    interval      = 60
   }
 
-  subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_backend_elb_internal_id}"]
-  alarm_actions   = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  listener {
+    instance_port     = "80"
+    instance_protocol = "http"
+    lb_port           = "443"
+    lb_protocol       = "https"
 
-  default_tags = {
-    Project         = "${var.stackname}"
-    aws_migration   = "backend"
-    aws_environment = "${var.aws_environment}"
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    target              = "TCP:80"
+    interval            = 30
+  }
+
+  cross_zone_load_balancing   = true
+  idle_timeout                = 400
+  connection_draining         = true
+  connection_draining_timeout = 400
+
+  tags = "${map("Name", "${var.stackname}-backend", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend")}"
+}
+
+resource "aws_route53_record" "service_record_external" {
+  count = "${var.create_external_elb}"
+
+  zone_id = "${data.aws_route53_zone.external.zone_id}"
+  name    = "backend.${var.external_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_elb.backend_elb_external.dns_name}"
+    zone_id                = "${aws_elb.backend_elb_external.zone_id}"
+    evaluate_target_health = true
   }
 }
 
-module "internal_lb_rules" {
-  source                 = "../../modules/aws/lb_listener_rules"
-  name                   = "backend-i"
-  autoscaling_group_name = "${module.backend.autoscaling_group_name}"
-  rules_host_domain      = "*"
-  vpc_id                 = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  listener_arn           = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
-  rules_host             = ["${var.app_service_records}"]
+resource "aws_route53_record" "app_service_records_external" {
+  count   = "${length(var.app_service_records)}"
+  zone_id = "${data.aws_route53_zone.external.zone_id}"
+  name    = "${element(var.app_service_records, count.index)}.${var.external_domain_name}"
+  type    = "CNAME"
+  records = ["backend.${var.external_domain_name}."]
+  ttl     = "300"
+}
 
-  default_tags = {
-    Project         = "${var.stackname}"
-    aws_migration   = "backend"
-    aws_environment = "${var.aws_environment}"
+resource "aws_elb" "backend_elb_internal" {
+  name            = "${var.stackname}-backend-internal"
+  subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_backend_elb_internal_id}"]
+  internal        = "true"
+
+  access_logs {
+    bucket        = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+    bucket_prefix = "elb/${var.stackname}-backend-internal-elb"
+    interval      = 60
   }
+
+  listener {
+    instance_port     = "80"
+    instance_protocol = "http"
+    lb_port           = "443"
+    lb_protocol       = "https"
+
+    ssl_certificate_id = "${data.aws_acm_certificate.elb_internal_cert.arn}"
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    target              = "HTTP:80/_healthcheck"
+    interval            = 30
+  }
+
+  cross_zone_load_balancing   = true
+  idle_timeout                = 400
+  connection_draining         = true
+  connection_draining_timeout = 400
+
+  tags = "${map("Name", "${var.stackname}-backend", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend")}"
 }
 
 resource "aws_route53_record" "service_record_internal" {
@@ -126,8 +215,8 @@ resource "aws_route53_record" "service_record_internal" {
   type    = "A"
 
   alias {
-    name                   = "${module.internal_lb.lb_dns_name}"
-    zone_id                = "${module.internal_lb.lb_zone_id}"
+    name                   = "${aws_elb.backend_elb_internal.dns_name}"
+    zone_id                = "${aws_elb.backend_elb_internal.zone_id}"
     evaluate_target_health = true
   }
 }
@@ -141,6 +230,11 @@ resource "aws_route53_record" "app_service_records_internal" {
   ttl     = "300"
 }
 
+locals {
+  instance_elb_ids_length = "${var.create_external_elb ? 2 : 1}"
+  instance_elb_ids        = "${compact(list(join("", aws_elb.backend_elb_external.*.id), aws_elb.backend_elb_internal.id))}"
+}
+
 module "backend" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-backend"
@@ -149,6 +243,8 @@ module "backend" {
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}", "${data.terraform_remote_state.infra_security_groups.sg_aws-vpn_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
+  instance_elb_ids_length       = "${local.instance_elb_ids_length}"
+  instance_elb_ids              = ["${local.instance_elb_ids}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "${var.asg_size}"
   asg_min_size                  = "${var.asg_size}"
@@ -157,11 +253,43 @@ module "backend" {
   root_block_device_volume_size = "60"
 }
 
+locals {
+  elb_httpcode_backend_5xx_threshold = "${var.create_external_elb ? 100 : 0}"
+  elb_httpcode_elb_4xx_threshold     = "${var.create_external_elb ? 100 : 0}"
+  elb_httpcode_elb_5xx_threshold     = "${var.create_external_elb ? 100 : 0}"
+}
+
+module "alarms-elb-backend-internal" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-backend-internal"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  elb_name                       = "${aws_elb.backend_elb_internal.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "${local.elb_httpcode_backend_5xx_threshold}"
+  httpcode_elb_4xx_threshold     = "${local.elb_httpcode_elb_4xx_threshold}"
+  httpcode_elb_5xx_threshold     = "${local.elb_httpcode_elb_5xx_threshold}"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
+module "alarms-elb-backend-external" {
+  source                         = "../../modules/aws/alarms/elb"
+  name_prefix                    = "${var.stackname}-backend-external"
+  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  elb_name                       = "${aws_elb.backend_elb_external.name}"
+  httpcode_backend_4xx_threshold = "0"
+  httpcode_backend_5xx_threshold = "100"
+  httpcode_elb_4xx_threshold     = "100"
+  httpcode_elb_5xx_threshold     = "100"
+  surgequeuelength_threshold     = "0"
+  healthyhostcount_threshold     = "0"
+}
+
 # Outputs
 # --------------------------------------------------------------
 
 output "backend_elb_internal_address" {
-  value       = "${module.internal_lb.lb_dns_name}"
+  value       = "${aws_elb.backend_elb_internal.dns_name}"
   description = "AWS' internal DNS name for the backend ELB"
 }
 
@@ -172,5 +300,20 @@ output "service_dns_name_internal" {
 
 output "app_service_records_internal_dns_name" {
   value       = "${aws_route53_record.app_service_records_internal.*.name}"
+  description = "DNS name to access the app service records"
+}
+
+output "backend_elb_external_address" {
+  value       = "${join("", aws_elb.backend_elb_external.*.dns_name)}"
+  description = "AWS' external DNS name for the backend ELB"
+}
+
+output "service_dns_name_external" {
+  value       = "${join("", aws_route53_record.service_record_external.*.name)}"
+  description = "DNS name to access the node service"
+}
+
+output "app_service_records_external_dns_name" {
+  value       = "${aws_route53_record.app_service_records_external.*.name}"
   description = "DNS name to access the app service records"
 }


### PR DESCRIPTION
#1269 tries to create another 31 TGs and attach them to the `blue-backend` ASG. The limit is 50 TGs on any given ASG, so it's not possible to roll out. The TF provider isn't smart enough to validate that when running `terraform plan`.

Reverts alphagov/govuk-aws#1269.