### PR TITLE
Empty bucket manually instead of force destroying

### DIFF
--- a/terraform/projects/infra-email-alert-api-archive/README.md
+++ b/terraform/projects/infra-email-alert-api-archive/README.md
@@ -14,7 +14,6 @@ purposes.
 
 | Name | Version |
 |------|---------|
-| aws | 2.46.0 |
 | terraform | n/a |
 
 ## Inputs

--- a/terraform/projects/infra-email-alert-api-archive/main.tf
+++ b/terraform/projects/infra-email-alert-api-archive/main.tf
@@ -32,18 +32,3 @@ provider "aws" {
   region  = "${var.aws_region}"
   version = "2.46.0"
 }
-
-resource "aws_s3_bucket" "email_alert_api_archive" {
-  bucket        = "govuk-${var.aws_environment}-email-alert-api-archive"
-  force_destroy = true
-
-  tags {
-    Name            = "govuk-${var.aws_environment}-email-alert-api-archive"
-    aws_environment = "${var.aws_environment}"
-  }
-
-  logging {
-    target_bucket = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-    target_prefix = "s3/govuk-${var.aws_environment}-email-alert-api-archive/"
-  }
-}


### PR DESCRIPTION
https://trello.com/c/UMGXUk5R/654-retire-archiving-emails

Previously we tried using the "force_destroy" flag, but this doesn't
seem to have the intended effect (nothing changes), and actually just
leaves Terraform thinking it's already deleted the bucket. Turns out
we can empty the bucket manually, so this just removes it.

Note that we will delete the project entirely in a future commit.