### PR TITLE
Remove email-alert-api ingress restriction

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -38,7 +38,6 @@ Manage the security groups for the entire infrastructure
 | concourse\_ips | An array of CIDR blocks that represent ingress Concourse | `list` | n/a | yes |
 | ithc\_access\_ips | An array of CIDR blocks that will be allowed temporary access for ITHC purposes. | `list` | `[]` | no |
 | office\_ips | An array of CIDR blocks that will be allowed offsite access. | `list` | n/a | yes |
-| paas\_egress\_ips | An array of CIDR blocks that are used for egress from the GOV.UK PaaS | `list` | `[]` | no |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |
 | remote\_state\_infra\_vpc\_key\_stack | Override infra\_vpc remote state path | `string` | `""` | no |

--- a/terraform/projects/infra-security-groups/email-alert-api.tf
+++ b/terraform/projects/infra-security-groups/email-alert-api.tf
@@ -113,27 +113,6 @@ resource "aws_security_group_rule" "email-alert-api-elb-external_egress_any_any"
   security_group_id = "${aws_security_group.email-alert-api_elb_external.id}"
 }
 
-resource "aws_security_group" "email-alert-api_paas_access" {
-  count       = "${length(var.paas_egress_ips) > 0 ? 1 : 0}"
-  name        = "${var.stackname}_email-alert-api_paas_access"
-  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  description = "Control access from the GOV.UK PaaS"
-
-  tags {
-    Name = "${var.stackname}_email-alert-api_paas_access"
-  }
-}
-
-resource "aws_security_group_rule" "paas_ingress_email-alert-api_ssh" {
-  count             = "${length(var.paas_egress_ips) > 0 ? 1 : 0}"
-  type              = "ingress"
-  to_port           = 443
-  from_port         = 443
-  protocol          = "tcp"
-  cidr_blocks       = "${var.paas_egress_ips}"
-  security_group_id = "${aws_security_group.email-alert-api_paas_access.id}"
-}
-
 resource "aws_security_group" "email-alert-api_ithc_access" {
   count       = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
   name        = "${var.stackname}_email-alert-api_ithc_access"

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -83,12 +83,6 @@ variable "carrenza_vpn_subnet_cidr" {
   default     = []
 }
 
-variable "paas_egress_ips" {
-  type        = "list"
-  description = "An array of CIDR blocks that are used for egress from the GOV.UK PaaS"
-  default     = []
-}
-
 variable "ithc_access_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will be allowed temporary access for ITHC purposes."


### PR DESCRIPTION
We added a security group to only permit ingress to email-alert-api from the GOV.UK PaaS, but there was already a security group permitting access from any IP.

This reverts commits 22434e0baa145f939ad46396ad70e648c0b4738a, 28fae7be6396a381a81eeeea2912e4265eb92c02 and e65340979dd8eac46b150e64513bd696bdcec501.