### PR TITLE
Add lifecycle rules within govuk-data-infrastructure-integration bucket

### DIFF
--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -64,6 +64,39 @@ resource "aws_s3_bucket" "data_infrastructure_bucket" {
     aws_environment = "${var.aws_environment}"
     Name            = "${local.data_infrastructure_bucket_name}"
   }
+
+  lifecycle_rule {
+    id      = "functional-network-lifecycle-rule"
+    enabled = true
+    prefix  = "functional-network/"
+
+    expiration {
+      days                         = 30
+      expired_object_delete_marker = true
+    }
+  }
+
+  lifecycle_rule {
+    id      = "knowledge-graph-lifecycle-rule"
+    enabled = true
+    prefix  = "knowledge-graph/"
+
+    expiration {
+      days                         = 30
+      expired_object_delete_marker = true
+    }
+  }
+
+  lifecycle_rule {
+    id      = "structural-network-lifecycle-rule"
+    enabled = true
+    prefix  = "structural-network/"
+
+    expiration {
+      days                         = 30
+      expired_object_delete_marker = true
+    }
+  }
 }
 
 data "aws_ami" "neo4j_community_ami" {


### PR DESCRIPTION
This PR adds lifecycle rules within the `govuk-data-infrastructure-integration` bucket to keep only the last 30 days of data. This is necessary as we currently hold more data which is never used, so by only keeping the most recent month's worth of data we can reduce costs and remove noise.