### PR TITLE
content-publisher-sync

### DIFF
--- a/terraform/projects/app-db-admin/README.md
+++ b/terraform/projects/app-db-admin/README.md
@@ -31,6 +31,7 @@ These nodes connect to RDS instances and administer them.
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
+| remote\_state\_infra\_content\_publisher\_key\_stack | Override stackname path to infra\_content\_publisher remote state | `string` | `""` | no |
 | remote\_state\_infra\_database\_backups\_bucket\_key\_stack | Override stackname path to infra\_database\_backups\_bucket remote state | `string` | `""` | no |
 | remote\_state\_infra\_monitoring\_key\_stack | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |

--- a/terraform/projects/infra-content-publisher/README.md
+++ b/terraform/projects/infra-content-publisher/README.md
@@ -26,6 +26,7 @@ Stores ActiveStorage blobs uploaded via Content Publisher.
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | aws\_replica\_region | AWS region | `string` | `"eu-west-2"` | no |
+| aws\_staging\_account\_root\_arn | root arn of the aws staging account of govuk | `string` | `""` | no |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_monitoring\_key\_stack | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |
@@ -39,5 +40,10 @@ Stores ActiveStorage blobs uploaded via Content Publisher.
 
 ## Outputs
 
-No output.
+| Name | Description |
+|------|-------------|
+| integration\_content\_publisher\_active\_storage\_bucket\_reader\_writer\_policy\_arn | ARN of the staging content publisher storage bucket reader writer policy |
+| production\_content\_publisher\_active\_storage\_bucket\_reader\_policy\_arn | ARN of the production content publisher storage bucket reader policy |
+| staging\_content\_publisher\_active\_storage\_bucket\_reader\_policy\_arn | ARN of the staging content publisher storage bucket reader policy |
+| staging\_content\_publisher\_active\_storage\_bucket\_reader\_writer\_policy\_arn | ARN of the staging content publisher storage bucket reader writer policy |
 

--- a/terraform/projects/infra-content-publisher/env_sync.tf
+++ b/terraform/projects/infra-content-publisher/env_sync.tf
@@ -1,3 +1,12 @@
+variable "aws_staging_account_root_arn" {
+  type        = "string"
+  description = "root arn of the aws staging account of govuk"
+  default     = ""
+}
+
+# Resources
+# --------------------------------------------------------------
+
 resource "aws_s3_bucket_policy" "cross_account_access" {
   count  = "${var.aws_environment != "production" ? 1 : 0}"
   bucket = "${aws_s3_bucket.activestorage.id}"
@@ -53,4 +62,153 @@ data "aws_iam_policy_document" "cross_account_access" {
       "arn:aws:s3:::${aws_s3_bucket.activestorage.id}/*",
     ]
   }
+}
+
+resource "aws_s3_bucket_policy" "staging_cross_account_access_to_production" {
+  count  = "${var.aws_environment == "production" ? 1 : 0}"
+  bucket = "${aws_s3_bucket.activestorage.id}"
+  policy = "${data.aws_iam_policy_document.staging_cross_account_access_to_production.json}"
+}
+
+data "aws_iam_policy_document" "staging_cross_account_access_to_production" {
+  statement {
+    effect = "Allow"
+
+    principals = {
+      type = "AWS"
+
+      identifiers = [
+        "${var.aws_staging_account_root_arn}", # govuk-infrastructure-staging
+      ]
+    }
+
+    actions = [
+      "s3:List*",
+      "s3:Get*",
+    ]
+
+    resources = [
+      "arn:aws:s3:::govuk-production-content-publisher-activestorage",
+      "arn:aws:s3:::govuk-production-content-publisher-activestorage/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "integration_content_publisher_active_storage_reader_writer" {
+  name        = "integration_content_publisher_active_storage-reader_writer-policy"
+  policy      = "${data.aws_iam_policy_document.integration_content_publisher_active_storage_reader_writer.json}"
+  description = "Allows reading and writing the integration content publisher active storage bucket"
+}
+
+data "aws_iam_policy_document" "integration_content_publisher_active_storage_reader_writer" {
+  statement {
+    sid = "IntegrationContentPublisherActiveStorageReaderWriter"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-integration-content-publisher-activestorage",
+      "arn:aws:s3:::govuk-integration-content-publisher-activestorage/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "staging_content_publisher_active_storage_reader" {
+  name        = "staging_content_publisher_active_storage-reader-policy"
+  policy      = "${data.aws_iam_policy_document.staging_content_publisher_active_storage_reader.json}"
+  description = "Allows reading the staging content publisher active storage bucket"
+}
+
+data "aws_iam_policy_document" "staging_content_publisher_active_storage_reader" {
+  statement {
+    sid = "StagingContentPublisherActiveStorageReader"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-staging-content-publisher-activestorage",
+      "arn:aws:s3:::govuk-staging-content-publisher-activestorage/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "staging_content_publisher_active_storage_reader_writer" {
+  name        = "staging_content_publisher_active_storage-reader_writer-policy"
+  policy      = "${data.aws_iam_policy_document.staging_content_publisher_active_storage_reader_writer.json}"
+  description = "Allows reading and writing the staging content publisher active storage bucket"
+}
+
+data "aws_iam_policy_document" "staging_content_publisher_active_storage_reader_writer" {
+  statement {
+    sid = "StagingContentPublisherActiveStorageReaderWriter"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-staging-content-publisher-activestorage",
+      "arn:aws:s3:::govuk-staging-content-publisher-activestorage/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "production_content_publisher_active_storage_reader" {
+  name        = "production_content_publisher_active_storage-reader-policy"
+  policy      = "${data.aws_iam_policy_document.production_content_publisher_active_storage_reader.json}"
+  description = "Allows reading the production content publisher active storage bucket"
+}
+
+data "aws_iam_policy_document" "production_content_publisher_active_storage_reader" {
+  statement {
+    sid = "ProductionContentPublisherActiveStorageReader"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-production-content-publisher-activestorage",
+      "arn:aws:s3:::govuk-production-content-publisher-activestorage/*",
+    ]
+  }
+}
+
+# Outputs
+# --------------------------------------------------------------
+
+output "integration_content_publisher_active_storage_bucket_reader_writer_policy_arn" {
+  value       = "${aws_iam_policy.integration_content_publisher_active_storage_reader_writer.arn}"
+  description = "ARN of the staging content publisher storage bucket reader writer policy"
+}
+
+output "staging_content_publisher_active_storage_bucket_reader_policy_arn" {
+  value       = "${aws_iam_policy.staging_content_publisher_active_storage_reader.arn}"
+  description = "ARN of the staging content publisher storage bucket reader policy"
+}
+
+output "staging_content_publisher_active_storage_bucket_reader_writer_policy_arn" {
+  value       = "${aws_iam_policy.staging_content_publisher_active_storage_reader_writer.arn}"
+  description = "ARN of the staging content publisher storage bucket reader writer policy"
+}
+
+output "production_content_publisher_active_storage_bucket_reader_policy_arn" {
+  value       = "${aws_iam_policy.production_content_publisher_active_storage_reader.arn}"
+  description = "ARN of the production content publisher storage bucket reader policy"
 }


### PR DESCRIPTION
add the necessary permissions so the puppet govuk_env_sync running
on the db_admin machines can sync the content publisher s3
buckets