### PR TITLE
Allow grafana to make requests to prometheus

### DIFF
--- a/terraform/projects/infra-security-groups/prometheus.tf
+++ b/terraform/projects/infra-security-groups/prometheus.tf
@@ -58,6 +58,19 @@ resource "aws_security_group_rule" "prometheus-elb_ingress_officeips_https" {
   cidr_blocks = ["${var.office_ips}"]
 }
 
+resource "aws_security_group_rule" "prometheus-elb_ingress_grafana_https" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.prometheus_external_elb.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.graphite.id}" # Note: Grafana runs on the graphite VM
+}
+
 resource "aws_security_group_rule" "prometheus-elb_egress_prometheus_http" {
   type      = "egress"
   from_port = 80


### PR DESCRIPTION
Currently our grafana is configured with a prometheus data source that
expects to talk to prometheus on:

https://prometheus.production.govuk-internal.digital

but there's no DNS entry for `prometheus.production.govuk-internal.digital`,
so I don't think that can ever have worked.

If we wanted it to work, we'd need to create an internal load balancer
for prometheus, and then publish its address in route53.

That would be consistent, but it seems like a pain to me - do we really
want to run a separate load balancer just for this traffic?

Instead I suggest we let Grafana reach prometheus on the public URL
instead:

https://prometheus.production.govuk.digital

(note `govuk.digital`, not `govuk-internal.digital`)

It can't do this at the moment because prometheus's external load
balancer only allows requests from office IPs, and Grafana doesn't have
an office IP.

Adding this security group rule will allow requests from Grafana (which
is on the graphite VM) to Prometheus.

I've tested this on integration by applying terraform from this branch, and snowflaking in a datasource and a dashboard:

https://grafana.blue.integration.govuk.digital/dashboard/db/router-prometheus-metrics?orgId=1

![image](https://user-images.githubusercontent.com/1696784/103676919-94bd4080-4f79-11eb-933a-d28e0855b81a.png)
