### PR TITLE
Use app healthcheck for account ELB healthcheck

### DIFF
--- a/terraform/projects/app-account/main.tf
+++ b/terraform/projects/app-account/main.tf
@@ -95,6 +95,14 @@ resource "aws_elb" "account_elb_internal" {
     ssl_certificate_id = "${data.aws_acm_certificate.elb_internal_cert.arn}"
   }
 
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    target              = "HTTP:80/_healthcheck_account-api"
+    interval            = 30
+  }
+
   cross_zone_load_balancing   = true
   idle_timeout                = 400
   connection_draining         = true


### PR DESCRIPTION
This ensures that the app is up and running, not just that the
instance is.

```
michaelswalker@ec2-integration-blue-account-ip-10-1-4-18:~$ curl localhost/_healthcheck_account-api
{"status":"ok","checks":{"database_connectivity":{"status":"ok"}}}
```

---

[Plan](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/931/console)