### PR TITLE
public ALB for ci master in AWS integration

### DIFF
--- a/terraform/projects/app-ci-master/README.md
+++ b/terraform/projects/app-ci-master/README.md
@@ -26,14 +26,18 @@ CI Master Node
 | create\_external\_elb | Create the external ELB | `bool` | `true` | no |
 | deploy\_subnet | Name of the subnet to place the ci and EBS volume | `string` | n/a | yes |
 | ebs\_encrypted | Whether or not the EBS volume is encrypted | `string` | n/a | yes |
-| elb\_external\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
-| elb\_internal\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| elb\_external\_certname | The ACM cert domain name to find the ARN of, will be attached to external classic ELB | `string` | n/a | yes |
+| elb\_internal\_certname | The ACM cert domain name to find the ARN of, will be attached to internal classic ELB | `string` | n/a | yes |
+| elb\_public\_certname | The ACM cert domain name to find the ARN of, will be attached to external ALB | `string` | n/a | yes |
+| elb\_public\_secondary\_certname | The ACM secondary cert domain name to find the ARN of, will be attached to external ALB | `string` | n/a | yes |
 | external\_domain\_name | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | external\_zone\_name | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | instance\_ami\_filter\_name | Name to use to find AMI images | `string` | `""` | no |
 | instance\_type | Instance type used for EC2 resources | `string` | `"t2.medium"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
+| internal\_service\_names | list of internal names for ci-master, used for DNS domain | `list` | <pre>[<br>  "ci"<br>]</pre> | no |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
+| public\_service\_names | list of public names for ci-master, used for DNS domain | `list` | <pre>[<br>  "ci"<br>]</pre> | no |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_artefact\_bucket\_key\_stack | Override infra\_artefact\_bucket remote state path | `string` | `""` | no |
 | remote\_state\_infra\_monitoring\_key\_stack | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |


### PR DESCRIPTION
we defined the public ALB for ci master in app-ci-master instead of infra-public-services because it is intended for this to be deployed in AWS integration only, rather than other environments.