### PR TITLE
Revert "Switch to c5.xlarge instances for the Email Alert API"

### DIFF
--- a/terraform/projects/app-email-alert-api/README.md
+++ b/terraform/projects/app-email-alert-api/README.md
@@ -26,7 +26,7 @@ email-alert-api node
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | instance\_ami\_filter\_name | Name to use to find AMI images | `string` | `""` | no |
-| instance\_type | Instance type used for EC2 resources | `string` | `"c5.xlarge"` | no |
+| instance\_type | Instance type used for EC2 resources | `string` | `"m5.xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |

--- a/terraform/projects/app-email-alert-api/main.tf
+++ b/terraform/projects/app-email-alert-api/main.tf
@@ -49,7 +49,7 @@ variable "internal_domain_name" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for EC2 resources"
-  default     = "c5.xlarge"
+  default     = "m5.xlarge"
 }
 
 # Resources


### PR DESCRIPTION
8GB of memory should be fine for the Email Alert API, but for the last
4 Fridays, some of the Sidekiq processes for the Email Alert API have
used lots of memory, beyond the limit set for the Icinga checks.

Until we've managed to address the excessive memory usage, and
reliability of the jobs (Sidekiq isn't exactly reliable), going back
to 16GB of memory might help to avoid issues with Sidekiq using all
the memory.

This reverts commit dae54679cf50585abddb6c4413b7b2a26b0492e5.