### PR TITLE
final fixes to gemstash and ci

### DIFF
--- a/terraform/projects/app-apt/README.md
+++ b/terraform/projects/app-apt/README.md
@@ -28,6 +28,7 @@ Apt node
 | ebs\_volume\_size | EBS volume size | `string` | `"40"` | no |
 | elb\_external\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| elb\_public\_secondary\_certname | The ACM secondary cert domain name to find the ARN of | `string` | n/a | yes |
 | external\_domain\_name | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | external\_zone\_name | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | instance\_ami\_filter\_name | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -40,6 +40,11 @@ variable "elb_external_certname" {
   description = "The ACM cert domain name to find the ARN of"
 }
 
+variable "elb_public_secondary_certname" {
+  type        = "string"
+  description = "The ACM secondary cert domain name to find the ARN of"
+}
+
 variable "apt_1_subnet" {
   type        = "string"
   description = "Name of the subnet to place the apt instance 1 and EBS volume"
@@ -118,7 +123,7 @@ module "apt_external_lb" {
   access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
   access_logs_bucket_prefix                  = "elb/${var.stackname}-apt-external-elb"
   listener_certificate_domain_name           = "${var.elb_external_certname}"
-  listener_secondary_certificate_domain_name = ""
+  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
   listener_action                            = "${local.external_lb_map}"
   subnets                                    = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                            = ["${data.terraform_remote_state.infra_security_groups.sg_apt_external_elb_id}"]

--- a/terraform/projects/infra-security-groups/ci-master.tf
+++ b/terraform/projects/infra-security-groups/ci-master.tf
@@ -51,6 +51,7 @@ resource "aws_security_group_rule" "ci-master_ingress_ci-master-internal-elb_htt
 }
 
 resource "aws_security_group" "ci-master_elb" {
+  count       = "${var.aws_environment == "integration" ? 1 : 0}"
   name        = "${var.stackname}_ci-master_elb_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
   description = "Access the ci-master ELB"


### PR DESCRIPTION
- no ci security groups in production as ci is in integration only
- add publishing.service.gov.uk to externla ELB of apt so that gemstash.publishing.service.gov.uk works.