### PR TITLE
Per-app healthchecks on `backend` internal LB.

### DIFF
--- a/terraform/projects/app-backend/README.md
+++ b/terraform/projects/app-backend/README.md
@@ -19,6 +19,7 @@ Backend node
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| elb\_public\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | instance\_ami\_filter\_name | Name to use to find AMI images | `string` | `""` | no |
 | instance\_type | Instance type used for EC2 resources | `string` | `"m5.2xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
@@ -26,6 +27,7 @@ Backend node
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_monitoring\_key\_stack | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |
+| remote\_state\_infra\_public\_services\_key\_stack | Override stackname path to infra\_public\_services remote state | `string` | `""` | no |
 | remote\_state\_infra\_root\_dns\_zones\_key\_stack | Override stackname path to infra\_root\_dns\_zones remote state | `string` | `""` | no |
 | remote\_state\_infra\_security\_groups\_key\_stack | Override infra\_security\_groups stackname path to infra\_vpc remote state | `string` | `""` | no |
 | remote\_state\_infra\_stack\_dns\_zones\_key\_stack | Override stackname path to infra\_stack\_dns\_zones remote state | `string` | `""` | no |
@@ -35,9 +37,5 @@ Backend node
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| app\_service\_records\_internal\_dns\_name | DNS name to access the app service records |
-| backend\_elb\_internal\_address | AWS' internal DNS name for the backend ELB |
-| service\_dns\_name\_internal | DNS name to access the node service |
+No output.
 

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -1667,9 +1667,33 @@ resource "aws_route53_record" "travel-advice-publisher-internal" {
 # LB listener rules and CNAME records for services on public (external) LB.
 #
 
-resource "aws_lb_listener_rule" "collections-publisher-external" {
+resource "aws_lb_listener_rule" "asset-manager-external" {
   listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
   priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.asset-manager.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["asset-manager.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "asset-manager-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "asset-manager"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "collections-publisher-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 200
 
   action {
     type             = "forward"
@@ -1691,5 +1715,554 @@ resource "aws_route53_record" "collections-publisher-external" {
   ttl     = "300"
 }
 
-# TODO: add listener rules and CNAMEs for the rest of the backend_public_service_cnames services.
+resource "aws_lb_listener_rule" "contacts-admin-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 300
 
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.contacts-admin.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["contacts-admin.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "contacts-admin-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "contacts-admin"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "content-data-admin-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 400
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.content-data-admin.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["content-data-admin.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "content-data-admin-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "content-data-admin"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "content-data-api-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 500
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.content-data-api.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["content-data-api.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "content-data-api-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "content-data-api"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "content-performance-manager-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 600
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.content-performance-manager.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["content-performance-manager.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "content-performance-manager-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "content-performance-manager"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "content-publisher-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 700
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.content-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["content-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "content-publisher-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "content-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "content-tagger-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 800
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.content-tagger.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["content-tagger.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "content-tagger-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "content-tagger"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "docs-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 900
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.docs.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["docs.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "docs-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "docs"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "hmrc-manuals-api-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1000
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.hmrc-manuals-api.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["hmrc-manuals-api.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "hmrc-manuals-api-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "hmrc-manuals-api"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "imminence-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1100
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.imminence.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["imminence.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "imminence-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "imminence"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "local-links-manager-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1200
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.local-links-manager.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["local-links-manager.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "local-links-manager-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "local-links-manager"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "manuals-publisher-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1300
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.manuals-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["manuals-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "manuals-publisher-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "manuals-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "maslow-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1400
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.maslow.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["maslow.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "maslow-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "maslow"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "policy-publisher-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1500
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.policy-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["policy-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "policy-publisher-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "policy-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "publisher-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1600
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "publisher-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "release-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1700
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.release.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["release.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "release-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "release"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "search-admin-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1800
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.search-admin.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["search-admin.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "search-admin-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "search-admin"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "service-manual-publisher-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1900
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.service-manual-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["service-manual-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "service-manual-publisher-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "service-manual-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "short-url-manager-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2000
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.short-url-manager.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["short-url-manager.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "short-url-manager-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "short-url-manager"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "signon-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2100
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.signon.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["signon.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "signon-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "signon"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "specialist-publisher-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2200
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.specialist-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["specialist-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "specialist-publisher-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "specialist-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "support-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2300
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.support.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["support.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "support-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "support"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "transition-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2400
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.transition.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["transition.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "transition-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "transition"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "travel-advice-publisher-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2500
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.travel-advice-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["travel-advice-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "travel-advice-publisher-external" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "travel-advice-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -25,6 +25,11 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
+variable "elb_public_certname" {
+  type        = "string"
+  description = "The ACM cert domain name to find the ARN of"
+}
+
 variable "elb_internal_certname" {
   type        = "string"
   description = "The ACM cert domain name to find the ARN of"
@@ -42,11 +47,13 @@ variable "asg_size" {
   default     = "2"
 }
 
+# TODO: remove once Prod traffic is moved off the classic ELB.
 variable "internal_zone_name" {
   type        = "string"
   description = "The name of the Route53 zone that contains internal records"
 }
 
+# TODO: remove once Prod traffic is moved off the classic ELB.
 variable "internal_domain_name" {
   type        = "string"
   description = "The domain name of the internal DNS records, it could be different from the zone name"
@@ -70,16 +77,27 @@ provider "aws" {
   version = "2.46.0"
 }
 
+locals {
+  common_tags = {
+    Project         = "${var.stackname}"
+    aws_migration   = "backend"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
+# TODO: remove once Prod traffic is moved off the classic ELB.
 data "aws_route53_zone" "internal" {
   name         = "${var.internal_zone_name}"
   private_zone = true
 }
 
+# TODO: remove once Prod traffic is moved off the classic ELB.
 data "aws_acm_certificate" "elb_internal_cert" {
   domain   = "${var.elb_internal_certname}"
   statuses = ["ISSUED"]
 }
 
+# TODO: remove once Prod traffic is moved off this classic ELB.
 resource "aws_elb" "backend_elb_internal" {
   name            = "${var.stackname}-backend-internal"
   subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
@@ -117,6 +135,7 @@ resource "aws_elb" "backend_elb_internal" {
   tags = "${map("Name", "${var.stackname}-backend", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend")}"
 }
 
+# TODO: remove once Prod traffic is moved off the classic ELB.
 resource "aws_route53_record" "service_record_internal" {
   zone_id = "${data.aws_route53_zone.internal.zone_id}"
   name    = "backend.${var.internal_domain_name}"
@@ -129,6 +148,7 @@ resource "aws_route53_record" "service_record_internal" {
   }
 }
 
+# TODO: remove once Prod traffic is moved off the classic ELB.
 resource "aws_route53_record" "app_service_records_internal" {
   count   = "${length(var.app_service_records)}"
   zone_id = "${data.aws_route53_zone.internal.zone_id}"
@@ -146,6 +166,8 @@ module "backend" {
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_backend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}", "${data.terraform_remote_state.infra_security_groups.sg_aws-vpn_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
+
+  # TODO: remove instance_elb_ids* once Prod traffic is moved off the classic ELB.
   instance_elb_ids_length       = 1
   instance_elb_ids              = ["${aws_elb.backend_elb_internal.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
@@ -156,6 +178,7 @@ module "backend" {
   root_block_device_volume_size = "60"
 }
 
+# TODO: remove once Prod traffic is moved off the classic ELB.
 module "alarms-elb-backend-internal" {
   source                         = "../../modules/aws/alarms/elb"
   name_prefix                    = "${var.stackname}-backend-internal"
@@ -168,3 +191,207 @@ module "alarms-elb-backend-internal" {
   surgequeuelength_threshold     = "0"
   healthyhostcount_threshold     = "0"
 }
+
+module "public_lb" {
+  source                           = "../../modules/aws/lb"
+  name                             = "govuk-backend-public"
+  internal                         = false
+  vpc_id                           = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix        = "elb/govuk-backend-public-elb"
+  listener_certificate_domain_name = "${var.elb_public_certname}"
+
+  listener_action = {
+    "HTTPS:443" = "HTTP:80"
+  }
+
+  subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_backend_elb_external_id}"]
+  alarm_actions   = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  default_tags    = "${local.common_tags}"
+}
+
+# TODO: return 400 when hostname is unknown
+# (https://tools.ietf.org/html/rfc7230#section-5.4). This is important to
+# ensure that there is no L7 ingress to internal-only "backend" apps from the
+# Internet.
+
+resource "aws_wafregional_web_acl_association" "public_lb" {
+  resource_arn = "${module.public_lb.lb_id}"
+  web_acl_id   = "${data.terraform_remote_state.infra_public_services.default_waf_acl}"
+}
+
+resource "aws_route53_record" "public_lb_alias" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "backend"
+  type    = "A"
+
+  alias {
+    name                   = "${module.public_lb.lb_dns_name}"
+    zone_id                = "${module.public_lb.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+module "internal_lb" {
+  source                           = "../../modules/aws/lb"
+  name                             = "govuk-backend-internal"
+  internal                         = true
+  vpc_id                           = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix        = "elb/govuk-backend-internal-elb"
+  listener_certificate_domain_name = "${var.elb_internal_certname}"
+
+  listener_action = {
+    "HTTPS:443" = "HTTP:80"
+  }
+
+  subnets         = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_backend_elb_internal_id}"]
+  alarm_actions   = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+
+  default_tags = "${local.common_tags}"
+}
+
+resource "aws_route53_record" "internal_lb_alias" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "backend"
+  type    = "A"
+
+  alias {
+    name                   = "${module.internal_lb.lb_dns_name}"
+    zone_id                = "${module.internal_lb.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+#
+# Target groups and autoscaling group attachments.
+#
+# Each service on the `backend` machines has one aws_lb_target_group and one
+# aws_autoscaling_attachment. Each aws_lb_target_group is referred to by up to
+# two aws_lb_listener_rules, depending on whether it's behind the public LB or
+# the internal LB or both.
+#
+# AWS has a hard limit of 50 TGs on an ASG and we have over 30 services running
+# on `backend`, so we need to stick to just one TG for each service. This also
+# minimises the overhead caused by healthchecks.
+#
+# Generating all this using count() and lists may seem tempting, but we tried
+# that and it led to extreme difficulties in making simple changes such as
+# retiring a service, changing a timeout on a particular service, or avoiding
+# creating unnecessary duplicate target groups for each load balancer so that
+# we stay below 50 TG per ASG limit. Repetition is not the enemy here; this is
+# config, not application logic.
+#
+
+resource "aws_lb_target_group" "asset-manager" {
+  name     = "backend-asset-manager"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  tags     = "${local.common_tags}"
+
+  health_check {
+    interval            = 30
+    path                = "/_healthcheck_asset-manager"
+    matcher             = "200-399"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 5
+  }
+}
+
+resource "aws_autoscaling_attachment" "asset-manager" {
+  autoscaling_group_name = "${module.backend.autoscaling_group_name}"
+  alb_target_group_arn   = "${aws_lb_target_group.asset-manager.arn}"
+}
+
+resource "aws_lb_target_group" "collections-publisher" {
+  name     = "backend-collections-publisher"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  tags     = "${local.common_tags}"
+
+  health_check {
+    interval            = 30
+    path                = "/_healthcheck_collections-publisher"
+    matcher             = "200-399"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 5
+  }
+}
+
+resource "aws_autoscaling_attachment" "collections-publisher" {
+  autoscaling_group_name = "${module.backend.autoscaling_group_name}"
+  alb_target_group_arn   = "${aws_lb_target_group.collections-publisher.arn}"
+}
+
+# TODO: add TGs and ASG attachments for the rest of the services from backend_public_service_cnames and app_service_records (without duplicates).
+
+#
+# LB listener rules and CNAME records for services on internal LB.
+#
+
+resource "aws_lb_listener_rule" "asset-manager-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.asset-manager.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["asset-manager.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "internal_lb_cname_asset_manager" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "asset-manager"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+# TODO: add listener rules and CNAMEs for the rest of the app_service_records services.
+
+#
+# LB listener rules and CNAME records for services on public (external) LB.
+#
+
+resource "aws_lb_listener_rule" "collections-publisher-external" {
+  listener_arn = "${module.public_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.collections-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["collections-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "public_lb_cname_collections_publisher" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "collections-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.public_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+# TODO: add listener rules and CNAMEs for the rest of the backend_public_service_cnames services.
+

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -935,7 +935,7 @@ resource "aws_lb_listener_rule" "asset-manager-internal" {
   }
 }
 
-resource "aws_route53_record" "internal_lb_cname_asset_manager" {
+resource "aws_route53_record" "asset-manager-internal" {
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
   name    = "asset-manager"
   type    = "CNAME"
@@ -943,7 +943,725 @@ resource "aws_route53_record" "internal_lb_cname_asset_manager" {
   ttl     = "300"
 }
 
-# TODO: add listener rules and CNAMEs for the rest of the app_service_records services.
+resource "aws_lb_listener_rule" "backdrop-admin-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 200
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.backdrop-admin.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["backdrop-admin.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "backdrop-admin-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "backdrop-admin"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "canary-backend-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 300
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.canary-backend.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["canary-backend.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "canary-backend-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "canary-backend"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "collections-publisher-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 400
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.collections-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["collections-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "collections-publisher-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "collections-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "contacts-admin-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 500
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.contacts-admin.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["contacts-admin.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "contacts-admin-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "contacts-admin"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "content-data-admin-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 600
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.content-data-admin.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["content-data-admin.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "content-data-admin-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "content-data-admin"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "content-data-api-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 700
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.content-data-api.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["content-data-api.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "content-data-api-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "content-data-api"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "content-performance-manager-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 800
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.content-performance-manager.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["content-performance-manager.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "content-performance-manager-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "content-performance-manager"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "content-publisher-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 900
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.content-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["content-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "content-publisher-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "content-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "content-tagger-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1000
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.content-tagger.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["content-tagger.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "content-tagger-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "content-tagger"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "docs-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1100
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.docs.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["docs.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "docs-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "docs"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "event-store-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1200
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.event-store.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["event-store.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "event-store-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "event-store"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "hmrc-manuals-api-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1300
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.hmrc-manuals-api.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["hmrc-manuals-api.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "hmrc-manuals-api-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "hmrc-manuals-api"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "imminence-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1400
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.imminence.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["imminence.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "imminence-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "imminence"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "link-checker-api-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1500
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.link-checker-api.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["link-checker-api.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "link-checker-api-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "link-checker-api"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "local-links-manager-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1600
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.local-links-manager.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["local-links-manager.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "local-links-manager-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "local-links-manager"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "manuals-publisher-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1700
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.manuals-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["manuals-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "manuals-publisher-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "manuals-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "maslow-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1800
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.maslow.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["maslow.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "maslow-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "maslow"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "performanceplatform-admin-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 1900
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.performanceplatform-admin.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["performanceplatform-admin.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "performanceplatform-admin-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "performanceplatform-admin"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "policy-publisher-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2000
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.policy-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["policy-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "policy-publisher-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "policy-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "publisher-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2100
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "publisher-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "release-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2200
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.release.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["release.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "release-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "release"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "search-admin-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2300
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.search-admin.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["search-admin.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "search-admin-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "search-admin"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "service-manual-publisher-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2400
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.service-manual-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["service-manual-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "service-manual-publisher-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "service-manual-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "short-url-manager-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2500
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.short-url-manager.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["short-url-manager.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "short-url-manager-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "short-url-manager"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "signon-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2600
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.signon.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["signon.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "signon-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "signon"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "specialist-publisher-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2700
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.specialist-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["specialist-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "specialist-publisher-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "specialist-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "support-api-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2800
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.support-api.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["support-api.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "support-api-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "support-api"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "support-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 2900
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.support.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["support.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "support-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "support"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "transition-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 3000
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.transition.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["transition.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "transition-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "transition"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
+
+resource "aws_lb_listener_rule" "travel-advice-publisher-internal" {
+  listener_arn = "${module.internal_lb.load_balancer_ssl_listeners[0]}"
+  priority     = 3100
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.travel-advice-publisher.arn}"
+  }
+
+  condition {
+    host_header {
+      values = ["travel-advice-publisher.*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "travel-advice-publisher-internal" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "travel-advice-publisher"
+  type    = "CNAME"
+  records = ["${aws_route53_record.internal_lb_alias.fqdn}"]
+  ttl     = "300"
+}
 
 #
 # LB listener rules and CNAME records for services on public (external) LB.
@@ -965,7 +1683,7 @@ resource "aws_lb_listener_rule" "collections-publisher-external" {
   }
 }
 
-resource "aws_route53_record" "public_lb_cname_collections_publisher" {
+resource "aws_route53_record" "collections-publisher-external" {
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
   name    = "collections-publisher"
   type    = "CNAME"

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -1745,7 +1745,10 @@ resource "aws_lb_listener_rule" "content-data-admin-external" {
 
   condition {
     host_header {
-      values = ["content-data-admin.*"]
+      # content-data-admin is accessed via both
+      # content-data-admin.publishing.service.gov.uk and
+      # content-data.publishing.service.gov.uk. The latter is canonical.
+      values = ["content-data-admin.*", "content-data.*"]
     }
   }
 }

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -168,21 +168,3 @@ module "alarms-elb-backend-internal" {
   surgequeuelength_threshold     = "0"
   healthyhostcount_threshold     = "0"
 }
-
-# Outputs
-# --------------------------------------------------------------
-
-output "backend_elb_internal_address" {
-  value       = "${aws_elb.backend_elb_internal.dns_name}"
-  description = "AWS' internal DNS name for the backend ELB"
-}
-
-output "service_dns_name_internal" {
-  value       = "${aws_route53_record.service_record_internal.name}"
-  description = "DNS name to access the node service"
-}
-
-output "app_service_records_internal_dns_name" {
-  value       = "${aws_route53_record.app_service_records_internal.*.name}"
-  description = "DNS name to access the app service records"
-}

--- a/terraform/projects/app-backend/remote_state.tf
+++ b/terraform/projects/app-backend/remote_state.tf
@@ -47,6 +47,12 @@ variable "remote_state_infra_monitoring_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_public_services_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_public_services remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -106,6 +112,16 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
+    region = "${var.aws_region}"
+  }
+}
+
+data "terraform_remote_state" "infra_public_services" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_public_services_key_stack, var.stackname)}/infra-public-services.tfstate"
     region = "${var.aws_region}"
   }
 }

--- a/tools/generate-remote-state-boiler-plate.sh
+++ b/tools/generate-remote-state-boiler-plate.sh
@@ -59,6 +59,12 @@ variable "remote_state_infra_monitoring_key_stack" {
   default     = ""
 }
 
+variable "remote_state_infra_public_services_key_stack" {
+  type        = "string"
+  description = "Override stackname path to infra_public_services remote state "
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -118,6 +124,16 @@ data "terraform_remote_state" "infra_monitoring" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
+    region = "${var.aws_region}"
+  }
+}
+
+data "terraform_remote_state" "infra_public_services" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_public_services_key_stack, var.stackname)}/infra-public-services.tfstate"
     region = "${var.aws_region}"
   }
 }


### PR DESCRIPTION
### What

* Define a new ALB `govuk-backend-internal` for internal traffic.
* Use a single target group per app. Where an app is supposed to be reachable both internally and externally, point both LBs at the app's target group rather than creating duplicate target groups, which we can't afford because of the 50 TG per ASG hard limit.
* Move the existing `govuk-backend-public` ALB definition into the `app-backend` project. The two ALBs need to be in the same place in order to use the same set of TGs without excessive complexity.
* Move the service DNS records along with the ALBs. These belong together because they're inherently tightly coupled to the ALBs.
* Prevent ingress from the Internet to internal-only services via the public/external load balancer.

### Why

Our `lb_listener_rules` module has become unsuitable for configuring the `backend` load balancers. This is because:

* We need to do [per-app healthchecks](https://github.com/alphagov/govuk-aws/blob/master/doc/architecture/decisions/0037-alb-health-checks.md) in order for our services to be sufficiently reliable.
* The `backend` autoscaling group hosts 31 services and needs both an external and an internal LB. Most, but not all, of the services are available both internally and externally.
* In order to do per-app healthchecks on the internal LB, we need to upgrade it from classic ELB to ALB (like the external one).
* AWS has a hard limit of 50 target groups on a given autoscaling group. This isn't one of the quotas that they can raise for us.
* We only need a single TG for each application service (in order to healthcheck each app independently), but `lb_listener_rules` prevents us from doing this because it encapsulates the creation of the listener rule, TG and ASG attachment. With `lb_listener_rules`, we end up trying to attach 62 or more TGs to a single ASG and failing.

Therefore, given that we need per-app healthchecks before migrating the publisher apps to AWS, we have to move away from `lb_listener_rules`.

The lb_listener_rules module also makes extensive use of Terraform lists and `count`, which causes severe problems when there are many services on the same load balancer. These include the inability to remove a service without causing downtime for other services. We have encountered situations in which removing a service from near the top of the list results in Terraform failing part-way through the rollout, breaking the live configuration and entering a state which cannot be recovered from by re-running `apply`.

### Design goals / nonfunctional requirements

* Ease of understanding (relative to what we had before).
* Ease of maintenance.
* Flexibility.
    * We need to be able to easily adapt config to meet unforeseen future needs, not just anticipated ones.
* Straightforward changes like adding/removing a service or changing settings for a particular service should be simple and obvious to make and safe to roll out.
* Changes to one service should not be able to affect other services.
* Keeping related (or closely coupled or interdependent) config together.
    * If two config items need to be read together in order to understand what's going on, they should be in the same place unless there's an overriding reason for them not to be (for example if one of the config items is shared between many other TF projects and therefore warrants being in a central place or its own project).
    * We want to avoid making the user jump between lots of different files and having to keep an unnecessarily large amount of state in their head when making changes.
* Avoiding multiple definitions of information which would cause problems if they were to go out of sync.

#### Non-goals

 * Minimising the number of lines of code.
 * Avoiding repetition just for the sake of avoiding repetition.
    * It's important to remember that this is configuration code, not application logic. Good config code contains almost no logic.
    * This isn't supposed to be a program which generates config. It's supposed to *be* the config.

### Tips for reviewing

This is probably not one to review line-by-line 😅 I'd recommend going commit-by-commit, focusing on the _Avoid using lb_listener_rules module for backend LBs_ commit and assessing the overall approach and structure against the design goals above. The `terraform plan` output is as important as the code changes, of course (see links in comments below).

I'm not too worried about detail mistakes getting missed in review, because we're likely to catch those in testing. My primary concern is that we converge on a structure and approach that's maintainable for the future as well as solving the immediate practical problem.

### Requisite PRs in other repos

* alphagov/govuk-aws-data/pull/703