### PR TITLE
Change scheduled action times for app-data-science-data and app-knowledge-graph

### DIFF
--- a/terraform/projects/app-data-science-data/main.tf
+++ b/terraform/projects/app-data-science-data/main.tf
@@ -169,7 +169,7 @@ resource "aws_autoscaling_group" "data-science-data_asg" {
 resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-up" {
   autoscaling_group_name = "${aws_autoscaling_group.data-science-data_asg.name}"
   scheduled_action_name  = "data-science-data_schedule-spin-up"
-  recurrence             = "0 6 * * MON-SUN"
+  recurrence             = "30 8 * * MON-SUN"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 1
@@ -178,7 +178,7 @@ resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-up" {
 resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-down" {
   autoscaling_group_name = "${aws_autoscaling_group.data-science-data_asg.name}"
   scheduled_action_name  = "data-science-data_schedule-spin-down"
-  recurrence             = "59 6 * * MON-SUN"
+  recurrence             = "29 10 * * MON-SUN"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 0

--- a/terraform/projects/app-data-science-data/main.tf
+++ b/terraform/projects/app-data-science-data/main.tf
@@ -150,7 +150,7 @@ resource "aws_autoscaling_group" "data-science-data_asg" {
   name             = "${var.stackname}_data-science-data"
   min_size         = 0
   max_size         = 1
-  desired_capacity = 1
+  desired_capacity = 0
 
   launch_template {
     id      = "${aws_launch_template.data-science-data_launch_template.id}"

--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -260,7 +260,7 @@ resource "aws_autoscaling_group" "knowledge-graph_asg" {
 resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-up" {
   autoscaling_group_name = "${aws_autoscaling_group.knowledge-graph_asg.name}"
   scheduled_action_name  = "knowledge-graph_schedule-spin-up"
-  recurrence             = "0 9 * * MON-FRI"
+  recurrence             = "30 9 * * MON-FRI"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 1
@@ -269,7 +269,7 @@ resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-up" {
 resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-down" {
   autoscaling_group_name = "${aws_autoscaling_group.knowledge-graph_asg.name}"
   scheduled_action_name  = "knowledge-graph_schedule-spin-down"
-  recurrence             = "55 17 * * MON-FRI"
+  recurrence             = "29 18 * * MON-FRI"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 0


### PR DESCRIPTION
This PR updates the scheduled action times for spinning-up and spinning-down instances of both `app-data-science-data` and `app-knowledge-graph`. The reason for doing this is because data that we rely on in GA as part of the data generation pipeline is often not created until 08:30 UTC daily, so we should hold off until then to ensure that it's available.

The Knowledge Graph uses the output of the data generation pipeline, so it is also moved back an hour to ensure that output exists when the machine spins-up.