### PR TITLE
Switch to c5.xlarge instances for the Email Alert API

### DIFF
--- a/terraform/projects/app-email-alert-api/README.md
+++ b/terraform/projects/app-email-alert-api/README.md
@@ -26,7 +26,7 @@ email-alert-api node
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | instance\_ami\_filter\_name | Name to use to find AMI images | `string` | `""` | no |
-| instance\_type | Instance type used for EC2 resources | `string` | `"m5.xlarge"` | no |
+| instance\_type | Instance type used for EC2 resources | `string` | `"c5.xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |

--- a/terraform/projects/app-email-alert-api/main.tf
+++ b/terraform/projects/app-email-alert-api/main.tf
@@ -49,7 +49,7 @@ variable "internal_domain_name" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for EC2 resources"
-  default     = "m5.xlarge"
+  default     = "c5.xlarge"
 }
 
 # Resources


### PR DESCRIPTION
From m5.xlarge instances, this provides less memory, but they should
be more performant. The Email Alert API doesn't need 16GiB of memory,
8GiB should be fine, and I'm planning to increase the number of
instances, which should spread the load.