### PR TITLE
Change search instance type to c5.xlarge

### DIFF
--- a/terraform/projects/app-search/README.md
+++ b/terraform/projects/app-search/README.md
@@ -30,7 +30,7 @@ Search application servers
 | concourse\_aws\_account\_id | AWS account ID which contains the Concourse role | `string` | n/a | yes |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | instance\_ami\_filter\_name | Name to use to find AMI images | `string` | `""` | no |
-| instance\_type | Instance type used for EC2 resources | `string` | `"c5.large"` | no |
+| instance\_type | Instance type used for EC2 resources | `string` | `"c5.xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -67,7 +67,7 @@ variable "internal_domain_name" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for EC2 resources"
-  default     = "c5.large"
+  default     = "c5.xlarge"
 }
 
 variable "concourse_aws_account_id" {


### PR DESCRIPTION
At the moment the search machines are `c5.large` which has 4 GB of memory. We seem to be pretty close to that limit at the moment as most machines are using around 3.5 GB of memory. We've also noticed that Ruby 2.7 seems to use slightly more memory than earlier versions so I think it makes sense to increase the memory on these machines in advance of that. The `c5.xlarge` instance type has 8 GB of memory available.