### PR TITLE
sync gcs later

### DIFF
--- a/terraform/projects/infra-google-mirror-bucket/main.tf
+++ b/terraform/projects/infra-google-mirror-bucket/main.tf
@@ -157,7 +157,7 @@ resource "google_storage_transfer_job" "s3-bucket-daily-sync" {
     }
 
     start_time_of_day {
-      hours   = 11
+      hours   = 18
       minutes = 00
       seconds = 0
       nanos   = 0


### PR DESCRIPTION
This PR syncs GCS mirror buckets from S3 mirror buckets later. The mirrorer machine is configured/dimensioned to finish mirroring before 08 00 in the morning. The S3 sync from the the mirrorer machine takes on average 8 hours.

Hence we should start no earlier than 16 00. We add some extra hours to take into account for undercertainty in the duration of the crawling and syncing and also increase in number of assets/web pages on GOV.UK.