### PR TITLE
Bump knowledge graph instance type

### DIFF
--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -212,7 +212,7 @@ resource "aws_launch_template" "knowledge-graph_launch_template" {
   name     = "knowledge-graph_launch-template"
   image_id = "${data.aws_ami.neo4j_community_ami.id}"
 
-  instance_type = "m4.large"
+  instance_type = "r4.2xlarge"
 
   vpc_security_group_ids = ["${data.terraform_remote_state.infra_security_groups.sg_knowledge-graph_id}"]
 


### PR DESCRIPTION
This PR bumps the knowledge graph instance type from an `m4.large` to an `r4.2xlarge`. This change has already been tested via the AWS Console and is necessary because eligibility extraction is currently running on the graph, requiring more resources.