### PR TITLE
Fix internal load balancer healthcheck for MapIt.

### DIFF
--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -125,7 +125,7 @@ resource "aws_elb" "mapit_elb" {
     unhealthy_threshold = 2
     timeout             = 3
 
-    target   = "TCP:80"
+    target   = "HTTP:80/postcode/W54XA"
     interval = 30
   }
 


### PR DESCRIPTION
This changes the load balancer healthcheck for MapIt to
talk to the app itself rather than the nginx reverse proxy in front of
the app (which always returns healthy even if the app is down).

See https://github.com/alphagov/govuk-aws/blob/master/doc/architecture/decisions/0037-alb-health-checks.md