### PR TITLE
Content publisher env sync refactor

### DIFF
--- a/terraform/projects/infra-content-publisher/README.md
+++ b/terraform/projects/infra-content-publisher/README.md
@@ -24,9 +24,11 @@ Stores ActiveStorage blobs uploaded via Content Publisher.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aws\_environment | AWS Environment | `string` | n/a | yes |
+| aws\_integration\_account\_root\_arn | root arn of the aws integration account of govuk | `string` | `""` | no |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | aws\_replica\_region | AWS region | `string` | `"eu-west-2"` | no |
 | aws\_staging\_account\_root\_arn | root arn of the aws staging account of govuk | `string` | `""` | no |
+| aws\_test\_account\_root\_arn | root arn of the aws test account of govuk | `string` | `""` | no |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_monitoring\_key\_stack | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |


### PR DESCRIPTION
changes:
1. allow only child environment to access parent environment bucket, e.g. integration should only access staging only.
2. aws accounts are put in govuk-aws-data
3. a given environment has all put rights to its bucket so that it can take ownership of the object. This is needed because integration would not be able to copy staging bucket objects if the objects are still owned by production.