### PR TITLE
Add account_internal_service_cnames

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -77,6 +77,7 @@ This project adds global resources for app components:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| account\_internal\_service\_cnames | n/a | `list` | `[]` | no |
 | account\_internal\_service\_names | n/a | `list` | `[]` | no |
 | app\_stackname | Stackname of the app projects in this environment | `string` | `"blue"` | no |
 | apt\_internal\_service\_names | n/a | `list` | `[]` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -54,6 +54,11 @@ variable "account_internal_service_names" {
   default = []
 }
 
+variable "account_internal_service_cnames" {
+  type    = "list"
+  default = []
+}
+
 variable "apt_public_service_names" {
   type    = "list"
   default = []
@@ -513,6 +518,15 @@ resource "aws_route53_record" "account_internal_service_names" {
   name    = "${element(var.account_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
   type    = "CNAME"
   records = ["${element(var.account_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+resource "aws_route53_record" "account_internal_service_cnames" {
+  count   = "${length(var.account_internal_service_cnames)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.account_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.account_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
   ttl     = "300"
 }
 


### PR DESCRIPTION
The account machine class is accessible as "account", but it'll also
be running the "account-api" application, which Plek will expect to
find at "account-api.{domain}":

```
irb(main):001:0> Plek.find("account-api")
=> "https://account-api.integration.govuk-internal.digital"
```

---

[Plan](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/924/console)