### PR TITLE
Add variable block for GOV.UK PaaS egress IPs

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -38,6 +38,7 @@ Manage the security groups for the entire infrastructure
 | concourse\_ips | An array of CIDR blocks that represent ingress Concourse | `list` | n/a | yes |
 | ithc\_access\_ips | An array of CIDR blocks that will be allowed temporary access for ITHC purposes. | `list` | `[]` | no |
 | office\_ips | An array of CIDR blocks that will be allowed offsite access. | `list` | n/a | yes |
+| paas\_egress\_ips | An array of CIDR blocks that are used for egress from the GOV.UK PaaS | `list` | `[]` | no |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |
 | remote\_state\_infra\_vpc\_key\_stack | Override infra\_vpc remote state path | `string` | `""` | no |

--- a/terraform/projects/infra-security-groups/email-alert-api.tf
+++ b/terraform/projects/infra-security-groups/email-alert-api.tf
@@ -125,7 +125,7 @@ resource "aws_security_group" "email-alert-api_paas_access" {
 }
 
 resource "aws_security_group_rule" "paas_ingress_email-alert-api_ssh" {
-  count             = "${length(var.paas_access_ips) > 0 ? 1 : 0}"
+  count             = "${length(var.paas_egress_ips) > 0 ? 1 : 0}"
   type              = "ingress"
   to_port           = 443
   from_port         = 443

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -83,6 +83,12 @@ variable "carrenza_vpn_subnet_cidr" {
   default     = []
 }
 
+variable "paas_egress_ips" {
+  type        = "list"
+  description = "An array of CIDR blocks that are used for egress from the GOV.UK PaaS"
+  default     = []
+}
+
 variable "ithc_access_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will be allowed temporary access for ITHC purposes."


### PR DESCRIPTION
This was missing, so the Terraform failed to apply.

Trello card: https://trello.com/c/U0P11cQc