### PR TITLE
git rm .blue.integration.env

### DIFF
--- a/.blue.integration.env
+++ b/.blue.integration.env
@@ -1,3 +1,0 @@
-export DATA_DIR=../govuk-aws-data/data
-export ENVIRONMENT=integration
-export STACKNAME=blue


### PR DESCRIPTION
- This was added 3 years ago in https://github.com/alphagov/govuk-aws/pull/233 when we were building out the new AWS integration environment.
- Given we have better ways of deploying Terraform for existing enviromnments now, and it's telling that we don't have `.blue.staging.env` files or `.blue.production.env` files (and definitely not `.pink.test.env` for the new replatforming work), we don't need this. Also, as mentioned in the original PR, it's too easy to forget you've `source`d this and do things to the wrong environment.
