### PR TITLE
Update Ask Export IAM policy

### DIFF
--- a/terraform/policies/ask_export_s3_writer_policy.tpl
+++ b/terraform/policies/ask_export_s3_writer_policy.tpl
@@ -14,7 +14,11 @@
         {
             "Effect": "Allow",
             "Action": [
-                "s3:PutObject"
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+                "s3:PutObjectVersionAcl",
+                "s3:GetObjectAcl",
+                "s3:GetObjectVersionAcl"
             ],
             "Resource": [
                 "arn:aws:s3:::${bucket}/*"


### PR DESCRIPTION
This adds permissions to manage object ACLs because permission needs to be given to the cross account bucket owner to access the objects.