### PR TITLE
Un-redact waf logs

### DIFF
--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -35,17 +35,6 @@ resource "aws_wafregional_web_acl" "default" {
 
   logging_configuration {
     log_destination = "${aws_kinesis_firehose_delivery_stream.splunk.arn}"
-
-    redacted_fields {
-      field_to_match {
-        type = "URI"
-      }
-
-      field_to_match {
-        data = "referer"
-        type = "HEADER"
-      }
-    }
   }
 
   depends_on = [


### PR DESCRIPTION
As requested by Cyber security :
"those fields are particularly useful when it comes to web attack
 detection - so could we un-redact them please?"