### PR TITLE
Allow Cloudwatch To Collect Data From Frontend Machines

### DIFF
--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -198,6 +198,31 @@ module "frontend" {
   root_block_device_volume_size     = "${var.root_block_device_volume_size}"
 }
 
+resource "aws_iam_policy" "ec2_access_cloudwatch_policy" {
+  name        = "cloudwatch-ec2-access-${var.aws_environment}-policy"
+  description = "Allows Cloudwatch to send data from an ec2 instance. Used to collect logs."
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "ec2.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_access_cloudwatch_policy_iam_role_policy_attachment" {
+  role       = "${module.frontend.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.ec2_access_cloudwatch_policy.arn}"
+}
+
 module "alarms-elb-frontend-internal" {
   source                         = "../../modules/aws/alarms/elb"
   name_prefix                    = "${var.stackname}-frontend-internal"


### PR DESCRIPTION
Cyber have asked for this to be implemented so they can improve logging. This commit
adds the necessary policy to the Frontend instances. It has been set up in
accordance to the guidance in the AWS Docs:
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/create-iam-roles-for-cloudwatch-agent-commandline.html