### PR TITLE
Update PaaS egress IPs and Knowledge Graph access

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -38,7 +38,8 @@ Manage the security groups for the entire infrastructure
 | concourse\_ips | An array of CIDR blocks that represent ingress Concourse | `list` | n/a | yes |
 | ithc\_access\_ips | An array of CIDR blocks that will be allowed temporary access for ITHC purposes. | `list` | `[]` | no |
 | office\_ips | An array of CIDR blocks that will be allowed offsite access. | `list` | n/a | yes |
-| paas\_egress\_ips | An array of CIDR blocks that are used for egress from the GOV.UK PaaS | `list` | `[]` | no |
+| paas\_ireland\_egress\_ips | An array of CIDR blocks that are used for egress from the GOV.UK PaaS Ireland region | `list` | `[]` | no |
+| paas\_london\_egress\_ips | An array of CIDR blocks that are used for egress from the GOV.UK PaaS London region | `list` | `[]` | no |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |
 | remote\_state\_infra\_vpc\_key\_stack | Override infra\_vpc remote state path | `string` | `""` | no |

--- a/terraform/projects/infra-security-groups/knowledge-graph.tf
+++ b/terraform/projects/infra-security-groups/knowledge-graph.tf
@@ -117,7 +117,7 @@ resource "aws_security_group_rule" "knowledge-graph-elb-external_ingress_paas_bo
   protocol    = "tcp"
   from_port   = 7687
   to_port     = 7687
-  cidr_blocks = ["${var.paas_egress_ips}"]
+  cidr_blocks = ["${var.paas_ireland_egress_ips}"]
 
   security_group_id = "${aws_security_group.knowledge-graph_elb_external.id}"
 }

--- a/terraform/projects/infra-security-groups/knowledge-graph.tf
+++ b/terraform/projects/infra-security-groups/knowledge-graph.tf
@@ -112,11 +112,11 @@ resource "aws_security_group_rule" "knowledge-graph-elb-external_ingress_office_
   security_group_id = "${aws_security_group.knowledge-graph_elb_external.id}"
 }
 
-resource "aws_security_group_rule" "knowledge-graph-elb-external_ingress_paas_bolt" {
+resource "aws_security_group_rule" "knowledge-graph-elb-external_ingress_paas_https" {
   type        = "ingress"
   protocol    = "tcp"
-  from_port   = 7687
-  to_port     = 7687
+  from_port   = 7473
+  to_port     = 7473
   cidr_blocks = ["${var.paas_ireland_egress_ips}"]
 
   security_group_id = "${aws_security_group.knowledge-graph_elb_external.id}"

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -83,9 +83,15 @@ variable "carrenza_vpn_subnet_cidr" {
   default     = []
 }
 
-variable "paas_egress_ips" {
+variable "paas_ireland_egress_ips" {
   type        = "list"
-  description = "An array of CIDR blocks that are used for egress from the GOV.UK PaaS"
+  description = "An array of CIDR blocks that are used for egress from the GOV.UK PaaS Ireland region"
+  default     = []
+}
+
+variable "paas_london_egress_ips" {
+  type        = "list"
+  description = "An array of CIDR blocks that are used for egress from the GOV.UK PaaS London region"
   default     = []
 }
 


### PR DESCRIPTION
This PR renames the variable `paas_egress_ips` to `paas_london_egress_ips` for the current London-region PaaS IPs, adds `paas_ireland_egress_ips` for Ireland region PaaS IPs and updates the Knowledge Graph security group to reflect these changes.

It also changes PaaS access to the Knowledge Graph from being over bolt to now being over https.