### PR TITLE
tools/govukcli: Deprecate SSH, and remove AWS features

### DIFF
--- a/tools/govukcli
+++ b/tools/govukcli
@@ -27,8 +27,6 @@ function usage {
   get-context              Get the current context.
   list-contexts            Show the available contexts.
 
-  ssh [options]            Run "$0 ssh help" for details.
-
   help                     Show this help.
 
   Set the GOVUKCLI_OUTPUT environment variable to
@@ -43,22 +41,15 @@ EOF
 
 function ssh_usage {
   cat << EOF
-  Usage: govukcli ssh [options]
+  DEPRECATED: Use the "gds govuk connect" command instead
 
-  By default it will expect a Puppet node class (eg backend, frontend), and
-  will attempt to SSH to a random instance within that class. If only a single
-  instance exists, then it will SSH to that instance (eg puppetmaster,
-  jenkins).
+    - Run "brew tap alphagov/gds; brew install gds-cli govuk-connect"
 
-  Options:
-
-  set-user <username>  Set a different username to SSH with than the default
-                       shell user ($(whoami)).
-
-  node-types           List the types of instances available to connect to.
-
-  node-list <machine>  List the machines for a particular node. Try node-list whitehall_backend.
-
+    - To SSH to a GOV.UK Integration backend machine:
+        gds govuk connect -e integration ssh backend
+    - To SSH into a GOV.UK Carrenza Production monitoring machine:
+        gds govuk connect -e production ssh carrenza/monitoring
+    - Read the "gds govuk connect --help" output for more command examples!
 EOF
 }
 

--- a/tools/govukcli
+++ b/tools/govukcli
@@ -62,25 +62,6 @@ function ssh_usage {
 EOF
 }
 
-function aws_usage {
-  cat << EOF
-    DEPRECATED: Use the gds-cli instead.
-
-    - Run "brew install alphagov/gds/gds-cli"
-    - Read the setup and usage instructions at https://docs.publishing.service.gov.uk/manual/gds-cli.html.
-
-    Examples:
-
-    - To assume-role into GOV.UK Integration as a PowerUser and get an AWS Console:
-        gds aws govuk-integration-poweruser -l
-
-    - To assume-role into GOV.UK Production as a PlatformHealthPowerUser and export some access keys for Terraform:
-        gds aws govuk-production-platformhealth-poweruser -e
-
-    - Read the README or play around for more command examples!
-EOF
-}
-
 # Set regex for allowed things
 ALLOWED_CONTEXTS=$(echo "^(${CONTEXTS})$" | sed 's/ /\|/g')
 
@@ -287,7 +268,6 @@ case ${COMMAND} in
   'list-contexts') list_contexts;;
   'set-context') set_context $1;;
   'ssh') run_ssh "$@";;
-  'aws') run_aws "$@";;
   'help') usage ;;
   *) usage ;;
 esac


### PR DESCRIPTION
SSH:

- We sent out an email about deprecating `govukcli ssh`, pointing people
  to the new way: `gds govuk connect`, as documented in the dev docs.
- This does the same deprecation as we did for the AWS command.

AWS:

- The `govukcli aws` command has been deprecated for 6 months - since
November (6cd2d59535749f14bfebe2b1008605b0152fb287).
- That's enough time for people to migrate to `gds aws`.

https://trello.com/c/ZBGHVlTr/132-deprecate-and-delete-govukcli