### PR TITLE
Add a shared elasticache instance for Mapit

### DIFF
--- a/terraform/projects/app-mapit/README.md
+++ b/terraform/projects/app-mapit/README.md
@@ -31,6 +31,8 @@ Mapit node
 |------|
 | [aws_acm_certificate](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/acm_certificate) |
 | [aws_ebs_volume](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/ebs_volume) |
+| [aws_elasticache_cluster](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/elasticache_cluster) |
+| [aws_elasticache_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/elasticache_subnet_group) |
 | [aws_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/elb) |
 | [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_policy) |
 | [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) |
@@ -57,6 +59,7 @@ Mapit node
 | mapit\_subnet\_a | Name of the subnet to place the first third of mapit instances and EBS volumes | `string` | n/a | yes |
 | mapit\_subnet\_b | Name of the subnet to place the second third of mapit instances and EBS volumes | `string` | n/a | yes |
 | mapit\_subnet\_c | Name of the subnet to place the last third of mapit instances and EBS volumes | `string` | n/a | yes |
+| memcached\_instance\_type | Instance type used for the shared Elasticache Memcached instances | `string` | `"cache.m6g.large"` | no |
 | remote\_state\_bucket | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | remote\_state\_infra\_monitoring\_key\_stack | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | remote\_state\_infra\_networking\_key\_stack | Override infra\_networking remote state path | `string` | `""` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1816,6 +1816,14 @@ resource "aws_autoscaling_attachment" "mapit-2_asg_attachment_alb" {
   alb_target_group_arn   = "${element(module.mapit_public_lb.target_group_arns, 0)}"
 }
 
+resource "aws_route53_record" "mapit_cache_name" {
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "mapit-memcached.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["mapit-memcached.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
 resource "aws_route53_record" "mapit_internal_service_names" {
   count   = "${length(var.mapit_internal_service_names)}"
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -150,6 +150,7 @@ No Modules.
 | sg\_licensify-frontend\_internal\_lb\_id | n/a |
 | sg\_licensify\_documentdb\_id | n/a |
 | sg\_management\_id | n/a |
+| sg\_mapit\_cache\_id | n/a |
 | sg\_mapit\_carrenza\_alb\_id | n/a |
 | sg\_mapit\_elb\_id | n/a |
 | sg\_mapit\_id | n/a |

--- a/terraform/projects/infra-security-groups/mapit.tf
+++ b/terraform/projects/infra-security-groups/mapit.tf
@@ -20,6 +20,29 @@ resource "aws_security_group" "mapit" {
   }
 }
 
+resource "aws_security_group" "mapit_cache" {
+  name        = "${var.stackname}_mapit_cache_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access to the mapit cache from mapit"
+
+  tags {
+    Name = "${var.stackname}_mapit_cache_access"
+  }
+}
+
+resource "aws_security_group_rule" "mapit_ingress_mapit_cache_memcached" {
+  type      = "ingress"
+  from_port = 11211
+  to_port   = 11211
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.mapit_cache.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.mapit.id}"
+}
+
 resource "aws_security_group_rule" "mapit_ingress_mapit-elb_http" {
   type      = "ingress"
   from_port = 80

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -346,6 +346,10 @@ output "sg_mapit_id" {
   value = "${aws_security_group.mapit.id}"
 }
 
+output "sg_mapit_cache_id" {
+  value = "${aws_security_group.mapit_cache.id}"
+}
+
 output "sg_mapit_carrenza_alb_id" {
   value = "${aws_security_group.mapit_carrenza_alb.id}"
 }


### PR DESCRIPTION
Mapit currently runs memcached per instance of mapit. This decreases our caching ability if we have instance number >= 2. Introducing a shared cache will allow us to scale Mapit if we need to handle load without impacting of cache. It also allows us to pre-warm our cache more easily, as we don't have to pre-warm every instance of Mapit.