### PR TITLE
Add an output for the default WAF ACL.

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -117,5 +117,7 @@ This project adds global resources for app components:
 
 ## Outputs
 
-No output.
+| Name | Description |
+|------|-------------|
+| default\_waf\_acl | GOV.UK default regional WAF ACL |
 

--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -205,3 +205,8 @@ resource "aws_kinesis_firehose_delivery_stream" "splunk" {
     }
   }
 }
+
+output "default_waf_acl" {
+  value       = "${aws_wafregional_web_acl.default.id}"
+  description = "GOV.UK default regional WAF ACL"
+}


### PR DESCRIPTION
Allows other Terraform projects to attach their load balancers to the WAF. The shared `backend` ELB in `app-backend` will be the first to need this.