### PR TITLE
Correct policy parameter for whitehall s3 access

### DIFF
--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -174,7 +174,7 @@ resource "aws_iam_role_policy" "whitehall_csvs_policy" {
 
 resource "aws_iam_role_policy_attachment" "whitehall_csvs_attach" {
   role       = "${module.whitehall-backend.instance_iam_role_name}"
-  policy_arn = "${aws_iam_policy.s3_writer.policy.arn}"
+  policy_arn = "${aws_iam_policy.s3_writer.arn}"
 }
 
 # Outputs


### PR DESCRIPTION
Fixing errors from #1315, #1317, #1318.

https://trello.com/c/5xKHcam8/2012-5-whitehall-replace-attachments-in-documentlistexport-so-that-notify-can-be-used