### PR TITLE
Create a shared memcached cluster for Frontend

### DIFF
--- a/terraform/projects/app-frontend/README.md
+++ b/terraform/projects/app-frontend/README.md
@@ -31,6 +31,7 @@ Frontend application servers
 | instance\_type | Instance type used for EC2 resources | `string` | `"m5.xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
+| memcached\_instance\_type | Instance type used for the shared Elasticache Memcached instances | `string` | `"cache.r6g.large"` | no |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_monitoring\_key\_stack | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -54,6 +54,13 @@ variable "instance_type" {
   default     = "m5.xlarge"
 }
 
+variable "memcached_instance_type" {
+  type    = "string"
+  default = "cache.r6g.large" # Memory optimized Graviton2 ($0.206/hour as of 2020)
+
+  description = "Instance type used for the shared Elasticache Memcached instances"
+}
+
 variable "enable_alb" {
   type        = "string"
   description = "Use application specific target groups and healthchecks based on the list of services in the cname variable."
@@ -189,7 +196,7 @@ resource "aws_elasticache_cluster" "memcached" {
   engine          = "memcached"
   engine_version  = "1.6.6"
   port            = 11211
-  node_type       = "cache.r6g.large" # Memory optimized Graviton2 ($0.206/hour as of 2020)
+  node_type       = "${var.memcached_instance_type}"
   num_cache_nodes = 1
 
   parameter_group_name = "default.memcached1.6"

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -185,13 +185,13 @@ module "internal_lb_rules" {
   default_tags           = "${map("Project", var.stackname, "aws_migration", "frontend", "aws_environment", var.aws_environment)}"
 }
 
-resource "aws_elasticache_subnet_group" "cache" {
-  name       = "${var.stackname}-frontend-cache"
+resource "aws_elasticache_subnet_group" "memcached" {
+  name       = "${var.stackname}-frontend-memcached"
   subnet_ids = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
 }
 
 resource "aws_elasticache_cluster" "memcached" {
-  cluster_id = "${var.stackname}-frontend-cache"
+  cluster_id = "${var.stackname}-frontend-memcached"
 
   engine          = "memcached"
   engine_version  = "1.6.6"
@@ -200,11 +200,11 @@ resource "aws_elasticache_cluster" "memcached" {
   num_cache_nodes = 1
 
   parameter_group_name = "default.memcached1.6"
-  subnet_group_name    = "${aws_elasticache_subnet_group.cache.name}"
+  subnet_group_name    = "${aws_elasticache_subnet_group.memcached.name}"
   security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_frontend_cache_id}"]
 }
 
-resource "aws_route53_record" "cache_cname" {
+resource "aws_route53_record" "memcached_cname" {
   zone_id = "${data.aws_route53_zone.internal.zone_id}"
   name    = "frontend-memcached.${var.internal_domain_name}"
   type    = "CNAME"

--- a/terraform/projects/app-frontend/main.tf
+++ b/terraform/projects/app-frontend/main.tf
@@ -197,6 +197,14 @@ resource "aws_elasticache_cluster" "memcached" {
   security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_frontend_cache_id}"]
 }
 
+resource "aws_route53_record" "cache_cname" {
+  zone_id = "${data.aws_route53_zone.internal.zone_id}"
+  name    = "frontend-memcached.${var.internal_domain_name}"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["${aws_elasticache_cluster.memcached.cluster_address}"]
+}
+
 module "frontend" {
   source                            = "../../modules/aws/node_group"
   name                              = "${var.stackname}-frontend"

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1347,6 +1347,14 @@ resource "aws_route53_record" "frontend_internal_service_cnames" {
   ttl     = "300"
 }
 
+resource "aws_route53_record" "frontend_cache_name" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "frontend-memcached.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["frontend-memcached.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
 #
 # Graphite
 #

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -117,6 +117,7 @@ Manage the security groups for the entire infrastructure
 | sg\_email-alert-api\_elb\_internal\_id | n/a |
 | sg\_email-alert-api\_id | n/a |
 | sg\_feedback\_elb\_id | n/a |
+| sg\_frontend\_cache\_id | n/a |
 | sg\_frontend\_elb\_id | n/a |
 | sg\_frontend\_id | n/a |
 | sg\_gatling\_external\_elb\_id | n/a |

--- a/terraform/projects/infra-security-groups/frontend.tf
+++ b/terraform/projects/infra-security-groups/frontend.tf
@@ -100,6 +100,29 @@ resource "aws_security_group_rule" "static_ingress_static-carrenza-alb_http" {
   source_security_group_id = "${aws_security_group.static_carrenza_alb.id}"
 }
 
+resource "aws_security_group" "frontend_cache" {
+  name        = "${var.stackname}_frontend_cache_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access to the frontend cache from frontend"
+
+  tags {
+    Name = "${var.stackname}_frontend_cache_access"
+  }
+}
+
+resource "aws_security_group_rule" "frontend_ingress_frontend_cache_memcached" {
+  type      = "ingress"
+  from_port = 11211
+  to_port   = 11211
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.frontend_cache.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.frontend.id}"
+}
+
 # Security resources for ALB set up for Carrenza access to AWS
 
 resource "aws_security_group" "static_carrenza_alb" {

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -274,6 +274,10 @@ output "sg_frontend_id" {
   value = "${aws_security_group.frontend.id}"
 }
 
+output "sg_frontend_cache_id" {
+  value = "${aws_security_group.frontend_cache.id}"
+}
+
 output "sg_gatling_id" {
   value = "${aws_security_group.gatling.id}"
 }


### PR DESCRIPTION
The theory here is that having a shared rails cache should improve
performance of the frontend applications now that we've scaled them
up to a large number of instances.

We're particularly hoping to see improvements between `collections` and
`mapit`, as the responses from mapit are highly cacheable (postcodes
don't change local authority very often.

`infra-security-groups` will need to be applied first, as `app-frontend`
depends on a new output.

The `r6g` instance type is the default if you click through in the AWS
console. AWS suggest that the ARM based processers work well with
elasticache:

https://aws.amazon.com/about-aws/whats-new/2020/10/amazon-elasticache-now-supports-m6g-and-r6g-graviton2-based-instances/

The choice between `m6g` and `r6g` is arbitrary - `r6g` comes first in
the dropdown in the console.

The choice of `large` (rather than `xlarge` or higher) is also
arbitrary. I'm assuming that the failure mode for this will be graceful,
as it's just a cache, so starting small and scaling based on metrics
feels reasonable. You could argue the other way though (start big and
make it smaller based on metrics).

## Release Plan

* Merge this PR
* Apply `infra-security-groups` from master in integration
* Apply `app-frontend` from master in integration
* Apply `infra-public-services` from master in integration
* Apply `infra-security-groups` from master in staging
* Apply `app-frontend` from master in staging
* Apply `infra-public-services` from master in staging
* Apply `infra-security-groups` from master in production
* Apply `app-frontend` from master in production
* Apply `infra-public-services` from master in production
* Update https://github.com/alphagov/govuk-puppet/pull/10896 to target integration and staging, but leave production using local caches
* Merge govuk-puppet
* Apply govuk-puppet from master in integration
* Apply govuk-puppet from master in staging
* Apply govuk-puppet from master in production (should be almost a no-op - setting MEMCACHE_SERVERS to 127.0.0.1:11211 which is the default)
* Test the performance of the shared cache in staging (because we've traffic replay there, so it's more realistic)
* If we're happy, raise a govuk-puppet PR to use the shared cache in production
* ????
* Profit!

* Raise a PR in govuk-aws-data to scale down the elasticache memcached instance in integration