### PR TITLE
Change the prometheus instance type to t3.small

### DIFF
--- a/terraform/projects/app-prometheus/README.md
+++ b/terraform/projects/app-prometheus/README.md
@@ -17,7 +17,7 @@ Prometheus node
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | instance\_ami\_filter\_name | Name to use to find AMI images | `string` | `"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"` | no |
-| instance\_type | Instance type used for EC2 resources | `string` | `"t3.micro"` | no |
+| instance\_type | Instance type used for EC2 resources | `string` | `"t3.small"` | no |
 | prometheus\_1\_subnet | Name of the subnet to place the Prometheus instance and EBS volume | `string` | n/a | yes |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_monitoring\_key\_stack | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |

--- a/terraform/projects/app-prometheus/main.tf
+++ b/terraform/projects/app-prometheus/main.tf
@@ -35,7 +35,7 @@ variable "prometheus_1_subnet" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for EC2 resources"
-  default     = "t3.micro"
+  default     = "t3.small"
 }
 
 # Resources


### PR DESCRIPTION
From a t3.micro, as it looks like with the addition of data for the
router, Prometheus requires more than 1GB of memory.