### PR TITLE
Add variables for mapit subnets

### DIFF
--- a/terraform/projects/app-mapit/README.md
+++ b/terraform/projects/app-mapit/README.md
@@ -33,7 +33,13 @@ Mapit node
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | lc\_create\_ebs\_volume | Creates a launch configuration which will add an additional ebs volume to the instance if this value is set to 1 | `string` | n/a | yes |
 | mapit\_1\_subnet | Name of the subnet to place the mapit instance 1 and EBS volume | `string` | n/a | yes |
-| mapit\_2\_subnet | Name of the subnet to place the mapit instance 1 and EBS volume | `string` | n/a | yes |
+| mapit\_2\_subnet | Name of the subnet to place the mapit instance 2 and EBS volume | `string` | n/a | yes |
+| mapit\_3\_subnet | Name of the subnet to place the mapit instance 3 and EBS volume | `string` | n/a | yes |
+| mapit\_4\_subnet | Name of the subnet to place the mapit instance 4 and EBS volume | `string` | n/a | yes |
+| mapit\_5\_subnet | Name of the subnet to place the mapit instance 5 and EBS volume | `string` | n/a | yes |
+| mapit\_6\_subnet | Name of the subnet to place the mapit instance 6 and EBS volume | `string` | n/a | yes |
+| mapit\_7\_subnet | Name of the subnet to place the mapit instance 7 and EBS volume | `string` | n/a | yes |
+| mapit\_8\_subnet | Name of the subnet to place the mapit instance 8 and EBS volume | `string` | n/a | yes |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_monitoring\_key\_stack | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -37,7 +37,37 @@ variable "mapit_1_subnet" {
 
 variable "mapit_2_subnet" {
   type        = "string"
-  description = "Name of the subnet to place the mapit instance 1 and EBS volume"
+  description = "Name of the subnet to place the mapit instance 2 and EBS volume"
+}
+
+variable "mapit_3_subnet" {
+  type        = "string"
+  description = "Name of the subnet to place the mapit instance 3 and EBS volume"
+}
+
+variable "mapit_4_subnet" {
+  type        = "string"
+  description = "Name of the subnet to place the mapit instance 4 and EBS volume"
+}
+
+variable "mapit_5_subnet" {
+  type        = "string"
+  description = "Name of the subnet to place the mapit instance 5 and EBS volume"
+}
+
+variable "mapit_6_subnet" {
+  type        = "string"
+  description = "Name of the subnet to place the mapit instance 6 and EBS volume"
+}
+
+variable "mapit_7_subnet" {
+  type        = "string"
+  description = "Name of the subnet to place the mapit instance 7 and EBS volume"
+}
+
+variable "mapit_8_subnet" {
+  type        = "string"
+  description = "Name of the subnet to place the mapit instance 8 and EBS volume"
 }
 
 variable "elb_internal_certname" {


### PR DESCRIPTION
This was missed in https://github.com/alphagov/govuk-aws/pull/1351 and is required otherwise the Terraform is invalid.