### PR TITLE
Allow Jenkins to send https to Bouncer internal ELB

### DIFF
--- a/terraform/projects/infra-security-groups/bouncer.tf
+++ b/terraform/projects/infra-security-groups/bouncer.tf
@@ -130,3 +130,12 @@ resource "aws_security_group_rule" "bouncer-internal-elb_egress_any_any" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.bouncer_internal_elb.id}"
 }
+
+resource "aws_security_group_rule" "bouncer-internal-elb_ingress_smokey_https" {
+  type                     = "ingress"
+  to_port                  = 443
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.bouncer_internal_elb.id}"
+  source_security_group_id = "${aws_security_group.deploy.id}"
+}


### PR DESCRIPTION
This is required so that Jenkins can run smokey tests against Bouncer
for continuous deployment reasons. Jenkins will access Bouncer via
the internal ELB of Bouncer on HTTPS (port 443).