### PR TITLE
Edit app-frontend ags_size

### DIFF
--- a/terraform/projects/app-frontend/README.md
+++ b/terraform/projects/app-frontend/README.md
@@ -22,7 +22,7 @@ Frontend application servers
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | app\_service\_records | List of application service names that get traffic via this loadbalancer | `list` | `[]` | no |
-| asg\_size | The autoscaling groups desired/max/min capacity | `string` | `"3"` | no |
+| asg\_size | The autoscaling groups desired/max/min capacity | `string` | `"12"` | no |
 | aws\_environment | AWS Environment | `string` | n/a | yes |
 | aws\_region | AWS region | `string` | `"eu-west-1"` | no |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -39,7 +39,7 @@ variable "app_service_records" {
 variable "asg_size" {
   type        = "string"
   description = "The autoscaling groups desired/max/min capacity"
-  default     = "3"
+  default     = "12"
 }
 
 variable "root_block_device_volume_size" {


### PR DESCRIPTION
This updates the default AWS auto scaling group size for `frontend` from
3 to 12. The only environment using 3 was staging, and this will align
the default to what production uses instead.

Follow up PR: https://github.com/alphagov/govuk-aws-data/pull/805

Co-authored-by: Alan Gabbianelli <Alan.Gabbianelli@digital.cabinet-office.gov.uk>
Co-authored-by: Rebecca Pearce <Rebecca.Pearce@digital.cabinet-office.gov.uk>