### PR TITLE
Pin Neo4j Community to 3.5.16 in app-knowledge-graph

### DIFF
--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -67,14 +67,11 @@ resource "aws_s3_bucket" "data_infrastructure_bucket" {
 }
 
 data "aws_ami" "neo4j_community_ami" {
-  most_recent = true
-
-  # canonical
   owners = ["679593333241"]
 
   filter {
-    name   = "name"
-    values = ["neo4j-community-*"]
+    name   = "image-id"
+    values = ["ami-094ccb4dbb8650bdf"]
   }
 }
 


### PR DESCRIPTION
This PR pins Neo4j Community Edition version `3.5.16` in the `app-knowledge-graph` project. 

A new major version has been released on 3rd September 2020 which is causing problems (the release seems to have quite a few bugs), so we should wait until these are fixed as well as testing our setup on the new major version before making the jump to it. 

Version `3.5.21` (released 26th August 2020) also contains a bug where the default password is not the instance id (according to the [docs](https://aws.amazon.com/marketplace/pp/Neo4j-Neo4j-Graph-Database-Community-Edition/B071P26C9D#pdp-usage) it should be), which is another reason why this commit uses a known stable version.