### PR TITLE
Add missing SageMaker action to policy

### DIFF
--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -236,13 +236,14 @@ resource "aws_iam_policy" "data-science-access-glue" {
 data "aws_iam_policy_document" "data-science-access-sagemaker" {
   statement {
     actions = [
-      "sagemaker:ListNotebookInstances",
-      "sagemaker:DescribeNotebookInstance",
       "sagemaker:CreateNotebookInstance",
-      "sagemaker:UpdateNotebookInstance",
+      "sagemaker:CreatePresignedNotebookInstanceUrl",
+      "sagemaker:DescribeNotebookInstance",
       "sagemaker:DeleteNotebookInstance",
+      "sagemaker:ListNotebookInstances",
       "sagemaker:StartNotebookInstance",
       "sagemaker:StopNotebookInstance",
+      "sagemaker:UpdateNotebookInstance",
     ]
 
     effect    = "Allow"


### PR DESCRIPTION
This PR adds the missing action `CreatePresignedNotebookInstanceUrl` to the `data-science-access-sagemaker` policy, which allows anyone assuming the `govuk-datascienceusers` role to successfully open a Jupyter notebook hosted within SageMaker.