### PR TITLE
Correct role names for whitehall s3 access

### DIFF
--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -167,14 +167,14 @@ data "template_file" "s3_writer_policy_template" {
 
 resource "aws_iam_role_policy" "whitehall_csvs_policy" {
   name = "govuk-${var.aws_environment}-whitehall-csvs-policy"
-  role = "${aws_iam_role.whitehall_csvs_bucket_access_role.id}"
+  role = "${module.whitehall-backend.instance_iam_role_name}"
 
   policy_arn = "${aws_iam_policy.s3_writer.arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "whitehall_csvs_attach" {
   role       = "${module.whitehall-backend.instance_iam_role_name}"
-  policy_arn = "${aws_iam_policy.whitehall_csvs_bucket_access_role.policy.arn}"
+  policy_arn = "${aws_iam_policy.s3_writer.policy.arn}"
 }
 
 # Outputs


### PR DESCRIPTION
Errors introduced in #1315. This points resources at correct role names rather than ones that have been removed.

https://trello.com/c/5xKHcam8/2012-5-whitehall-replace-attachments-in-documentlistexport-so-that-notify-can-be-used