### PR TITLE
allow AWS jenkins for continuous deployment

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -23,7 +23,9 @@ Manage the security groups for the entire infrastructure
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aws\_environment | AWS Environment | `string` | n/a | yes |
+| aws\_integration\_external\_nat\_gateway\_ips | An array of public IPs of the AWS integration external NAT gateways. | `list` | `[]` | no |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
+| aws\_staging\_external\_nat\_gateway\_ips | An array of public IPs of the AWS staging external NAT gateways. | `list` | `[]` | no |
 | carrenza\_draft\_frontend\_ips | An array of CIDR blocks for the current environment that will allow access to draft-content-store from Carrenza. | `list` | `[]` | no |
 | carrenza\_env\_ips | An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox. | `list` | `[]` | no |
 | carrenza\_integration\_ips | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | `list` | n/a | yes |

--- a/terraform/projects/infra-security-groups/deploy.tf
+++ b/terraform/projects/infra-security-groups/deploy.tf
@@ -78,6 +78,28 @@ resource "aws_security_group_rule" "deploy-elb_ingress_carrenza_https" {
   cidr_blocks       = ["${var.carrenza_integration_ips}", "${var.carrenza_production_ips}"]
 }
 
+resource "aws_security_group_rule" "deploy-elb_ingress_aws_integration_access_https" {
+  count     = "${var.aws_environment == "staging" ? 1 : 0}"
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id = "${aws_security_group.deploy_elb.id}"
+  cidr_blocks       = ["${var.aws_integration_external_nat_gateway_ips}"]
+}
+
+resource "aws_security_group_rule" "deploy-elb_ingress_aws_staging_access_https" {
+  count     = "${var.aws_environment == "production" ? 1 : 0}"
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id = "${aws_security_group.deploy_elb.id}"
+  cidr_blocks       = ["${var.aws_staging_external_nat_gateway_ips}"]
+}
+
 resource "aws_security_group_rule" "deploy-elb_egress_any_any" {
   type              = "egress"
   from_port         = 0

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -88,3 +88,15 @@ variable "ithc_access_ips" {
   description = "An array of CIDR blocks that will be allowed temporary access for ITHC purposes."
   default     = []
 }
+
+variable "aws_integration_external_nat_gateway_ips" {
+  type        = "list"
+  description = "An array of public IPs of the AWS integration external NAT gateways."
+  default     = []
+}
+
+variable "aws_staging_external_nat_gateway_ips" {
+  type        = "list"
+  description = "An array of public IPs of the AWS staging external NAT gateways."
+  default     = []
+}


### PR DESCRIPTION
For continuous deployment:
1. AWS Integration Jenkins should be able to access AWS Staging Jenkins
2. AWS Staging Jenkins should be able to access AWS Production Jenkins