### PR TITLE
Set cache asg_min_size to asg_desired_capacity - 1

### DIFF
--- a/terraform/projects/app-cache/main.tf
+++ b/terraform/projects/app-cache/main.tf
@@ -250,7 +250,7 @@ module "cache" {
   instance_elb_ids              = ["${local.instance_elb_ids}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   asg_max_size                  = "${var.asg_size}"
-  asg_min_size                  = "${var.asg_size}"
+  asg_min_size                  = "${var.asg_size - 1}"
   asg_desired_capacity          = "${var.asg_size}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
 }


### PR DESCRIPTION
Having the minimum capacity be 1 less than the max/desired capacity enables us to move one instance into a standby state, without the ASG starting a new instance to replace the instance we are performing maintenance on.

This is helpful for rebooting an instance. We can follow the procedure to [place an ASG instance in a standby state](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-enter-exit-standby.html#standby-state) which lets us reboot a machine safely (preventing it from serving requests while it is rebooting).