### PR TITLE
Allow ${var.ithc_access_ips} SSH access

### DIFF
--- a/terraform/projects/infra-security-groups/apt.tf
+++ b/terraform/projects/infra-security-groups/apt.tf
@@ -147,3 +147,24 @@ resource "aws_security_group_rule" "apt-internal-elb_egress_any_any" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.apt_internal_elb.id}"
 }
+
+resource "aws_security_group" "apt_ithc_access" {
+  count       = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  name        = "${var.stackname}_apt_ithc_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Control access to ITHC SSH"
+
+  tags {
+    Name = "${var.stackname}_apt_ithc_access"
+  }
+}
+
+resource "aws_security_group_rule" "ithc_ingress_apt_ssh" {
+  count             = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  type              = "ingress"
+  to_port           = 22
+  from_port         = 22
+  protocol          = "tcp"
+  cidr_blocks       = "${var.ithc_access_ips}"
+  security_group_id = "${aws_security_group.apt_ithc_access.id}"
+}

--- a/terraform/projects/infra-security-groups/licensify-backend.tf
+++ b/terraform/projects/infra-security-groups/licensify-backend.tf
@@ -111,3 +111,24 @@ resource "aws_security_group_rule" "licensify-backend-external-elb_egress_any_an
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.licensify-backend_external_elb.id}"
 }
+
+resource "aws_security_group" "licensify_backend_ithc_access" {
+  count       = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  name        = "${var.stackname}_licensify_backend_ithc_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Control access to ITHC SSH"
+
+  tags {
+    Name = "${var.stackname}_licensify_backend_ithc_access"
+  }
+}
+
+resource "aws_security_group_rule" "ithc_ingress_licensify_backend_ssh" {
+  count             = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  type              = "ingress"
+  to_port           = 22
+  from_port         = 22
+  protocol          = "tcp"
+  cidr_blocks       = "${var.ithc_access_ips}"
+  security_group_id = "${aws_security_group.licensify_backend_ithc_access.id}"
+}

--- a/terraform/projects/infra-security-groups/licensify-frontend.tf
+++ b/terraform/projects/infra-security-groups/licensify-frontend.tf
@@ -139,3 +139,24 @@ resource "aws_security_group_rule" "licensify-frontend-internal-lb_egress_any_an
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.licensify-frontend_internal_lb.id}"
 }
+
+resource "aws_security_group" "licensify_frontend_ithc_access" {
+  count       = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  name        = "${var.stackname}_licensify_frontend_ithc_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Control access to ITHC SSH"
+
+  tags {
+    Name = "${var.stackname}_licensify_frontend_ithc_access"
+  }
+}
+
+resource "aws_security_group_rule" "ithc_ingress_licensify_frontend_ssh" {
+  count             = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  type              = "ingress"
+  to_port           = 22
+  from_port         = 22
+  protocol          = "tcp"
+  cidr_blocks       = "${var.ithc_access_ips}"
+  security_group_id = "${aws_security_group.licensify_frontend_ithc_access.id}"
+}

--- a/terraform/projects/infra-security-groups/publishing-api.tf
+++ b/terraform/projects/infra-security-groups/publishing-api.tf
@@ -124,3 +124,24 @@ resource "aws_security_group_rule" "publishing-api-elb-external_egress_any_any" 
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.publishing-api_elb_external.id}"
 }
+
+resource "aws_security_group" "publishing-api_ithc_access" {
+  count       = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  name        = "${var.stackname}_publishing-api_ithc_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Control access to ITHC SSH"
+
+  tags {
+    Name = "${var.stackname}_publishing-api_ithc_access"
+  }
+}
+
+resource "aws_security_group_rule" "ithc_ingress_publishing-api_ssh" {
+  count             = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  type              = "ingress"
+  to_port           = 22
+  from_port         = 22
+  protocol          = "tcp"
+  cidr_blocks       = "${var.ithc_access_ips}"
+  security_group_id = "${aws_security_group.publishing-api_ithc_access.id}"
+}

--- a/terraform/projects/infra-security-groups/whitehall-backend.tf
+++ b/terraform/projects/infra-security-groups/whitehall-backend.tf
@@ -104,3 +104,24 @@ resource "aws_security_group_rule" "whitehall-backend-external-elb_egress_any_an
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.whitehall-backend_external_elb.id}"
 }
+
+resource "aws_security_group" "whitehall_ithc_access" {
+  count       = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  name        = "${var.stackname}_whitehall_ithc_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Control access to ITHC SSH"
+
+  tags {
+    Name = "${var.stackname}_whitehall_ithc_access"
+  }
+}
+
+resource "aws_security_group_rule" "ithc_ingress_whitehall_ssh" {
+  count             = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  type              = "ingress"
+  to_port           = 22
+  from_port         = 22
+  protocol          = "tcp"
+  cidr_blocks       = "${var.ithc_access_ips}"
+  security_group_id = "${aws_security_group.whitehall_ithc_access.id}"
+}

--- a/terraform/projects/infra-security-groups/whitehall-frontend.tf
+++ b/terraform/projects/infra-security-groups/whitehall-frontend.tf
@@ -107,3 +107,24 @@ resource "aws_security_group_rule" "whitehall-frontend-external-elb_egress_any_a
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.whitehall-frontend_external_elb.id}"
 }
+
+resource "aws_security_group" "whitehall-frontend_ithc_access" {
+  count       = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  name        = "${var.stackname}_whitehall-frontend_ithc_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Control access to ITHC SSH"
+
+  tags {
+    Name = "${var.stackname}_whitehall-frontend_ithc_access"
+  }
+}
+
+resource "aws_security_group_rule" "ithc_ingress_whitehall-frontend_ssh" {
+  count             = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  type              = "ingress"
+  to_port           = 22
+  from_port         = 22
+  protocol          = "tcp"
+  cidr_blocks       = "${var.ithc_access_ips}"
+  security_group_id = "${aws_security_group.whitehall-frontend_ithc_access.id}"
+}


### PR DESCRIPTION
Allow ${var.ithc_access_ips} to Apt, Licensify, Publishing API and Whitehall. This enables testers access to machines without needing to be on the VPN.