### PR TITLE
Update Gatling load-testing instances to 1

### DIFF
--- a/terraform/projects/app-gatling/README.md
+++ b/terraform/projects/app-gatling/README.md
@@ -14,9 +14,9 @@ Gatling node
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
-| asg\_desired\_capacity | The autoscaling groups desired capacity | `string` | `"0"` | no |
-| asg\_max\_size | The autoscaling groups max\_size | `string` | `"0"` | no |
-| asg\_min\_size | The autoscaling groups max\_size | `string` | `"0"` | no |
+| asg\_desired\_capacity | The autoscaling groups desired capacity | `string` | `"1"` | no |
+| asg\_max\_size | The autoscaling groups max\_size | `string` | `"1"` | no |
+| asg\_min\_size | The autoscaling groups min\_size | `string` | `"1"` | no |
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | ebs\_encrypted | Whether or not the EBS volume is encrypted | `string` | n/a | yes |

--- a/terraform/projects/app-gatling/main.tf
+++ b/terraform/projects/app-gatling/main.tf
@@ -22,19 +22,19 @@ variable "aws_environment" {
 variable "asg_desired_capacity" {
   type        = "string"
   description = "The autoscaling groups desired capacity"
-  default     = "0"
+  default     = "1"
 }
 
 variable "asg_max_size" {
   type        = "string"
   description = "The autoscaling groups max_size"
-  default     = "0"
+  default     = "1"
 }
 
 variable "asg_min_size" {
   type        = "string"
-  description = "The autoscaling groups max_size"
-  default     = "0"
+  description = "The autoscaling groups min_size"
+  default     = "1"
 }
 
 variable "ebs_encrypted" {


### PR DESCRIPTION
During a period of forthcoming load-testing we would like to maintain an active Gatling instance.