### PR TITLE
Remove sent and finished_sending_at from schema

### DIFF
--- a/terraform/projects/infra-email-alert-api-archive/main.tf
+++ b/terraform/projects/infra-email-alert-api-archive/main.tf
@@ -169,7 +169,7 @@ resource "aws_glue_catalog_table" "email_archive" {
       name = "ser_de_name"
 
       parameters {
-        paths = "archived_at_utc,content_change,message,created_at_utc,finished_sending_at_utc,id,sent,subject,subscriber_id"
+        paths = "archived_at_utc,content_change,message,created_at_utc,id,subject,subscriber_id"
       }
 
       serialization_library = "org.openx.data.jsonserde.JsonSerDe"
@@ -180,16 +180,6 @@ resource "aws_glue_catalog_table" "email_archive" {
         name    = "id"
         type    = "string"
         comment = "UUID that corresponds with the entry in the email table"
-      },
-      {
-        name    = "finished_sending_at_utc"
-        type    = "timestamp"
-        comment = "Time the email was sent or when we aborted trying to send the email"
-      },
-      {
-        name    = "sent"
-        type    = "boolean"
-        comment = "Whether the email was sent or not"
       },
       {
         name    = "subscriber_id"


### PR DESCRIPTION
Removes two columns from the email-alert-api archive schema. These are
`finished_sending_at_utc` and `sent`. The reason we are removing these
is they may change after an email has been archived, which
makes them misleading. For archiving purposes, it should be enough to
know when the email was created, since this is usually similar to when
it was sent.

Dependant on:
https://github.com/alphagov/email-alert-api/pull/1396

Trello:
https://trello.com/c/15eVh9Qg/482-stop-relying-on-notify-status-updates-to-archive-delete-emails