### PR TITLE
Change time of data-science-data_schedule-spin-up

### DIFF
--- a/terraform/projects/app-data-science-data/main.tf
+++ b/terraform/projects/app-data-science-data/main.tf
@@ -191,7 +191,7 @@ resource "aws_autoscaling_group" "data-science-data_asg" {
 resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-up" {
   autoscaling_group_name = "${aws_autoscaling_group.data-science-data_asg.name}"
   scheduled_action_name  = "data-science-data_schedule-spin-up"
-  recurrence             = "30 8 * * MON-SUN"
+  recurrence             = "00 7 * * MON-SUN"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 1
@@ -200,7 +200,7 @@ resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-up" {
 resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-down" {
   autoscaling_group_name = "${aws_autoscaling_group.data-science-data_asg.name}"
   scheduled_action_name  = "data-science-data_schedule-spin-down"
-  recurrence             = "29 10 * * MON-SUN"
+  recurrence             = "29 09 * * MON-SUN"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 0

--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -38,13 +38,13 @@ Infrastructure security settings:
 
 | Name |
 |------|
-| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/3.25.0/docs/data-sources/caller_identity) |
-| [aws_iam_account_password_policy](https://registry.terraform.io/providers/hashicorp/aws/3.25.0/docs/resources/iam_account_password_policy) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.25.0/docs/resources/iam_policy) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.25.0/docs/data-sources/iam_policy_document) |
-| [aws_key_pair](https://registry.terraform.io/providers/hashicorp/aws/3.25.0/docs/resources/key_pair) |
-| [aws_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/3.25.0/docs/resources/kms_alias) |
-| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/3.25.0/docs/resources/kms_key) |
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
+| [aws_iam_account_password_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_key_pair](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) |
+| [aws_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) |
+| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) |
 
 ## Inputs
 

--- a/terraform/projects/infra-stack-dns-zones/README.md
+++ b/terraform/projects/infra-stack-dns-zones/README.md
@@ -37,8 +37,8 @@ No Modules.
 | Name |
 |------|
 | [aws_route53_record](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) |
-| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_zone) |
 | [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/route53_zone) |
+| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_zone) |
 | [terraform_remote_state](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) |
 
 ## Inputs


### PR DESCRIPTION
The data generation process now takes longer
and the data wasn't ready in time for
knowledge-graph machines.
This fixes that by starting the data generation
process earlier

Trello: https://trello.com/c/6TnYiqdo/837-productionalise-external-link-extraction