### PR TITLE
Use one subnet per availability zone in AWS

### DIFF
--- a/terraform/projects/app-mapit/README.md
+++ b/terraform/projects/app-mapit/README.md
@@ -32,18 +32,9 @@ Mapit node
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | lc\_create\_ebs\_volume | Creates a launch configuration which will add an additional ebs volume to the instance if this value is set to 1 | `string` | n/a | yes |
-| mapit\_10\_subnet | Name of the subnet to place the mapit instance 10 and EBS volume | `string` | n/a | yes |
-| mapit\_11\_subnet | Name of the subnet to place the mapit instance 11 and EBS volume | `string` | n/a | yes |
-| mapit\_12\_subnet | Name of the subnet to place the mapit instance 12 and EBS volume | `string` | n/a | yes |
-| mapit\_1\_subnet | Name of the subnet to place the mapit instance 1 and EBS volume | `string` | n/a | yes |
-| mapit\_2\_subnet | Name of the subnet to place the mapit instance 2 and EBS volume | `string` | n/a | yes |
-| mapit\_3\_subnet | Name of the subnet to place the mapit instance 3 and EBS volume | `string` | n/a | yes |
-| mapit\_4\_subnet | Name of the subnet to place the mapit instance 4 and EBS volume | `string` | n/a | yes |
-| mapit\_5\_subnet | Name of the subnet to place the mapit instance 5 and EBS volume | `string` | n/a | yes |
-| mapit\_6\_subnet | Name of the subnet to place the mapit instance 6 and EBS volume | `string` | n/a | yes |
-| mapit\_7\_subnet | Name of the subnet to place the mapit instance 7 and EBS volume | `string` | n/a | yes |
-| mapit\_8\_subnet | Name of the subnet to place the mapit instance 8 and EBS volume | `string` | n/a | yes |
-| mapit\_9\_subnet | Name of the subnet to place the mapit instance 9 and EBS volume | `string` | n/a | yes |
+| mapit\_subnet\_a | Name of the subnet to place the first third of mapit instances and EBS volumes | `string` | n/a | yes |
+| mapit\_subnet\_b | Name of the subnet to place the second third of mapit instances and EBS volumes | `string` | n/a | yes |
+| mapit\_subnet\_c | Name of the subnet to place the last third of mapit instances and EBS volumes | `string` | n/a | yes |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_monitoring\_key\_stack | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -30,64 +30,19 @@ variable "instance_ami_filter_name" {
   default     = ""
 }
 
-variable "mapit_1_subnet" {
+variable "mapit_subnet_a" {
   type        = "string"
-  description = "Name of the subnet to place the mapit instance 1 and EBS volume"
+  description = "Name of the subnet to place the first third of mapit instances and EBS volumes"
 }
 
-variable "mapit_2_subnet" {
+variable "mapit_subnet_b" {
   type        = "string"
-  description = "Name of the subnet to place the mapit instance 2 and EBS volume"
+  description = "Name of the subnet to place the second third of mapit instances and EBS volumes"
 }
 
-variable "mapit_3_subnet" {
+variable "mapit_subnet_c" {
   type        = "string"
-  description = "Name of the subnet to place the mapit instance 3 and EBS volume"
-}
-
-variable "mapit_4_subnet" {
-  type        = "string"
-  description = "Name of the subnet to place the mapit instance 4 and EBS volume"
-}
-
-variable "mapit_5_subnet" {
-  type        = "string"
-  description = "Name of the subnet to place the mapit instance 5 and EBS volume"
-}
-
-variable "mapit_6_subnet" {
-  type        = "string"
-  description = "Name of the subnet to place the mapit instance 6 and EBS volume"
-}
-
-variable "mapit_7_subnet" {
-  type        = "string"
-  description = "Name of the subnet to place the mapit instance 7 and EBS volume"
-}
-
-variable "mapit_8_subnet" {
-  type        = "string"
-  description = "Name of the subnet to place the mapit instance 8 and EBS volume"
-}
-
-variable "mapit_9_subnet" {
-  type        = "string"
-  description = "Name of the subnet to place the mapit instance 9 and EBS volume"
-}
-
-variable "mapit_10_subnet" {
-  type        = "string"
-  description = "Name of the subnet to place the mapit instance 10 and EBS volume"
-}
-
-variable "mapit_11_subnet" {
-  type        = "string"
-  description = "Name of the subnet to place the mapit instance 11 and EBS volume"
-}
-
-variable "mapit_12_subnet" {
-  type        = "string"
-  description = "Name of the subnet to place the mapit instance 12 and EBS volume"
+  description = "Name of the subnet to place the last third of mapit instances and EBS volumes"
 }
 
 variable "elb_internal_certname" {
@@ -204,7 +159,7 @@ module "mapit-1" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-1"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-1")}"
-  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_1_subnet))}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_a))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
@@ -219,7 +174,7 @@ module "mapit-1" {
 }
 
 resource "aws_ebs_volume" "mapit-1" {
-  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_1_subnet)}"
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_a)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"
@@ -240,7 +195,7 @@ module "mapit-2" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-2"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-2")}"
-  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_2_subnet))}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_b))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
@@ -255,7 +210,7 @@ module "mapit-2" {
 }
 
 resource "aws_ebs_volume" "mapit-2" {
-  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_2_subnet)}"
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_b)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"
@@ -276,7 +231,7 @@ module "mapit-3" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-3"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-3")}"
-  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_3_subnet))}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_c))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
@@ -291,7 +246,7 @@ module "mapit-3" {
 }
 
 resource "aws_ebs_volume" "mapit-3" {
-  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_3_subnet)}"
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_c)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"
@@ -312,7 +267,7 @@ module "mapit-4" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-4"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-4")}"
-  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_4_subnet))}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_a))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
@@ -327,7 +282,7 @@ module "mapit-4" {
 }
 
 resource "aws_ebs_volume" "mapit-4" {
-  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_4_subnet)}"
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_a)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"
@@ -348,7 +303,7 @@ module "mapit-5" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-5"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-5")}"
-  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_5_subnet))}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_b))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
@@ -363,7 +318,7 @@ module "mapit-5" {
 }
 
 resource "aws_ebs_volume" "mapit-5" {
-  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_5_subnet)}"
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_b)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"
@@ -384,7 +339,7 @@ module "mapit-6" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-6"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-6")}"
-  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_6_subnet))}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_c))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
@@ -399,7 +354,7 @@ module "mapit-6" {
 }
 
 resource "aws_ebs_volume" "mapit-6" {
-  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_6_subnet)}"
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_c)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"
@@ -420,7 +375,7 @@ module "mapit-7" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-7"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-7")}"
-  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_7_subnet))}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_a))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
@@ -435,7 +390,7 @@ module "mapit-7" {
 }
 
 resource "aws_ebs_volume" "mapit-7" {
-  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_7_subnet)}"
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_a)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"
@@ -456,7 +411,7 @@ module "mapit-8" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-8"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-8")}"
-  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_8_subnet))}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_b))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
@@ -471,7 +426,7 @@ module "mapit-8" {
 }
 
 resource "aws_ebs_volume" "mapit-8" {
-  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_8_subnet)}"
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_b)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"
@@ -492,7 +447,7 @@ module "mapit-9" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-9"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-9")}"
-  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_9_subnet))}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_c))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
@@ -507,7 +462,7 @@ module "mapit-9" {
 }
 
 resource "aws_ebs_volume" "mapit-9" {
-  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_9_subnet)}"
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_c)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"
@@ -528,7 +483,7 @@ module "mapit-10" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-10"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-10")}"
-  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_10_subnet))}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_a))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
@@ -543,7 +498,7 @@ module "mapit-10" {
 }
 
 resource "aws_ebs_volume" "mapit-10" {
-  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_10_subnet)}"
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_a)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"
@@ -564,7 +519,7 @@ module "mapit-11" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-11"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-11")}"
-  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_11_subnet))}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_b))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
@@ -579,7 +534,7 @@ module "mapit-11" {
 }
 
 resource "aws_ebs_volume" "mapit-11" {
-  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_11_subnet)}"
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_b)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"
@@ -600,7 +555,7 @@ module "mapit-12" {
   source                        = "../../modules/aws/node_group"
   name                          = "${var.stackname}-mapit-12"
   default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-12")}"
-  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_12_subnet))}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_c))}"
   instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                 = "${var.instance_type}"
   instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
@@ -615,7 +570,7 @@ module "mapit-12" {
 }
 
 resource "aws_ebs_volume" "mapit-12" {
-  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_12_subnet)}"
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_c)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = 20
   type              = "gp2"


### PR DESCRIPTION
This is a refactor commit, it doesn't change any functionality.

Currently, we use one subnet variable for each mapit instance and EBS volume. This means for each new mapit instance we add here in `govuk-aws`, we add a new variable in `govuk-aws-data`. This makes scaling mapit up or down more time-consuming and more error prone (the more code we add or change, the higher the chance to introduce bugs).

https://github.com/alphagov/govuk-aws-data/pull/820 introduced `mapit_subnet_a`, `mapit_subnet_b` and `mapit_subnet_c`, and removed the numbered variables, making this change necessary.

This means in the future we'll only have to make changes to `govuk-aws` to scale mapit up or down.