### PR TITLE
Upgrade CI Jenkins EBS volume from gp2 to gp3.

### DIFF
--- a/terraform/projects/app-ci-master/main.tf
+++ b/terraform/projects/app-ci-master/main.tf
@@ -263,7 +263,7 @@ resource "aws_ebs_volume" "ci-master" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.deploy_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = 40
-  type              = "gp2"
+  type              = "gp3"
 
   tags {
     Name            = "${var.stackname}-ci"


### PR DESCRIPTION
CI Jenkins was regularly running out of IOPS quota ("burst balance") on its persistent data volume and this was impairing its performance.

As of Dec 2020, gp3 is the current generation general purpose EBS product and it comes with approximately 30 times the IOPS quota for (slightly less than) the same money. So it's a no-brainer.

The actual change has already been made (via `aws ec2 modify-volume --volume-id ... --volume-type gp3`). This commit just brings Terraform back into sync. I verified that there's no diff (and that there was the expected diff before).

This only exists in the integration environment, which is why I haven't parameterised the value.