### PR TITLE
Add coronavirus business volunteer lifecycle rule

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -258,6 +258,18 @@ resource "aws_s3_bucket" "database_backups" {
     }
   }
 
+  # Lifecycle rule for coronavirus business volunteer form backup
+
+  lifecycle_rule {
+    id      = "coronavirus_business_volunteer_form_lifecycle_rule"
+    prefix  = "coronavirus-business-volunteer-form/production.sql.gzip"
+    enabled = true
+
+    expiration {
+      days = 365
+    }
+  }
+
   # Integration lifecycle specific rules END
 
   versioning {


### PR DESCRIPTION
Holds production database backup for Coronavirus Business Volunteer form.
Set expiration for 1 year as our privacy policy states we would delete
data when no longer required.

[Trello](https://trello.com/c/bn2EPyTa/559-take-backup-of-the-business-volunteering-database)