### PR TITLE
Add 6 more Mapit instances

### DIFF
--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -221,6 +221,222 @@ resource "aws_ebs_volume" "mapit-2" {
   }
 }
 
+module "mapit-3" {
+  lc_create_ebs_volume          = "${var.lc_create_ebs_volume}"
+  source                        = "../../modules/aws/node_group"
+  name                          = "${var.stackname}-mapit-3"
+  default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-3")}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_3_subnet))}"
+  instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
+  instance_type                 = "${var.instance_type}"
+  instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
+  instance_elb_ids_length       = "1"
+  instance_elb_ids              = ["${aws_elb.mapit_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "20"
+  ebs_device_volume_size        = "${var.ebs_device_volume_size}"
+  ebs_encrypted                 = "${var.ebs_encrypted}"
+  ebs_device_name               = "${var.ebs_device_name}"
+}
+
+resource "aws_ebs_volume" "mapit-3" {
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_3_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
+  size              = 20
+  type              = "gp2"
+
+  tags {
+    Name            = "${var.stackname}-mapit"
+    Project         = "${var.stackname}"
+    Device          = "xvdf"
+    aws_hostname    = "mapit-3"
+    aws_migration   = "mapit"
+    aws_stackname   = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
+module "mapit-4" {
+  lc_create_ebs_volume          = "${var.lc_create_ebs_volume}"
+  source                        = "../../modules/aws/node_group"
+  name                          = "${var.stackname}-mapit-4"
+  default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-4")}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_4_subnet))}"
+  instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
+  instance_type                 = "${var.instance_type}"
+  instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
+  instance_elb_ids_length       = "1"
+  instance_elb_ids              = ["${aws_elb.mapit_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "20"
+  ebs_device_volume_size        = "${var.ebs_device_volume_size}"
+  ebs_encrypted                 = "${var.ebs_encrypted}"
+  ebs_device_name               = "${var.ebs_device_name}"
+}
+
+resource "aws_ebs_volume" "mapit-4" {
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_4_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
+  size              = 20
+  type              = "gp2"
+
+  tags {
+    Name            = "${var.stackname}-mapit"
+    Project         = "${var.stackname}"
+    Device          = "xvdf"
+    aws_hostname    = "mapit-4"
+    aws_migration   = "mapit"
+    aws_stackname   = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
+module "mapit-5" {
+  lc_create_ebs_volume          = "${var.lc_create_ebs_volume}"
+  source                        = "../../modules/aws/node_group"
+  name                          = "${var.stackname}-mapit-5"
+  default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-5")}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_5_subnet))}"
+  instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
+  instance_type                 = "${var.instance_type}"
+  instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
+  instance_elb_ids_length       = "1"
+  instance_elb_ids              = ["${aws_elb.mapit_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "20"
+  ebs_device_volume_size        = "${var.ebs_device_volume_size}"
+  ebs_encrypted                 = "${var.ebs_encrypted}"
+  ebs_device_name               = "${var.ebs_device_name}"
+}
+
+resource "aws_ebs_volume" "mapit-5" {
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_5_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
+  size              = 20
+  type              = "gp2"
+
+  tags {
+    Name            = "${var.stackname}-mapit"
+    Project         = "${var.stackname}"
+    Device          = "xvdf"
+    aws_hostname    = "mapit-5"
+    aws_migration   = "mapit"
+    aws_stackname   = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
+module "mapit-6" {
+  lc_create_ebs_volume          = "${var.lc_create_ebs_volume}"
+  source                        = "../../modules/aws/node_group"
+  name                          = "${var.stackname}-mapit-6"
+  default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-6")}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_6_subnet))}"
+  instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
+  instance_type                 = "${var.instance_type}"
+  instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
+  instance_elb_ids_length       = "1"
+  instance_elb_ids              = ["${aws_elb.mapit_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "20"
+  ebs_device_volume_size        = "${var.ebs_device_volume_size}"
+  ebs_encrypted                 = "${var.ebs_encrypted}"
+  ebs_device_name               = "${var.ebs_device_name}"
+}
+
+resource "aws_ebs_volume" "mapit-6" {
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_6_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
+  size              = 20
+  type              = "gp2"
+
+  tags {
+    Name            = "${var.stackname}-mapit"
+    Project         = "${var.stackname}"
+    Device          = "xvdf"
+    aws_hostname    = "mapit-6"
+    aws_migration   = "mapit"
+    aws_stackname   = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
+module "mapit-7" {
+  lc_create_ebs_volume          = "${var.lc_create_ebs_volume}"
+  source                        = "../../modules/aws/node_group"
+  name                          = "${var.stackname}-mapit-7"
+  default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-7")}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_7_subnet))}"
+  instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
+  instance_type                 = "${var.instance_type}"
+  instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
+  instance_elb_ids_length       = "1"
+  instance_elb_ids              = ["${aws_elb.mapit_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "20"
+  ebs_device_volume_size        = "${var.ebs_device_volume_size}"
+  ebs_encrypted                 = "${var.ebs_encrypted}"
+  ebs_device_name               = "${var.ebs_device_name}"
+}
+
+resource "aws_ebs_volume" "mapit-7" {
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_7_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
+  size              = 20
+  type              = "gp2"
+
+  tags {
+    Name            = "${var.stackname}-mapit"
+    Project         = "${var.stackname}"
+    Device          = "xvdf"
+    aws_hostname    = "mapit-7"
+    aws_migration   = "mapit"
+    aws_stackname   = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
+module "mapit-8" {
+  lc_create_ebs_volume          = "${var.lc_create_ebs_volume}"
+  source                        = "../../modules/aws/node_group"
+  name                          = "${var.stackname}-mapit-8"
+  default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-8")}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_8_subnet))}"
+  instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
+  instance_type                 = "${var.instance_type}"
+  instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
+  instance_elb_ids_length       = "1"
+  instance_elb_ids              = ["${aws_elb.mapit_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "20"
+  ebs_device_volume_size        = "${var.ebs_device_volume_size}"
+  ebs_encrypted                 = "${var.ebs_encrypted}"
+  ebs_device_name               = "${var.ebs_device_name}"
+}
+
+resource "aws_ebs_volume" "mapit-8" {
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_8_subnet)}"
+  encrypted         = "${var.ebs_encrypted}"
+  size              = 20
+  type              = "gp2"
+
+  tags {
+    Name            = "${var.stackname}-mapit"
+    Project         = "${var.stackname}"
+    Device          = "xvdf"
+    aws_hostname    = "mapit-8"
+    aws_migration   = "mapit"
+    aws_stackname   = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
 resource "aws_iam_policy" "mapit_iam_policy" {
   name   = "${var.stackname}-mapit-additional"
   path   = "/"
@@ -234,6 +450,36 @@ resource "aws_iam_role_policy_attachment" "mapit_1_iam_role_policy_attachment" {
 
 resource "aws_iam_role_policy_attachment" "mapit_2_iam_role_policy_attachment" {
   role       = "${module.mapit-2.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.mapit_iam_policy.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "mapit_3_iam_role_policy_attachment" {
+  role       = "${module.mapit-3.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.mapit_iam_policy.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "mapit_4_iam_role_policy_attachment" {
+  role       = "${module.mapit-4.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.mapit_iam_policy.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "mapit_5_iam_role_policy_attachment" {
+  role       = "${module.mapit-5.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.mapit_iam_policy.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "mapit_6_iam_role_policy_attachment" {
+  role       = "${module.mapit-6.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.mapit_iam_policy.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "mapit_7_iam_role_policy_attachment" {
+  role       = "${module.mapit-7.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.mapit_iam_policy.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "mapit_8_iam_role_policy_attachment" {
+  role       = "${module.mapit-8.instance_iam_role_name}"
   policy_arn = "${aws_iam_policy.mapit_iam_policy.arn}"
 }
 


### PR DESCRIPTION
Unfortunately the Terraform config is currently hard coded for 2 instances, so to up it to 8, I've had to copy and paste the resources manually.

It's definitely worth refactoring this in the future, but for now we need to get the instances up relatively quickly, so I think this will do.