### PR TITLE
ci: Rename "lint" job to "test"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: govuk-aws-linting
 on: [push, pull_request]
 jobs:
-  lint:
+  test:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
- The [GOV.UK repo
  autoconfigurer](https://github.com/alphagov/govuk-saas-config) expects a
  GitHub Actions workflow file at the following path
  `.github/workflows/ci.yml`. Within it, it expects a job named `test` to
  auto-configure. At the moment on PRs, there's a non-existent `test` task
  that is a required status check. This fixes it so PRs are mergeable
  again.
