### PR TITLE
Revert "Improve health detection for Content Store"

### DIFF
--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -131,7 +131,7 @@ resource "aws_elb" "content-store_external_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:80/_healthcheck_content-store"
+    target              = "TCP:80"
     interval            = 30
   }
 
@@ -182,7 +182,7 @@ resource "aws_elb" "content-store_internal_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:80/_healthcheck_content-store"
+    target              = "TCP:80"
     interval            = 30
   }
 

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -131,7 +131,7 @@ resource "aws_elb" "draft-content-store_external_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:80/_healthcheck_draft-content-store"
+    target              = "TCP:80"
     interval            = 30
   }
 
@@ -182,7 +182,7 @@ resource "aws_elb" "draft-content-store_internal_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:80/_healthcheck_draft-content-store"
+    target              = "TCP:80"
     interval            = 30
   }
 

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -954,7 +954,7 @@ module "content-store_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/_healthcheck_content-store"
+  target_group_health_check_path = "/_healthcheck"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_external_elb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]


### PR DESCRIPTION
Reverts alphagov/govuk-aws#1396

Referring to [this commit](https://github.com/alphagov/govuk-aws/pull/1396/commits/3f9393135177020393d79a993d053352b37d45f1), unfortunately this doesn't work because our Staging and Production environments don't have a "aws_migration" flag set, which means the "lb_healthchecks" file doesn't exist, which means we don't expose the app-specific healthcheck routes used in this PR.

We'll need to investigate exposing those routes in Puppet, first.