### PR TITLE
ci: Run on Ubuntu, not macOS, and rename job to "test"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,11 @@
-name: govuk-aws-linting
 on: [push, pull_request]
 jobs:
-  lint:
-    runs-on: macos-latest
+  test:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
-      - name: bundle install
-        run: bundle install
+      - uses: ruby/setup-ruby@v1
+      - run: bundle install
 
       - name: Docs Check
         run: |

--- a/terraform/modules/aws/iam/role_user/main.tf
+++ b/terraform/modules/aws/iam/role_user/main.tf
@@ -88,6 +88,6 @@ resource "aws_iam_role_policy_attachment" "user_policy_attachment" {
 #--------------------------------------------------------------
 
 output "role_arn" {
-  value       = "${join("",aws_iam_role.user_role.*.arn)}"
+  value       = "${join("", aws_iam_role.user_role.*.arn)}"
   description = "The ARN specifying the role."
 }


### PR DESCRIPTION
- Now that Homebrew exists on the Actions Linux runners, we can run
  these checks on Linux like every other Actions workflow we have.
- The repo auto-configurator expects a job named "test" within a file
  with `.github/workflows/ci.yml` so it marks the check as required.
- Also make some steps into single lines where they don't make sense to
  be multi-lines. And properly install Ruby.