### PR TITLE
Scaling up Mapit instance size to c5.2xlarge

### DIFF
--- a/terraform/projects/app-mapit/README.md
+++ b/terraform/projects/app-mapit/README.md
@@ -54,7 +54,7 @@ Mapit node
 | ebs\_encrypted | Whether or not the EBS volume is encrypted | `string` | n/a | yes |
 | elb\_internal\_certname | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | instance\_ami\_filter\_name | Name to use to find AMI images | `string` | `""` | no |
-| instance\_type | Instance type used for EC2 resources | `string` | `"t3.2xlarge"` | no |
+| instance\_type | Instance type used for EC2 resources | `string` | `"c5.2xlarge"` | no |
 | internal\_domain\_name | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | internal\_zone\_name | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | lc\_create\_ebs\_volume | Creates a launch configuration which will add an additional ebs volume to the instance if this value is set to 1 | `string` | n/a | yes |

--- a/terraform/projects/app-mapit/main.tf
+++ b/terraform/projects/app-mapit/main.tf
@@ -53,7 +53,7 @@ variable "elb_internal_certname" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for EC2 resources"
-  default     = "t3.2xlarge"
+  default     = "c5.2xlarge"
 }
 
 variable "memcached_instance_type" {


### PR DESCRIPTION
Upgrading the instance size from a burstable t3.xlarge to more reliable non-burstable c5.2xlarge instance type.