### PR TITLE
Add the --full-index flag to bundle install in bootstrap script

### DIFF
--- a/tools/govuk-puppetmaster-integration-bootstrap.sh
+++ b/tools/govuk-puppetmaster-integration-bootstrap.sh
@@ -114,7 +114,7 @@ gem install --no-ri --no-rdoc hiera-eyaml-gpg gpgme
 cd "/usr/share/puppet/production/current/" || exit
 
 # Installing Puppet dependencies
-bundle install
+bundle install --full-index
 bundle exec rake librarian:install
 
 cd "${GOVUK_WORKDIR}" || exit

--- a/tools/govuk-puppetmaster-production-bootstrap.sh
+++ b/tools/govuk-puppetmaster-production-bootstrap.sh
@@ -114,7 +114,7 @@ gem install --no-ri --no-rdoc hiera-eyaml-gpg gpgme
 cd "/usr/share/puppet/production/current/" || exit
 
 # Installing Puppet dependencies
-bundle install
+bundle install --full-index
 bundle exec rake librarian:install
 
 cd "${GOVUK_WORKDIR}" || exit

--- a/tools/govuk-puppetmaster-staging-bootstrap.sh
+++ b/tools/govuk-puppetmaster-staging-bootstrap.sh
@@ -114,7 +114,7 @@ gem install --no-ri --no-rdoc hiera-eyaml-gpg gpgme
 cd "/usr/share/puppet/production/current/" || exit
 
 # Installing Puppet dependencies
-bundle install
+bundle install --full-index
 bundle exec rake librarian:install
 
 cd "${GOVUK_WORKDIR}" || exit


### PR DESCRIPTION
To provision puppetmaster machines in AWS we run a bootstrap script
that will go through a bundle install at some point.
Recently this part of the process has started to fail with this
error : Retrying dependency api due to error (2/3):
Bundler::HTTPError Net::HTTPUnprocessableEntity: Too many gems
(use --full-index instead)

We can't be sure when this process broke since we provision
puppetmaster very rarely, I'm not sure what the underlying cause
of the problem is either, using --full-index seems to fix the issue