### PR TITLE
Remove calendars

### DIFF
--- a/doc/guides/redeploying-applications-on-rebuild.md
+++ b/doc/guides/redeploying-applications-on-rebuild.md
@@ -72,7 +72,6 @@ static
 
 ```
 calculators
-calendars
 finder-frontend
 licencefinder
 smartanswers

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -44,7 +44,6 @@ This project adds global resources for app components:
 | cache\_public\_service\_names | n/a | `list` | `[]` | no |
 | calculators\_frontend\_internal\_service\_cnames | n/a | `list` | `[]` | no |
 | calculators\_frontend\_internal\_service\_names | n/a | `list` | `[]` | no |
-| calendars\_public\_service\_names | n/a | `list` | `[]` | no |
 | ckan\_internal\_service\_cnames | n/a | `list` | `[]` | no |
 | ckan\_internal\_service\_names | n/a | `list` | `[]` | no |
 | ckan\_public\_service\_cnames | n/a | `list` | `[]` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -84,11 +84,6 @@ variable "cache_public_service_cnames" {
   default = []
 }
 
-variable "calendars_public_service_names" {
-  type    = "list"
-  default = []
-}
-
 variable "ckan_public_service_names" {
   type    = "list"
   default = []
@@ -779,62 +774,6 @@ resource "aws_route53_record" "cache_internal_service_cnames" {
   type    = "CNAME"
   records = ["${element(var.cache_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
   ttl     = "300"
-}
-
-#
-# Calendars
-#
-
-module "calendars_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-calendars-public"
-  internal                                   = false
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-calendars-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-
-  listener_action = {
-    "HTTPS:443" = "HTTP:80"
-  }
-
-  target_group_health_check_path = "/_healthcheck"
-  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_calendars_carrenza_alb_id}"]
-  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                   = "${map("Project", var.stackname, "aws_migration", "calendars", "aws_environment", var.aws_environment)}"
-}
-
-resource "aws_route53_record" "calendars_public_service_names" {
-  count   = "${length(var.calendars_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
-  name    = "${element(var.calendars_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.calendars_public_lb.lb_dns_name}"
-    zone_id                = "${module.calendars_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-data "aws_autoscaling_groups" "calendars" {
-  filter {
-    name   = "key"
-    values = ["Name"]
-  }
-
-  filter {
-    name   = "value"
-    values = ["blue-calculators-frontend"]
-  }
-}
-
-resource "aws_autoscaling_attachment" "calendars_asg_attachment_alb" {
-  count                  = "${length(data.aws_autoscaling_groups.calendars.names) > 0 ? 1 : 0}"
-  autoscaling_group_name = "${element(data.aws_autoscaling_groups.calendars.names, 0)}"
-  alb_target_group_arn   = "${element(module.calendars_public_lb.target_group_arns, 0)}"
 }
 
 # Calculators-frontend

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -63,7 +63,6 @@ Manage the security groups for the entire infrastructure
 | sg\_cache\_id | n/a |
 | sg\_calculators-frontend\_elb\_id | n/a |
 | sg\_calculators-frontend\_id | n/a |
-| sg\_calendars\_carrenza\_alb\_id | n/a |
 | sg\_ckan\_elb\_external\_id | n/a |
 | sg\_ckan\_elb\_internal\_id | n/a |
 | sg\_ckan\_id | n/a |

--- a/terraform/projects/infra-security-groups/calculators-frontend.tf
+++ b/terraform/projects/infra-security-groups/calculators-frontend.tf
@@ -21,16 +21,6 @@ resource "aws_security_group" "calculators-frontend" {
   }
 }
 
-resource "aws_security_group" "calendars" {
-  name        = "${var.stackname}_calendars_access"
-  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  description = "Access to the calendars host from its ELB"
-
-  tags {
-    Name = "${var.stackname}_calendars_access"
-  }
-}
-
 resource "aws_security_group_rule" "calculators-frontend_ingress_calculators-frontend-elb_http" {
   type      = "ingress"
   from_port = 80
@@ -42,19 +32,6 @@ resource "aws_security_group_rule" "calculators-frontend_ingress_calculators-fro
 
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.calculators-frontend_elb.id}"
-}
-
-resource "aws_security_group_rule" "calculators-frontend_ingress_calendars-carrenza-alb_http" {
-  type      = "ingress"
-  from_port = 80
-  to_port   = 80
-  protocol  = "tcp"
-
-  # Which security group is the rule assigned to
-  security_group_id = "${aws_security_group.calculators-frontend.id}"
-
-  # Which security group can use this rule
-  source_security_group_id = "${aws_security_group.calendars_carrenza_alb.id}"
 }
 
 resource "aws_security_group" "calculators-frontend_elb" {
@@ -85,51 +62,6 @@ resource "aws_security_group_rule" "calculators-frontends-elb_egress_any_any" {
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.calculators-frontend_elb.id}"
-}
-
-resource "aws_security_group_rule" "calendars_ingress_calendars-carrenza-alb_http" {
-  type      = "ingress"
-  from_port = 80
-  to_port   = 80
-  protocol  = "tcp"
-
-  # Which security group is the rule assigned to
-  security_group_id = "${aws_security_group.calendars.id}"
-
-  # Which security group can use this rule
-  source_security_group_id = "${aws_security_group.calendars_carrenza_alb.id}"
-}
-
-# Security resources for ALB set up for Carrenza access to AWS calendars
-
-resource "aws_security_group" "calendars_carrenza_alb" {
-  name        = "${var.stackname}_calendars_carrenza_alb"
-  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  description = "Access the calendars Carrenza ALB "
-
-  tags {
-    Name = "${var.stackname}_calendars_carrenza_alb_access"
-  }
-}
-
-resource "aws_security_group_rule" "calendars-carrenza-alb_ingress_443_carrenza" {
-  count     = "${length(var.carrenza_env_ips) > 0 ? 1 : 0}"
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  cidr_blocks       = ["${var.carrenza_env_ips}"]
-  security_group_id = "${aws_security_group.calendars_carrenza_alb.id}"
-}
-
-resource "aws_security_group_rule" "calendars-carrenza-alb_egress_any_any" {
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.calendars_carrenza_alb.id}"
 }
 
 resource "aws_security_group" "calculators_frontend_ithc_access" {

--- a/terraform/projects/infra-security-groups/frontend.tf
+++ b/terraform/projects/infra-security-groups/frontend.tf
@@ -100,7 +100,7 @@ resource "aws_security_group_rule" "static_ingress_static-carrenza-alb_http" {
   source_security_group_id = "${aws_security_group.static_carrenza_alb.id}"
 }
 
-# Security resources for ALB set up for Carrenza access to AWS calendars
+# Security resources for ALB set up for Carrenza access to AWS
 
 resource "aws_security_group" "static_carrenza_alb" {
   name        = "${var.stackname}_static_carrenza_alb"

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -66,10 +66,6 @@ output "sg_cache_id" {
   value = "${aws_security_group.cache.id}"
 }
 
-output "sg_calendars_carrenza_alb_id" {
-  value = "${aws_security_group.calendars_carrenza_alb.id}"
-}
-
 output "sg_calculators-frontend_elb_id" {
   value = "${aws_security_group.calculators-frontend_elb.id}"
 }


### PR DESCRIPTION
This commit removes the security group rules allowing Carrenza access,
without adding equivalent rules for frontend (which is what now serves
the calendar pages).  I don't think the rules are needed, as
gds-api-adapters uses 'Plek.new.website_root' for calendars, which
points to the external URL.

---

[Plan (infra-public-services)](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4298/console)
[Plan (infra-security-groups)](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4299/console)
[Trello card](https://trello.com/c/SKT4BnIQ/1953-retire-the-calendars-app-%F0%9F%8D%90)