### PR TITLE
Create an ASG for concourse to use for search LTR data generation

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -128,6 +128,7 @@ Manage the security groups for the entire infrastructure
 | sg\_router-api\_elb\_id | n/a |
 | sg\_router-backend\_id | n/a |
 | sg\_search-api\_external\_elb\_id | n/a |
+| sg\_search-ltr-generation\_id | n/a |
 | sg\_search\_elb\_id | n/a |
 | sg\_search\_id | n/a |
 | sg\_shared\_documentdb\_id | n/a |

--- a/terraform/projects/infra-security-groups/elasticsearch6.tf
+++ b/terraform/projects/infra-security-groups/elasticsearch6.tf
@@ -4,6 +4,7 @@
 # The elasticsearch cluster needs to be accessible on ports:
 #   - 80 and 443 from 'calculators_frontend' (for licence-finder)
 #   - 80 and 443 from 'search' (for search-api)
+#   - 443 search-ltr-generation
 #
 # When both licence-finder and search-api are using https, the http
 # rule can be removed.
@@ -75,4 +76,30 @@ resource "aws_security_group_rule" "elasticsearch6_ingress_search_elasticsearch-
 
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.search.id}"
+}
+
+resource "aws_security_group_rule" "elasticsearch6_ingress_search-ltr-generation_elasticsearch-api" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.elasticsearch6.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.search-ltr-generation.id}"
+}
+
+resource "aws_security_group_rule" "elasticsearch6_ingress_search-ltr-generation_elasticsearch-api-https" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.elasticsearch6.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.search-ltr-generation.id}"
 }

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -354,6 +354,10 @@ output "sg_search_id" {
   value = "${aws_security_group.search.id}"
 }
 
+output "sg_search-ltr-generation_id" {
+  value = "${aws_security_group.search-ltr-generation.id}"
+}
+
 output "sg_static_carrenza_alb_id" {
   value = "${aws_security_group.static_carrenza_alb.id}"
 }

--- a/terraform/projects/infra-security-groups/search-api.tf
+++ b/terraform/projects/infra-security-groups/search-api.tf
@@ -31,17 +31,6 @@ resource "aws_security_group_rule" "search-api_ingress_carrenza_external-elb_htt
   cidr_blocks       = ["${var.carrenza_env_ips}"]
 }
 
-resource "aws_security_group_rule" "search-api_ingress_concourse_external-elb_https" {
-  count     = "${length(var.concourse_ips) > 0 ? 1 : 0}"
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  security_group_id = "${aws_security_group.search-api_external_elb.id}"
-  cidr_blocks       = ["${var.concourse_ips}"]
-}
-
 resource "aws_security_group_rule" "search-api_egress_external_elb_any_any" {
   type              = "egress"
   from_port         = 0

--- a/terraform/projects/infra-security-groups/search-ltr-generation.tf
+++ b/terraform/projects/infra-security-groups/search-ltr-generation.tf
@@ -1,0 +1,29 @@
+resource "aws_security_group" "search-ltr-generation" {
+  name = "search-ltr-generation_access"
+
+  vpc_id = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+
+  tags {
+    Name = "search-ltr-generation"
+  }
+}
+
+resource "aws_security_group_rule" "search-ltr-generation_ingress_concourse_ssh" {
+  type        = "ingress"
+  protocol    = "tcp"
+  from_port   = 22
+  to_port     = 22
+  cidr_blocks = ["${var.concourse_ips}"]
+
+  security_group_id = "${aws_security_group.search-ltr-generation.id}"
+}
+
+resource "aws_security_group_rule" "search-ltr-generation_egress_any_any" {
+  type        = "egress"
+  protocol    = "-1"
+  from_port   = 0
+  to_port     = 0
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.search-ltr-generation.id}"
+}


### PR DESCRIPTION
This PR creates an ASG, where the node template uses the same role
as the regular search machines, so members will be able to access
Elasticsearch and S3 just as search-api currently does.

Currently training data is generated by sending an HTTP request to
search-api and waiting.  But we want to now start producing more
training data, which will significantly slow that down.  We don't want
to put lots of extra strain on a live search-api instance, so instead
here's how it's going to work:

1. Concourse will scale up the ASG to 1 member
2. Concourse will SSH in to the new instance, then:
   1. Clone search-api from github
   2. Install dependencies
   3. Run the training data generation rake task
3. Concourse will scale down the ASG to 0 members

---

[Trello card](https://trello.com/c/IsptO4Kk/1451-implement-elephant-model-changes)
[Plan (infra-security-groups)](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4154/console)
[Plan (app-search)](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4161/console)