### PR TITLE
Create a shared memcached cluster for Mapit

### DIFF
--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -154,6 +154,23 @@ resource "aws_route53_record" "mapit_service_record" {
   }
 }
 
+resource "aws_elasticache_subnet_group" "cache" {
+  name       = "${var.stackname}-mapit-cache"
+  subnet_ids = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
+}
+
+resource "aws_elasticache_cluster" "memcached" {
+  cluster_id           = "${var.stackname}-mapit-cache"
+  engine               = "memcached"
+  engine_version       = "1.6.6"
+  port                 = 11211
+  parameter_group_name = "default.memcached1.6"
+  node_type            = "cache.r6g.large"                                                          # Memory optimized Graviton2 ($0.206/hour as of 2020)
+  num_cache_nodes      = 1
+  security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_cache_id}"]
+  subnet_group_name    = "${aws_elasticache_subnet_group.cache.name}"
+}
+
 module "mapit-1" {
   lc_create_ebs_volume          = "${var.lc_create_ebs_volume}"
   source                        = "../../modules/aws/node_group"

--- a/terraform/projects/infra-security-groups/mapit.tf
+++ b/terraform/projects/infra-security-groups/mapit.tf
@@ -75,6 +75,29 @@ resource "aws_security_group_rule" "mapit_ingress_mapit-carrenza-alb_http" {
   source_security_group_id = "${aws_security_group.mapit_carrenza_alb.id}"
 }
 
+resource "aws_security_group" "mapit_cache" {
+  name        = "${var.stackname}_mapit_cache_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access to the mapit cache from mapit"
+
+  tags {
+    Name = "${var.stackname}_mapit_cache_access"
+  }
+}
+
+resource "aws_security_group_rule" "mapit_mapit_cache" {
+  type      = "ingress"
+  from_port = 11211
+  to_port   = 11211
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.mapit_cache.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.mapit.id}"
+}
+
 # Security resources for ALB set up for Carrenza access to AWS Mapit
 
 resource "aws_security_group" "mapit_carrenza_alb" {

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -346,6 +346,10 @@ output "sg_mapit_elb_id" {
   value = "${aws_security_group.mapit_elb.id}"
 }
 
+output "sg_mapit_cache_id" {
+  value = "${aws_security_group.mapit_cache.id}"
+}
+
 output "sg_management_id" {
   value = "${aws_security_group.management.id}"
 }


### PR DESCRIPTION
infra-security-groups will need to be applied first, as app-mapit
depends on a new output.

The r6g instance type is the default if you click through in the AWS
console. AWS suggest that the ARM based processers work well with
elasticache:

https://aws.amazon.com/about-aws/whats-new/2020/10/amazon-elasticache-now-supports-m6g-and-r6g-graviton2-based-instances/

The choice between m6g and r6g is arbitrary - r6g comes first in the
dropdown in the console.

The choice of `large` (rather than `xlarge` or higher) is also
arbitrary. I'm assuming that the failure mode for this will be graceful,
as it's just a cache, so starting small and scaling based on metrics
feels reasonable. You could argue the other way though (start big and
make it smaller based on metrics).