### PR TITLE
Edit app-cache ags_size

### DIFF
--- a/terraform/projects/app-cache/README.md
+++ b/terraform/projects/app-cache/README.md
@@ -22,7 +22,7 @@ Cache application servers
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | app\_service\_records | List of application service names that get traffic via this loadbalancer | `list` | `[]` | no |
-| asg\_size | The autoscaling groups desired/max/min capacity | `string` | `"6"` | no |
+| asg\_size | The autoscaling groups desired/max/min capacity | `string` | `"9"` | no |
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | create\_external\_elb | Create the external ELB | `bool` | `true` | no |

--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -44,7 +44,7 @@ variable "app_service_records" {
 variable "asg_size" {
   type        = "string"
   description = "The autoscaling groups desired/max/min capacity"
-  default     = "6"
+  default     = "9"
 }
 
 variable "external_zone_name" {


### PR DESCRIPTION
This updates the default AWS auto scaling group size for `cache` from 6
to 9. The only environment using 6 was staging, and this will align the
default to what production uses instead.

Follow up PR: https://github.com/alphagov/govuk-aws-data/pull/804

Co-authored-by: Alan Gabbianelli <Alan.Gabbianelli@digital.cabinet-office.gov.uk>
Co-authored-by: Rebecca Pearce <Rebecca.Pearce@digital.cabinet-office.gov.uk>