### PR TITLE
external gemstash in production and fix ci security groups

### DIFF
--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -170,6 +170,20 @@ resource "aws_route53_record" "gemstash_internal_service_record" {
   }
 }
 
+# used to allow carrenza production to use this aws production gemstash
+resource "aws_route53_record" "gemstash_external_service_record" {
+  count   = "${var.aws_environment == "production" ? 1 : 0}"
+  zone_id = "${data.aws_route53_zone.external.zone_id}"
+  name    = "gemstash.${var.external_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${module.apt_external_lb.lb_dns_name}"
+    zone_id                = "${module.apt_external_lb.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
 module "apt" {
   source                            = "../../modules/aws/node_group"
   name                              = "${var.stackname}-apt"

--- a/terraform/projects/infra-security-groups/apt.tf
+++ b/terraform/projects/infra-security-groups/apt.tf
@@ -69,6 +69,17 @@ resource "aws_security_group_rule" "apt-external-elb_ingress_office_https" {
   cidr_blocks       = ["${var.office_ips}"]
 }
 
+resource "aws_security_group_rule" "apt-external-elb_ingress_carrenza_production_https" {
+  count     = "${var.aws_environment == "production" ? 1 : 0}"
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id = "${aws_security_group.apt_external_elb.id}"
+  cidr_blocks       = ["${var.carrenza_production_ips}"]
+}
+
 resource "aws_security_group_rule" "apt-external-elb_ingress_fastly_https" {
   type      = "ingress"
   from_port = 443

--- a/terraform/projects/infra-security-groups/ci-agents.tf
+++ b/terraform/projects/infra-security-groups/ci-agents.tf
@@ -14,6 +14,7 @@
 /////////////////////ci-agent-1/////////////////////////////////////////////////
 
 resource "aws_security_group" "ci-agent-1" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-1_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access to the ci-agent-1 host from its ELB"
@@ -24,6 +25,7 @@ resource "aws_security_group" "ci-agent-1" {
 }
 
 resource "aws_security_group_rule" "ci-agent-1_ingress_ci-agent-1-elb_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -37,6 +39,7 @@ resource "aws_security_group_rule" "ci-agent-1_ingress_ci-agent-1-elb_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-1_ingress_ci-agent-1-ci_master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -50,6 +53,7 @@ resource "aws_security_group_rule" "ci-agent-1_ingress_ci-agent-1-ci_master_ssh_
 }
 
 resource "aws_security_group" "ci-agent-1_elb" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-1_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access the CI agent 1 ELB"
@@ -60,6 +64,7 @@ resource "aws_security_group" "ci-agent-1_elb" {
 }
 
 resource "aws_security_group_rule" "ci-agent-1-elb_ingress_management_https" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -70,6 +75,7 @@ resource "aws_security_group_rule" "ci-agent-1-elb_ingress_management_https" {
 }
 
 resource "aws_security_group_rule" "ci-agent-1-elb_ingress_ci-master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 0
   to_port   = 22
@@ -80,6 +86,7 @@ resource "aws_security_group_rule" "ci-agent-1-elb_ingress_ci-master_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-1-elb_egress_any_any" {
+  count             = "${var.aws_environment == "integration" ? 1 : 0}"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -91,6 +98,7 @@ resource "aws_security_group_rule" "ci-agent-1-elb_egress_any_any" {
 /////////////////////ci-agent-2/////////////////////////////////////////////////
 
 resource "aws_security_group" "ci-agent-2" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-2_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access to the ci-agent-2 host from its ELB"
@@ -101,6 +109,7 @@ resource "aws_security_group" "ci-agent-2" {
 }
 
 resource "aws_security_group_rule" "ci-agent-2_ingress_ci-agent-2-elb_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -114,6 +123,7 @@ resource "aws_security_group_rule" "ci-agent-2_ingress_ci-agent-2-elb_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-2_ingress_ci-agent-2-ci_master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -127,6 +137,7 @@ resource "aws_security_group_rule" "ci-agent-2_ingress_ci-agent-2-ci_master_ssh_
 }
 
 resource "aws_security_group" "ci-agent-2_elb" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-2_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access the CI agent 2 ELB"
@@ -137,6 +148,7 @@ resource "aws_security_group" "ci-agent-2_elb" {
 }
 
 resource "aws_security_group_rule" "ci-agent-2-elb_ingress_management_https" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -147,6 +159,7 @@ resource "aws_security_group_rule" "ci-agent-2-elb_ingress_management_https" {
 }
 
 resource "aws_security_group_rule" "ci-agent-2-elb_ingress_ci-master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 0
   to_port   = 22
@@ -157,6 +170,7 @@ resource "aws_security_group_rule" "ci-agent-2-elb_ingress_ci-master_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-2-elb_egress_any_any" {
+  count             = "${var.aws_environment == "integration" ? 1 : 0}"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -168,6 +182,7 @@ resource "aws_security_group_rule" "ci-agent-2-elb_egress_any_any" {
 /////////////////////ci-agent-3/////////////////////////////////////////////////
 
 resource "aws_security_group" "ci-agent-3" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-3_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access to the ci-agent-3 host from its ELB"
@@ -178,6 +193,7 @@ resource "aws_security_group" "ci-agent-3" {
 }
 
 resource "aws_security_group_rule" "ci-agent-3_ingress_ci-agent-3-elb_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -191,6 +207,7 @@ resource "aws_security_group_rule" "ci-agent-3_ingress_ci-agent-3-elb_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-3_ingress_ci-agent-3-ci_master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -204,6 +221,7 @@ resource "aws_security_group_rule" "ci-agent-3_ingress_ci-agent-3-ci_master_ssh_
 }
 
 resource "aws_security_group" "ci-agent-3_elb" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-3_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access the CI agent 3 ELB"
@@ -214,6 +232,7 @@ resource "aws_security_group" "ci-agent-3_elb" {
 }
 
 resource "aws_security_group_rule" "ci-agent-3-elb_ingress_management_https" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -224,6 +243,7 @@ resource "aws_security_group_rule" "ci-agent-3-elb_ingress_management_https" {
 }
 
 resource "aws_security_group_rule" "ci-agent-3-elb_ingress_ci-master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 0
   to_port   = 22
@@ -234,6 +254,7 @@ resource "aws_security_group_rule" "ci-agent-3-elb_ingress_ci-master_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-3-elb_egress_any_any" {
+  count             = "${var.aws_environment == "integration" ? 1 : 0}"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -245,6 +266,7 @@ resource "aws_security_group_rule" "ci-agent-3-elb_egress_any_any" {
 /////////////////////ci-agent-4/////////////////////////////////////////////////
 
 resource "aws_security_group" "ci-agent-4" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-4_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access to the ci-agent-4 host from its ELB"
@@ -255,6 +277,7 @@ resource "aws_security_group" "ci-agent-4" {
 }
 
 resource "aws_security_group_rule" "ci-agent-4_ingress_ci-agent-4-elb_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -268,6 +291,7 @@ resource "aws_security_group_rule" "ci-agent-4_ingress_ci-agent-4-elb_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-4_ingress_ci-agent-4-ci_master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -281,6 +305,7 @@ resource "aws_security_group_rule" "ci-agent-4_ingress_ci-agent-4-ci_master_ssh_
 }
 
 resource "aws_security_group" "ci-agent-4_elb" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-4_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access the CI agent 4 ELB"
@@ -291,6 +316,7 @@ resource "aws_security_group" "ci-agent-4_elb" {
 }
 
 resource "aws_security_group_rule" "ci-agent-4-elb_ingress_management_https" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -301,6 +327,7 @@ resource "aws_security_group_rule" "ci-agent-4-elb_ingress_management_https" {
 }
 
 resource "aws_security_group_rule" "ci-agent-4-elb_ingress_ci-master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 0
   to_port   = 22
@@ -311,6 +338,7 @@ resource "aws_security_group_rule" "ci-agent-4-elb_ingress_ci-master_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-4-elb_egress_any_any" {
+  count             = "${var.aws_environment == "integration" ? 1 : 0}"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -322,6 +350,7 @@ resource "aws_security_group_rule" "ci-agent-4-elb_egress_any_any" {
 /////////////////////ci-agent-5/////////////////////////////////////////////////
 
 resource "aws_security_group" "ci-agent-5" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-5_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access to the ci-agent-5 host from its ELB"
@@ -332,6 +361,7 @@ resource "aws_security_group" "ci-agent-5" {
 }
 
 resource "aws_security_group_rule" "ci-agent-5_ingress_ci-agent-5-elb_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -345,6 +375,7 @@ resource "aws_security_group_rule" "ci-agent-5_ingress_ci-agent-5-elb_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-5_ingress_ci-agent-5-ci_master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -358,6 +389,7 @@ resource "aws_security_group_rule" "ci-agent-5_ingress_ci-agent-5-ci_master_ssh_
 }
 
 resource "aws_security_group" "ci-agent-5_elb" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-5_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access the CI agent 5 ELB"
@@ -368,6 +400,7 @@ resource "aws_security_group" "ci-agent-5_elb" {
 }
 
 resource "aws_security_group_rule" "ci-agent-5-elb_ingress_management_https" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -378,6 +411,7 @@ resource "aws_security_group_rule" "ci-agent-5-elb_ingress_management_https" {
 }
 
 resource "aws_security_group_rule" "ci-agent-5-elb_ingress_ci-master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 0
   to_port   = 22
@@ -388,6 +422,7 @@ resource "aws_security_group_rule" "ci-agent-5-elb_ingress_ci-master_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-5-elb_egress_any_any" {
+  count             = "${var.aws_environment == "integration" ? 1 : 0}"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -399,6 +434,7 @@ resource "aws_security_group_rule" "ci-agent-5-elb_egress_any_any" {
 /////////////////////ci-agent-6/////////////////////////////////////////////////
 
 resource "aws_security_group" "ci-agent-6" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-6_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access to the ci-agent-6 host from its ELB"
@@ -409,6 +445,7 @@ resource "aws_security_group" "ci-agent-6" {
 }
 
 resource "aws_security_group_rule" "ci-agent-6_ingress_ci-agent-6-elb_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -422,6 +459,7 @@ resource "aws_security_group_rule" "ci-agent-6_ingress_ci-agent-6-elb_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-6_ingress_ci-agent-6-ci_master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -435,6 +473,7 @@ resource "aws_security_group_rule" "ci-agent-6_ingress_ci-agent-6-ci_master_ssh_
 }
 
 resource "aws_security_group" "ci-agent-6_elb" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-6_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access the CI agent 6 ELB"
@@ -445,6 +484,7 @@ resource "aws_security_group" "ci-agent-6_elb" {
 }
 
 resource "aws_security_group_rule" "ci-agent-6-elb_ingress_management_https" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -455,6 +495,7 @@ resource "aws_security_group_rule" "ci-agent-6-elb_ingress_management_https" {
 }
 
 resource "aws_security_group_rule" "ci-agent-6-elb_ingress_ci-master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 0
   to_port   = 22
@@ -465,6 +506,7 @@ resource "aws_security_group_rule" "ci-agent-6-elb_ingress_ci-master_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-6-elb_egress_any_any" {
+  count             = "${var.aws_environment == "integration" ? 1 : 0}"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -476,6 +518,7 @@ resource "aws_security_group_rule" "ci-agent-6-elb_egress_any_any" {
 /////////////////////ci-agent-7/////////////////////////////////////////////////
 
 resource "aws_security_group" "ci-agent-7" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-7_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access to the ci-agent-7 host from its ELB"
@@ -486,6 +529,7 @@ resource "aws_security_group" "ci-agent-7" {
 }
 
 resource "aws_security_group_rule" "ci-agent-7_ingress_ci-agent-7-elb_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -499,6 +543,7 @@ resource "aws_security_group_rule" "ci-agent-7_ingress_ci-agent-7-elb_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-7_ingress_ci-agent-7-ci_master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -512,6 +557,7 @@ resource "aws_security_group_rule" "ci-agent-7_ingress_ci-agent-7-ci_master_ssh_
 }
 
 resource "aws_security_group" "ci-agent-7_elb" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-7_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access the CI agent 7 ELB"
@@ -522,6 +568,7 @@ resource "aws_security_group" "ci-agent-7_elb" {
 }
 
 resource "aws_security_group_rule" "ci-agent-7-elb_ingress_management_https" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -532,6 +579,7 @@ resource "aws_security_group_rule" "ci-agent-7-elb_ingress_management_https" {
 }
 
 resource "aws_security_group_rule" "ci-agent-7-elb_ingress_ci-master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 0
   to_port   = 22
@@ -542,6 +590,7 @@ resource "aws_security_group_rule" "ci-agent-7-elb_ingress_ci-master_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-7-elb_egress_any_any" {
+  count             = "${var.aws_environment == "integration" ? 1 : 0}"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -553,6 +602,7 @@ resource "aws_security_group_rule" "ci-agent-7-elb_egress_any_any" {
 /////////////////////ci-agent-8/////////////////////////////////////////////////
 
 resource "aws_security_group" "ci-agent-8" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-8_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access to the ci-agent-8 host from its ELB"
@@ -563,6 +613,7 @@ resource "aws_security_group" "ci-agent-8" {
 }
 
 resource "aws_security_group_rule" "ci-agent-8_ingress_ci-agent-8-elb_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -576,6 +627,7 @@ resource "aws_security_group_rule" "ci-agent-8_ingress_ci-agent-8-elb_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-8_ingress_ci-agent-8-ci_master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 22
   to_port   = 22
@@ -589,6 +641,7 @@ resource "aws_security_group_rule" "ci-agent-8_ingress_ci-agent-8-ci_master_ssh_
 }
 
 resource "aws_security_group" "ci-agent-8_elb" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-agent-8_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access the CI agent 8 ELB"
@@ -599,6 +652,7 @@ resource "aws_security_group" "ci-agent-8_elb" {
 }
 
 resource "aws_security_group_rule" "ci-agent-8-elb_ingress_management_https" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -609,6 +663,7 @@ resource "aws_security_group_rule" "ci-agent-8-elb_ingress_management_https" {
 }
 
 resource "aws_security_group_rule" "ci-agent-8-elb_ingress_ci-master_ssh_tcp" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 0
   to_port   = 22
@@ -619,6 +674,7 @@ resource "aws_security_group_rule" "ci-agent-8-elb_ingress_ci-master_ssh_tcp" {
 }
 
 resource "aws_security_group_rule" "ci-agent-8-elb_egress_any_any" {
+  count             = "${var.aws_environment == "integration" ? 1 : 0}"
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/terraform/projects/infra-security-groups/ci-master.tf
+++ b/terraform/projects/infra-security-groups/ci-master.tf
@@ -12,6 +12,7 @@
 # sg_ci-master_elb_id
 
 resource "aws_security_group" "ci-master" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-master_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access to the ci-master host from its ELB"
@@ -22,6 +23,7 @@ resource "aws_security_group" "ci-master" {
 }
 
 resource "aws_security_group_rule" "ci-master_ingress_ci-master-elb_http" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -35,6 +37,7 @@ resource "aws_security_group_rule" "ci-master_ingress_ci-master-elb_http" {
 }
 
 resource "aws_security_group_rule" "ci-master_ingress_ci-master-internal-elb_http" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 80
   to_port   = 80
@@ -58,6 +61,7 @@ resource "aws_security_group" "ci-master_elb" {
 }
 
 resource "aws_security_group_rule" "ci-master-elb_ingress_office_https" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -69,6 +73,7 @@ resource "aws_security_group_rule" "ci-master-elb_ingress_office_https" {
 
 # Allow Carrenza Integration and Production access to trigger automated ci-masterments
 resource "aws_security_group_rule" "ci-master-elb_ingress_carrenza_https" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -78,29 +83,8 @@ resource "aws_security_group_rule" "ci-master-elb_ingress_carrenza_https" {
   cidr_blocks       = ["${var.carrenza_integration_ips}", "${var.carrenza_production_ips}"]
 }
 
-resource "aws_security_group_rule" "ci-master-elb_ingress_aws_integration_access_https" {
-  count     = "${var.aws_environment == "staging" ? 1 : 0}"
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  security_group_id = "${aws_security_group.ci-master_elb.id}"
-  cidr_blocks       = ["${var.aws_integration_external_nat_gateway_ips}"]
-}
-
-resource "aws_security_group_rule" "ci-master-elb_ingress_aws_staging_access_https" {
-  count     = "${var.aws_environment == "production" ? 1 : 0}"
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  security_group_id = "${aws_security_group.ci-master_elb.id}"
-  cidr_blocks       = ["${var.aws_staging_external_nat_gateway_ips}"]
-}
-
 resource "aws_security_group_rule" "ci-master-elb_egress_any_any" {
+  count             = "${var.aws_environment == "integration" ? 1 : 0}"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -110,6 +94,7 @@ resource "aws_security_group_rule" "ci-master-elb_egress_any_any" {
 }
 
 resource "aws_security_group_rule" "ci-master-internal-elb_egress_any_any" {
+  count             = "${var.aws_environment == "integration" ? 1 : 0}"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -119,6 +104,7 @@ resource "aws_security_group_rule" "ci-master-internal-elb_egress_any_any" {
 }
 
 resource "aws_security_group" "ci-master_internal_elb" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-master_internal_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access the ci-master Internal ELB"
@@ -129,6 +115,7 @@ resource "aws_security_group" "ci-master_internal_elb" {
 }
 
 resource "aws_security_group_rule" "ci-master-internal-elb_ingress_management_https" {
+  count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"
   from_port = 443
   to_port   = 443

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -75,79 +75,79 @@ output "sg_calculators-frontend_id" {
 }
 
 output "sg_ci-agent-1_elb_id" {
-  value = "${aws_security_group.ci-agent-1_elb.id}"
+  value = ["${aws_security_group.ci-agent-1_elb.*.id}"]
 }
 
 output "sg_ci-agent-1_id" {
-  value = "${aws_security_group.ci-agent-1.id}"
+  value = ["${aws_security_group.ci-agent-1.*.id}"]
 }
 
 output "sg_ci-agent-2_elb_id" {
-  value = "${aws_security_group.ci-agent-2_elb.id}"
+  value = ["${aws_security_group.ci-agent-2_elb.*.id}"]
 }
 
 output "sg_ci-agent-2_id" {
-  value = "${aws_security_group.ci-agent-2.id}"
+  value = ["${aws_security_group.ci-agent-2.*.id}"]
 }
 
 output "sg_ci-agent-3_elb_id" {
-  value = "${aws_security_group.ci-agent-3_elb.id}"
+  value = ["${aws_security_group.ci-agent-3_elb.*.id}"]
 }
 
 output "sg_ci-agent-3_id" {
-  value = "${aws_security_group.ci-agent-3.id}"
+  value = ["${aws_security_group.ci-agent-3.*.id}"]
 }
 
 output "sg_ci-agent-4_elb_id" {
-  value = "${aws_security_group.ci-agent-4_elb.id}"
+  value = ["${aws_security_group.ci-agent-4_elb.*.id}"]
 }
 
 output "sg_ci-agent-4_id" {
-  value = "${aws_security_group.ci-agent-4.id}"
+  value = ["${aws_security_group.ci-agent-4.*.id}"]
 }
 
 output "sg_ci-agent-5_elb_id" {
-  value = "${aws_security_group.ci-agent-5_elb.id}"
+  value = ["${aws_security_group.ci-agent-5_elb.*.id}"]
 }
 
 output "sg_ci-agent-5_id" {
-  value = "${aws_security_group.ci-agent-5.id}"
+  value = ["${aws_security_group.ci-agent-5.*.id}"]
 }
 
 output "sg_ci-agent-6_elb_id" {
-  value = "${aws_security_group.ci-agent-6_elb.id}"
+  value = ["${aws_security_group.ci-agent-6_elb.*.id}"]
 }
 
 output "sg_ci-agent-6_id" {
-  value = "${aws_security_group.ci-agent-6.id}"
+  value = ["${aws_security_group.ci-agent-6.*.id}"]
 }
 
 output "sg_ci-agent-7_elb_id" {
-  value = "${aws_security_group.ci-agent-7_elb.id}"
+  value = ["${aws_security_group.ci-agent-7_elb.*.id}"]
 }
 
 output "sg_ci-agent-7_id" {
-  value = "${aws_security_group.ci-agent-7.id}"
+  value = ["${aws_security_group.ci-agent-7.*.id}"]
 }
 
 output "sg_ci-agent-8_elb_id" {
-  value = "${aws_security_group.ci-agent-8_elb.id}"
+  value = ["${aws_security_group.ci-agent-8_elb.*.id}"]
 }
 
 output "sg_ci-agent-8_id" {
-  value = "${aws_security_group.ci-agent-8.id}"
+  value = ["${aws_security_group.ci-agent-8.*.id}"]
 }
 
 output "sg_ci-master_elb_id" {
-  value = "${aws_security_group.ci-master_elb.id}"
+  value = ["${aws_security_group.ci-master_elb.*.id}"]
 }
 
 output "sg_ci-master_internal_elb_id" {
-  value = "${aws_security_group.ci-master_internal_elb.id}"
+  value = ["${aws_security_group.ci-master_internal_elb.*.id}"]
 }
 
 output "sg_ci-master_id" {
-  value = "${aws_security_group.ci-master.id}"
+  value = ["${aws_security_group.ci-master.*.id}"]
 }
 
 output "sg_ckan_elb_internal_id" {


### PR DESCRIPTION
- allow external gemstash in aws production so that carrenza production can use it and shutdown its apt server
- fixes ci security groups so that they don't get created in production
- removes some ci master security group as there is no clear need for them