### PR TITLE
Update Mapit ELB health checks

### DIFF
--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -130,7 +130,7 @@ resource "aws_elb" "mapit_elb" {
     unhealthy_threshold = 2
     timeout             = 3
 
-    target   = "HTTP:80/postcode/W54XA"
+    target   = "HTTP:80/postcode/W54XA?nocache=true"
     interval = 30
   }
 

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1773,7 +1773,7 @@ module "mapit_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/postcode/W54XA"
+  target_group_health_check_path = "/postcode/W54XA?nocache=true"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_carrenza_alb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]


### PR DESCRIPTION
This adds a query string so the health checks bypass the Ngnix cache and monitor the application.