### PR TITLE
Block XSS and SQLi on AWS WAF

### DIFF
--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -17,7 +17,7 @@ resource "aws_wafregional_web_acl" "default" {
 
   rule {
     action {
-      type = "ALLOW" # FIXME: Change this to BLOCK after 25th July 2019
+      type = "BLOCK"
     }
 
     priority = 3
@@ -26,7 +26,7 @@ resource "aws_wafregional_web_acl" "default" {
 
   rule {
     action {
-      type = "ALLOW" # FIXME: Change this to BLOCK after 25th July 2019
+      type = "BLOCK"
     }
 
     priority = 4


### PR DESCRIPTION
This is actioning a `FIXME` for July 2019 which was added in #1055.

At the time it was noted that the this should be left on `ALLOW` for a while so the potential impact can be evaluated, it's not clear if this has occurred, but it is well past the original `FIXME` date, so if no one has had a chance to look at this, it may be worth extending the date listed.

Unrelated, the existence of this repository is awesome!