### PR TITLE
Simplify confusing logic for S3 lifecycle rules.

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/README.md
+++ b/terraform/projects/infra-database-backups-bucket/README.md
@@ -31,7 +31,6 @@ database-backups: The bucket that will hold database backups
 | expiration\_time | Expiration time in days of S3 Objects | `string` | `"120"` | no |
 | expiration\_time\_whisper\_mongo | Expiration time in days for Whisper/Mongo S3 database backups | `string` | `"7"` | no |
 | glacier\_storage\_time | Storage time in days for Glacier Objects | `string` | `"90"` | no |
-| integration\_only | Only apply these policies to integration | `string` | `"false"` | no |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_monitoring\_key\_stack | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | replication\_setting | Whether replication is Enabled or Disabled | `string` | `"Enabled"` | no |


### PR DESCRIPTION
Remove the unnecessary and confusing var `integration_only` and add some TODOs for further cleanup.

This should make the upcoming [fixes to retention policies](https://trello.com/c/6Br21sKD/3916) easier.

Tested: verified no diffs with `terraform plan` in integration, staging and production. (e.g. `gds aws govuk-integration-admin -- tools/build-terraform-project.sh -c plan -d ../govuk-aws-data/data -e integration -s govuk -p infra-database-backups-bucket`)

alphagov/govuk-aws-data#801 removes the disused vars from the private repo.