### PR TITLE
Enable Enhanced Monitoring on RDS Postgres.

### DIFF
--- a/terraform/modules/aws/rds_instance/README.md
+++ b/terraform/modules/aws/rds_instance/README.md
@@ -27,6 +27,8 @@ Create an RDS instance
 | instance\_name | The RDS Instance Name. | `string` | `""` | no |
 | maintenance\_window | The window to perform maintenance in. | `string` | `"Mon:04:00-Mon:06:00"` | no |
 | max\_allocated\_storage | current maximum storage in GB that AWS can autoscale the RDS storage to, 0 means disabled autoscaling | `string` | `"100"` | no |
+| monitoring\_interval | Collection interval in seconds for Enhanced Monitoring metrics. Default is 0, which disables Enhanced Monitoring. Valid values are 0, 1, 5, 10, 15, 30, 60. | `string` | `"0"` | no |
+| monitoring\_role\_arn | ARN of the IAM role which lets RDS send Enhanced Monitoring logs to CloudWatch. Must be specified if monitoring\_interval is non-zero. | `string` | `""` | no |
 | multi\_az | Specifies if the RDS instance is multi-AZ | `string` | `true` | no |
 | name | The common name for all the resources created by this module | `string` | n/a | yes |
 | parameter\_group\_name | Name of the parameter group to make the instance a member of. | `string` | `""` | no |

--- a/terraform/modules/aws/rds_instance/main.tf
+++ b/terraform/modules/aws/rds_instance/main.tf
@@ -181,6 +181,18 @@ variable "terraform_delete_rds_timeout" {
   default     = "2h"
 }
 
+variable "monitoring_interval" {
+  type        = "string"
+  description = "Collection interval in seconds for Enhanced Monitoring metrics. Default is 0, which disables Enhanced Monitoring. Valid values are 0, 1, 5, 10, 15, 30, 60."
+  default     = "0"
+}
+
+variable "monitoring_role_arn" {
+  type        = "string"
+  description = "ARN of the IAM role which lets RDS send Enhanced Monitoring logs to CloudWatch. Must be specified if monitoring_interval is non-zero."
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -205,6 +217,8 @@ resource "aws_db_instance" "db_instance_replica" {
   vpc_security_group_ids = ["${var.security_group_ids}"]
   replicate_source_db    = "${var.replicate_source_db}"
   parameter_group_name   = "${var.parameter_group_name}"
+  monitoring_interval    = "${var.monitoring_interval}"
+  monitoring_role_arn    = "${var.monitoring_role_arn}"
 
   timeouts {
     create = "${var.terraform_create_rds_timeout}"
@@ -238,6 +252,8 @@ resource "aws_db_instance" "db_instance" {
   backup_window           = "${var.backup_window}"
   copy_tags_to_snapshot   = "${var.copy_tags_to_snapshot}"
   snapshot_identifier     = "${var.snapshot_identifier}"
+  monitoring_interval     = "${var.monitoring_interval}"
+  monitoring_role_arn     = "${var.monitoring_role_arn}"
 
   timeouts {
     create = "${var.terraform_create_rds_timeout}"

--- a/terraform/projects/app-content-data-api-postgresql/main.tf
+++ b/terraform/projects/app-content-data-api-postgresql/main.tf
@@ -150,6 +150,8 @@ module "content-data-api-postgresql-primary_rds_instance" {
   event_sns_topic_arn   = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
   skip_final_snapshot   = "${var.skip_final_snapshot}"
   snapshot_identifier   = "${var.snapshot_identifier}"
+  monitoring_interval   = "60"
+  monitoring_role_arn   = "${data.terraform_remote_state.infra_monitoring.rds_enhanced_monitoring_role_arn}"
 }
 
 resource "aws_route53_record" "service_record" {

--- a/terraform/projects/app-postgresql/README.md
+++ b/terraform/projects/app-postgresql/README.md
@@ -33,6 +33,7 @@ RDS PostgreSQL instances
 | skip\_final\_snapshot | Set to true to NOT create a final snapshot when the cluster is deleted. | `string` | n/a | yes |
 | snapshot\_identifier | Specifies whether or not to create the database from this snapshot | `string` | `""` | no |
 | stackname | Stackname | `string` | n/a | yes |
+| standby\_instance\_type | Instance type used for standby RDS | `string` | `"db.m5.4xlarge"` | no |
 | username | PostgreSQL username | `string` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -131,6 +131,8 @@ module "postgresql-primary_rds_instance" {
   skip_final_snapshot   = "${var.skip_final_snapshot}"
   snapshot_identifier   = "${var.snapshot_identifier}"
   parameter_group_name  = "${aws_db_parameter_group.postgresql_pg.name}"
+  monitoring_interval   = "60"
+  monitoring_role_arn   = "${data.terraform_remote_state.infra_monitoring.rds_enhanced_monitoring_role_arn}"
 }
 
 resource "aws_route53_record" "service_record" {

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -67,6 +67,13 @@ variable "instance_type" {
   default     = "db.m5.12xlarge"
 }
 
+# TODO: confirm that the standby instance is unused and if so, decommission it.
+variable "standby_instance_type" {
+  type        = "string"
+  description = "Instance type used for standby RDS"
+  default     = "db.m5.4xlarge"
+}
+
 variable "allocated_storage" {
   type        = "string"
   description = "current set minimum storage in GB for the RDS"
@@ -148,7 +155,7 @@ module "postgresql-standby_rds_instance" {
 
   name                       = "${var.stackname}-postgresql-standby"
   default_tags               = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "postgresql_standby")}"
-  instance_class             = "${var.instance_type}"
+  instance_class             = "${var.standby_instance_type}"
   instance_name              = "${var.stackname}-postgresql-standby"
   security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_postgresql-primary_id}"]
   create_replicate_source_db = "1"

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -119,6 +119,8 @@ module "transition-postgresql-primary_rds_instance" {
   skip_final_snapshot   = "${var.skip_final_snapshot}"
   snapshot_identifier   = "${var.snapshot_identifier}"
   parameter_group_name  = "${aws_db_parameter_group.app_transition_pg.name}"
+  monitoring_interval   = "60"
+  monitoring_role_arn   = "${data.terraform_remote_state.infra_monitoring.rds_enhanced_monitoring_role_arn}"
 }
 
 resource "aws_route53_record" "service_record" {
@@ -144,6 +146,8 @@ module "transition-postgresql-standby_rds_instance" {
   event_sns_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
   skip_final_snapshot        = "${var.skip_final_snapshot}"
   parameter_group_name       = "${aws_db_parameter_group.app_transition_pg.name}"
+  monitoring_interval        = "60"
+  monitoring_role_arn        = "${data.terraform_remote_state.infra_monitoring.rds_enhanced_monitoring_role_arn}"
 }
 
 resource "aws_route53_record" "replica_service_record" {


### PR DESCRIPTION
* Enable Enhanced Monitoring on all of our RDS Postgres instances.
* Keep the RDS Postgres standby instance at its current size.

We recently enabled Enhanced Monitoring on the shared Postgres RDS in production. This change reflects that, and also enables it on all the other Postgres RDS instances in all environments. The cost of doing so is negligible (just a modest amount of log storage) and the benefits are significant, as it gives us per-process history of CPU usage (and therefore per-query history of CPU usage, albeit sampled).

We also recently enlarged the shared Postgres RDS in production to 12xlarge. We want to avoid applying the same change to the standby instance, which appears to be disused. We'll want to confirm that it's disused and if so, decommission it in the near future - but I'll leave that for another PR.

The `rds-monitoring-role` IAM role and policy attachment were already added in #1276.

alphagov/govuk-aws-data#702 keeps the Integration standby instance the same size.