### PR TITLE
Speed up cloning govuk-secrets to puppetmasters

### DIFF
--- a/tools/govuk-puppetmaster-integration-bootstrap.sh
+++ b/tools/govuk-puppetmaster-integration-bootstrap.sh
@@ -72,7 +72,7 @@ set -x
 git clone ${GOVUK_GIT_URL}/${GOVUK_PUPPET_REPO}
 
 # Clone secrets repo
-git clone ${GOVUK_GIT_URL}/${GOVUK_SECRETS_REPO}
+git clone --depth=1 ${GOVUK_GIT_URL}/${GOVUK_SECRETS_REPO}
 
 # Add secrets to puppet repository
 cp -r ${GOVUK_WORKDIR}/${GOVUK_SECRETS_REPO}/puppet_aws/hieradata/* ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/

--- a/tools/govuk-puppetmaster-production-bootstrap.sh
+++ b/tools/govuk-puppetmaster-production-bootstrap.sh
@@ -72,7 +72,7 @@ set -x
 git clone ${GOVUK_GIT_URL}/${GOVUK_PUPPET_REPO}
 
 # Clone secrets repo
-git clone ${GOVUK_GIT_URL}/${GOVUK_SECRETS_REPO}
+git clone --depth=1 ${GOVUK_GIT_URL}/${GOVUK_SECRETS_REPO}
 
 # Add secrets to puppet repository
 cp -r ${GOVUK_WORKDIR}/${GOVUK_SECRETS_REPO}/puppet_aws/hieradata/* ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/

--- a/tools/govuk-puppetmaster-staging-bootstrap.sh
+++ b/tools/govuk-puppetmaster-staging-bootstrap.sh
@@ -72,7 +72,7 @@ set -x
 git clone ${GOVUK_GIT_URL}/${GOVUK_PUPPET_REPO}
 
 # Clone secrets repo
-git clone ${GOVUK_GIT_URL}/${GOVUK_SECRETS_REPO}
+git clone --depth=1 ${GOVUK_GIT_URL}/${GOVUK_SECRETS_REPO}
 
 # Add secrets to puppet repository
 cp -r ${GOVUK_WORKDIR}/${GOVUK_SECRETS_REPO}/puppet_aws/hieradata/* ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/

--- a/tools/govuk-puppetmaster-training-bootstrap.sh
+++ b/tools/govuk-puppetmaster-training-bootstrap.sh
@@ -71,7 +71,7 @@ set -x
 git clone ${GOVUK_GIT_URL}/${GOVUK_PUPPET_REPO}
 
 # Clone secrets repo
-git clone ${GOVUK_GIT_URL}/${GOVUK_SECRETS_REPO}
+git clone --depth=1 ${GOVUK_GIT_URL}/${GOVUK_SECRETS_REPO}
 
 # Add secrets to puppet repository
 cp -r ${GOVUK_WORKDIR}/${GOVUK_SECRETS_REPO}/puppet_aws/hieradata/* ${GOVUK_WORKDIR}/${GOVUK_PUPPET_REPO}/hieradata_aws/


### PR DESCRIPTION
The puppet masters clone govuk-secrets, because govuk-secrets is now so
large it takes a very long time to provision a puppetmaster.

This change only pulls down the git repo to a depth of 1 rather than
everything back to the triassic period.  This greatly increases the speed
in which to provision a puppetmaster.