### PR TITLE
Scale up Mapit instance size and number

### DIFF
--- a/terraform/projects/app-mapit/README.md
+++ b/terraform/projects/app-mapit/README.md
@@ -52,7 +52,7 @@ Mapit node
 | ebs\_encrypted | Whether or not the EBS volume is encrypted | `string` | n/a | yes |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | instance\_ami\_filter\_name | Name to use to find AMI images | `string` | `""` | no |
-| instance\_type | Instance type used for EC2 resources | `string` | `"t2.medium"` | no |
+| instance\_type | Instance type used for EC2 resources | `string` | `"t3.2xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | lc\_create\_ebs\_volume | Creates a launch configuration which will add an additional ebs volume to the instance if this value is set to 1 | `string` | n/a | yes |

--- a/terraform/projects/app-mapit/README.md
+++ b/terraform/projects/app-mapit/README.md
@@ -24,6 +24,8 @@ Mapit node
 | alarms-elb-mapit-internal | ../../modules/aws/alarms/elb |  |
 | mapit-1 | ../../modules/aws/node_group |  |
 | mapit-2 | ../../modules/aws/node_group |  |
+| mapit-3 | ../../modules/aws/node_group |  |
+| mapit-4 | ../../modules/aws/node_group |  |
 
 ## Resources
 

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -260,6 +260,78 @@ resource "aws_ebs_volume" "mapit-2" {
   }
 }
 
+module "mapit-3" {
+  lc_create_ebs_volume          = "${var.lc_create_ebs_volume}"
+  source                        = "../../modules/aws/node_group"
+  name                          = "${var.stackname}-mapit-3"
+  default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-3")}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_b))}"
+  instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
+  instance_type                 = "${var.instance_type}"
+  instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
+  instance_elb_ids_length       = "1"
+  instance_elb_ids              = ["${aws_elb.mapit_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "20"
+  ebs_device_volume_size        = "${var.ebs_device_volume_size}"
+  ebs_encrypted                 = "${var.ebs_encrypted}"
+  ebs_device_name               = "${var.ebs_device_name}"
+}
+
+resource "aws_ebs_volume" "mapit-3" {
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_c)}"
+  encrypted         = "${var.ebs_encrypted}"
+  size              = 20
+  type              = "gp2"
+
+  tags {
+    Name            = "${var.stackname}-mapit"
+    Project         = "${var.stackname}"
+    Device          = "xvdf"
+    aws_hostname    = "mapit-3"
+    aws_migration   = "mapit"
+    aws_stackname   = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
+module "mapit-4" {
+  lc_create_ebs_volume          = "${var.lc_create_ebs_volume}"
+  source                        = "../../modules/aws/node_group"
+  name                          = "${var.stackname}-mapit-4"
+  default_tags                  = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "mapit", "aws_hostname", "mapit-4")}"
+  instance_subnet_ids           = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.mapit_subnet_b))}"
+  instance_security_group_ids   = ["${data.terraform_remote_state.infra_security_groups.sg_mapit_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
+  instance_type                 = "${var.instance_type}"
+  instance_additional_user_data = "${join("\n", null_resource.user_data.*.triggers.snippet)}"
+  instance_elb_ids_length       = "1"
+  instance_elb_ids              = ["${aws_elb.mapit_elb.id}"]
+  instance_ami_filter_name      = "${var.instance_ami_filter_name}"
+  asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
+  root_block_device_volume_size = "20"
+  ebs_device_volume_size        = "${var.ebs_device_volume_size}"
+  ebs_encrypted                 = "${var.ebs_encrypted}"
+  ebs_device_name               = "${var.ebs_device_name}"
+}
+
+resource "aws_ebs_volume" "mapit-4" {
+  availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mapit_subnet_a)}"
+  encrypted         = "${var.ebs_encrypted}"
+  size              = 20
+  type              = "gp2"
+
+  tags {
+    Name            = "${var.stackname}-mapit"
+    Project         = "${var.stackname}"
+    Device          = "xvdf"
+    aws_hostname    = "mapit-4"
+    aws_migration   = "mapit"
+    aws_stackname   = "${var.stackname}"
+    aws_environment = "${var.aws_environment}"
+  }
+}
+
 resource "aws_iam_policy" "mapit_iam_policy" {
   name   = "${var.stackname}-mapit-additional"
   path   = "/"
@@ -273,6 +345,16 @@ resource "aws_iam_role_policy_attachment" "mapit_1_iam_role_policy_attachment" {
 
 resource "aws_iam_role_policy_attachment" "mapit_2_iam_role_policy_attachment" {
   role       = "${module.mapit-2.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.mapit_iam_policy.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "mapit_3_iam_role_policy_attachment" {
+  role       = "${module.mapit-3.instance_iam_role_name}"
+  policy_arn = "${aws_iam_policy.mapit_iam_policy.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "mapit_4_iam_role_policy_attachment" {
+  role       = "${module.mapit-4.instance_iam_role_name}"
   policy_arn = "${aws_iam_policy.mapit_iam_policy.arn}"
 }
 

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -53,7 +53,7 @@ variable "elb_internal_certname" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for EC2 resources"
-  default     = "t2.medium"
+  default     = "t3.2xlarge"
 }
 
 variable "memcached_instance_type" {


### PR DESCRIPTION
Mapit currently runs with 12 workers and Postgres on each instance. CPU exhaustion can been seen when handling a high number of uncached requests. Increasing the instance size from 2vCPUs to 8vCPUs should improve the number of uncached requests handled.

To this we need to scale up the number of instances from 2 to 4, so we have can rotate the old instances without downtime.