### PR TITLE
S3 bucket for email attachments from whitehall

### DIFF
--- a/terraform/policies/whitehall_s3_writer_policy.tpl
+++ b/terraform/policies/whitehall_s3_writer_policy.tpl
@@ -1,0 +1,28 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:ListAllMyBuckets",
+                "s3:GetBucketLocation"
+             ],
+            "Resource": [
+                "arn:aws:s3:::*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${bucket}",
+                "arn:aws:s3:::${bucket}/*"
+            ]
+        }
+    ]
+}

--- a/terraform/projects/app-whitehall-backend/README.md
+++ b/terraform/projects/app-whitehall-backend/README.md
@@ -15,6 +15,7 @@ Whitehall Backend nodes
 |------|---------|
 | aws | 2.46.0 |
 | null | n/a |
+| template | n/a |
 | terraform | n/a |
 
 ## Inputs


### PR DESCRIPTION
As part of the migration to Notify, Whitehall needs to send emails as links rather than attachments. Following the example of specialist-publisher (alphagov/specialist-publisher#1576, alphagov/specialist-publisher#1625, #1254, #1256) this is being done by uploading them to s3 and then sending a link which will serve the file.

https://trello.com/c/5xKHcam8/2012-5-whitehall-replace-attachments-in-documentlistexport-so-that-notify-can-be-used