### PR TITLE
Improve health detection for Content Store

### DIFF
--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -131,7 +131,7 @@ resource "aws_elb" "content-store_external_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:80"
+    target              = "HTTP:80/_healthcheck_content-store"
     interval            = 30
   }
 
@@ -182,7 +182,7 @@ resource "aws_elb" "content-store_internal_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:80"
+    target              = "HTTP:80/_healthcheck_content-store"
     interval            = 30
   }
 

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -131,7 +131,7 @@ resource "aws_elb" "draft-content-store_external_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:80"
+    target              = "HTTP:80/_healthcheck_draft-content-store"
     interval            = 30
   }
 
@@ -182,7 +182,7 @@ resource "aws_elb" "draft-content-store_internal_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:80"
+    target              = "HTTP:80/_healthcheck_draft-content-store"
     interval            = 30
   }
 

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -954,7 +954,7 @@ module "content-store_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/_healthcheck"
+  target_group_health_check_path = "/_healthcheck_content-store"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_external_elb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]


### PR DESCRIPTION
https://trello.com/c/EADdQIOp/277-investigate-improving-healthchecks-for-content-store-and-other-lbs

This makes a couple of changes to the LB and Target Group
config, in response to an incident on Staging. Making these
changes brings the config for Content Store on a par with
most other apps. Please see the commits for more details.