### PR TITLE
Add lifecycle rule for lambdas prefix in data bucket

### DIFF
--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -97,6 +97,16 @@ resource "aws_s3_bucket" "data_infrastructure_bucket" {
       expired_object_delete_marker = true
     }
   }
+
+  lifecycle_rule {
+    id      = "lambdas-lifecycle-rule"
+    enabled = true
+    prefix  = "lambdas/"
+
+    noncurrent_version_expiration {
+      days = 30
+    }
+  }
 }
 
 data "aws_ami" "neo4j_community_ami" {


### PR DESCRIPTION
This PR adds a lifecycle rule for the `lambdas` prefix of the `govuk-data-infrastructure-integration` bucket in the integration account. The lifecycle rule will delete all previous versions of files under this prefix 30 days after they are made non-current versions, which will happen as new versions of Lamda deployment packages are uploaded.