### PR TITLE
Remove S3 lifecycle rule for business support database backup

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -256,18 +256,6 @@ resource "aws_s3_bucket" "database_backups" {
       days = 365
     }
   }
-
-  # Lifecycle rule for coronavirus business volunteer form backup
-
-  lifecycle_rule {
-    id      = "coronavirus_business_volunteer_form_lifecycle_rule"
-    prefix  = "coronavirus-business-volunteer-form/production.sql.gzip"
-    enabled = true
-
-    expiration {
-      days = 365
-    }
-  }
   versioning {
     enabled = true
   }


### PR DESCRIPTION
The backup has been transferred to another department and will no longer be stored. Cleaning up this extra lifecycle rules as its no longer needed.