### PR TITLE
postgres: Increase instance size to db.m5.12xlarge

### DIFF
--- a/terraform/projects/app-postgresql/README.md
+++ b/terraform/projects/app-postgresql/README.md
@@ -17,7 +17,7 @@ RDS PostgreSQL instances
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | cloudwatch\_log\_retention | Number of days to retain Cloudwatch logs for | `string` | n/a | yes |
-| instance\_type | Instance type used for RDS resources | `string` | `"db.m5.8xlarge"` | no |
+| instance\_type | Instance type used for RDS resources | `string` | `"db.m5.12xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | max\_allocated\_storage | current maximum storage in GB that AWS can autoscale the RDS storage to | `string` | `"500"` | no |

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -64,7 +64,7 @@ variable "internal_domain_name" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for RDS resources"
-  default     = "db.m5.8xlarge"
+  default     = "db.m5.12xlarge"
 }
 
 variable "allocated_storage" {


### PR DESCRIPTION
- We're using too old a Postgres version (9.6.old-patch) for Amazon to
  let us use `db.m5.8xlarge`:

```
* module.postgresql-primary_rds_instance.aws_db_instance.db_instance: 1 error occurred:
* aws_db_instance.db_instance: Error modifying DB Instance blue-postgresql-primary: InvalidParameterCombination: RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.m5.8xlarge, Engine=postgres, EngineVersion=9.6.11, LicenseModel=postgresql-license. For supported combinations of instance class and database engine version, see the documentation.
```

- Instead, we're upgrading to the next unrestricted database instance.
  This costs an extra $2254/month compared to what we have _now_
  (`db.m5.4xlarge`)

Related PRs (specifically relevant to costings): #1264.