### PR TITLE
Revert "Add create_before_destroy to target groups"

### DIFF
--- a/terraform/modules/aws/lb_listener_rules/main.tf
+++ b/terraform/modules/aws/lb_listener_rules/main.tf
@@ -130,10 +130,6 @@ resource "aws_lb_target_group" "tg" {
     timeout             = "${var.target_group_health_check_timeout}"
   }
 
-  lifecycle {
-    create_before_destroy = true
-  }
-
   tags = "${var.default_tags}"
 }
 
@@ -156,10 +152,6 @@ resource "aws_lb_listener_rule" "routing" {
   condition {
     field  = "host-header"
     values = ["${var.rules_host[count.index]}.${var.rules_host_domain}"]
-  }
-
-  lifecycle {
-    create_before_destroy = true
   }
 
   depends_on = [


### PR DESCRIPTION
See #1292 

> looks good, lets try it in staging or somewhere

> https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4349/console 😞

> no option than manual then. These are the only 2 things I know can change the order. Sorry :-(