### PR TITLE
Restore PaaS egress IPs to infra-security-groups

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -38,6 +38,7 @@ Manage the security groups for the entire infrastructure
 | concourse\_ips | An array of CIDR blocks that represent ingress Concourse | `list` | n/a | yes |
 | ithc\_access\_ips | An array of CIDR blocks that will be allowed temporary access for ITHC purposes. | `list` | `[]` | no |
 | office\_ips | An array of CIDR blocks that will be allowed offsite access. | `list` | n/a | yes |
+| paas\_egress\_ips | An array of CIDR blocks that are used for egress from the GOV.UK PaaS | `list` | `[]` | no |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |
 | remote\_state\_infra\_vpc\_key\_stack | Override infra\_vpc remote state path | `string` | `""` | no |

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -83,6 +83,12 @@ variable "carrenza_vpn_subnet_cidr" {
   default     = []
 }
 
+variable "paas_egress_ips" {
+  type        = "list"
+  description = "An array of CIDR blocks that are used for egress from the GOV.UK PaaS"
+  default     = []
+}
+
 variable "ithc_access_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will be allowed temporary access for ITHC purposes."


### PR DESCRIPTION
This PR restores the PaaS egress IPs to `infra-security-groups` that were removed as part of PR https://github.com/alphagov/govuk-aws/commit/a4d33cc8b05f5875c4f9ff7eac1ed322c30afe9f.

The reason for this is that they are being relied upon in the later-merged PR https://github.com/alphagov/govuk-aws/pull/1361, so they should still be available in this project.