### PR TITLE
Increase content store instance size

### DIFF
--- a/terraform/projects/app-content-store/README.md
+++ b/terraform/projects/app-content-store/README.md
@@ -30,7 +30,7 @@ content-store node
 | external\_domain\_name | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | external\_zone\_name | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | instance\_ami\_filter\_name | Name to use to find AMI images | `string` | `""` | no |
-| instance\_type | Instance type used for EC2 resources | `string` | `"m5.large"` | no |
+| instance\_type | Instance type used for EC2 resources | `string` | `"m5.2xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |

--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -69,7 +69,7 @@ variable "create_external_elb" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for EC2 resources"
-  default     = "m5.large"
+  default     = "m5.2xlarge"
 }
 
 # Resources


### PR DESCRIPTION
This changes the default instance size from m5.large to m5.2xlarge. The content store application currently runs with 15 workers and a large volume of requests quickly leads to CPU exhaustion ( as m5.large only has 2 vCPUs). This can cause increase latency in response times as requests wait for CPU cycles. An m5.2xlarge has 8 vCPUs which in load testing has improved throughput and latency.