### PR TITLE
Correct policy parameter for whitehall s3 access

### DIFF
--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -169,7 +169,7 @@ resource "aws_iam_role_policy" "whitehall_csvs_policy" {
   name = "govuk-${var.aws_environment}-whitehall-csvs-policy"
   role = "${module.whitehall-backend.instance_iam_role_name}"
 
-  policy_arn = "${aws_iam_policy.s3_writer.arn}"
+  policy = "${data.template_file.s3_writer_policy_template.rendered}"
 }
 
 resource "aws_iam_role_policy_attachment" "whitehall_csvs_attach" {


### PR DESCRIPTION
Fixing errors from #1315 and #1317.

https://trello.com/c/5xKHcam8/2012-5-whitehall-replace-attachments-in-documentlistexport-so-that-notify-can-be-used