### PR TITLE
Update the scaling times of the Knowledge Graph ASG

### DIFF
--- a/terraform/projects/app-data-science-data/main.tf
+++ b/terraform/projects/app-data-science-data/main.tf
@@ -169,7 +169,7 @@ resource "aws_autoscaling_group" "data-science-data_asg" {
 resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-up" {
   autoscaling_group_name = "${aws_autoscaling_group.data-science-data_asg.name}"
   scheduled_action_name  = "data-science-data_schedule-spin-up"
-  recurrence             = "0 7 * * MON-SUN"
+  recurrence             = "0 6 * * MON-SUN"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 1
@@ -178,7 +178,7 @@ resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-up" {
 resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-down" {
   autoscaling_group_name = "${aws_autoscaling_group.data-science-data_asg.name}"
   scheduled_action_name  = "data-science-data_schedule-spin-down"
-  recurrence             = "59 7 * * MON-SUN"
+  recurrence             = "59 6 * * MON-SUN"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 0

--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -263,7 +263,7 @@ resource "aws_autoscaling_group" "knowledge-graph_asg" {
 resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-up" {
   autoscaling_group_name = "${aws_autoscaling_group.knowledge-graph_asg.name}"
   scheduled_action_name  = "knowledge-graph_schedule-spin-up"
-  recurrence             = "0 9 * * MON-FRI"
+  recurrence             = "0 8 * * MON-FRI"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 1
@@ -272,7 +272,7 @@ resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-up" {
 resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-down" {
   autoscaling_group_name = "${aws_autoscaling_group.knowledge-graph_asg.name}"
   scheduled_action_name  = "knowledge-graph_schedule-spin-down"
-  recurrence             = "55 17 * * MON-FRI"
+  recurrence             = "55 16 * * MON-FRI"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 0


### PR DESCRIPTION
This PR updates the scaling times of the Knowledge Graph auto scaling group to maintain the expected availability of the platform now that we are in UTC+1. Auto scaling group scheduled actions do not cater for any other timezone than UTC, so this is a necessary change to ensure the graph is available when people expect it to be (see https://docs.aws.amazon.com/autoscaling/ec2/userguide/schedule_time.html for more info).