### PR TITLE
Add logging for queries which are waiting on locks to be relased

### DIFF
--- a/terraform/projects/app-content-data-api-postgresql/main.tf
+++ b/terraform/projects/app-content-data-api-postgresql/main.tf
@@ -127,6 +127,11 @@ resource "aws_db_parameter_group" "content_data_api" {
   }
 
   parameter {
+    name  = "deadlock_timeout"
+    value = 2500
+  }
+
+  parameter {
     name  = "log_lock_waits"
     value = true
   }

--- a/terraform/projects/app-content-data-api-postgresql/main.tf
+++ b/terraform/projects/app-content-data-api-postgresql/main.tf
@@ -126,6 +126,11 @@ resource "aws_db_parameter_group" "content_data_api" {
     value = "all"
   }
 
+  parameter {
+    name  = "log_lock_waits"
+    value = true
+  }
+
   tags {
     aws_stackname = "${var.stackname}"
   }

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -116,6 +116,11 @@ resource "aws_db_parameter_group" "postgresql_pg" {
     name  = "log_statement"
     value = "all"
   }
+
+  parameter {
+    name  = "log_lock_waits"
+    value = true
+  }
 }
 
 module "postgresql-primary_rds_instance" {

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -118,6 +118,11 @@ resource "aws_db_parameter_group" "postgresql_pg" {
   }
 
   parameter {
+    name  = "deadlock_timeout"
+    value = 2500
+  }
+
+  parameter {
     name  = "log_lock_waits"
     value = true
   }

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -99,6 +99,11 @@ resource "aws_db_parameter_group" "app_transition_pg" {
   }
 
   parameter {
+    name  = "deadlock_timeout"
+    value = 2500
+  }
+
+  parameter {
     name  = "log_lock_waits"
     value = true
   }

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -97,6 +97,11 @@ resource "aws_db_parameter_group" "app_transition_pg" {
     name  = "log_statement"
     value = "all"
   }
+
+  parameter {
+    name  = "log_lock_waits"
+    value = true
+  }
 }
 
 module "transition-postgresql-primary_rds_instance" {


### PR DESCRIPTION
See individual commits for more thorough details of each change.

This change is designed to help us debug issues with slow queries. Specifically, it came out of some work I've been doing to investigate timeouts in the Email Alert API.

These changes are mostly useful for Email Alert API, but I've decided to apply them across all our databases for consistency.

[Trello Card](https://trello.com/c/AHKVvZb2/2290-investigate-500-errors-in-email-alert-frontend)