### PR TITLE
Add Sidekiq Monitoring load balancer

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -43,6 +43,7 @@ This project adds global resources for app components:
 | prometheus_public_lb | ../../modules/aws/lb |  |
 | search_api_public_lb | ../../modules/aws/lb |  |
 | search_api_public_lb_rules | ../../modules/aws/lb_listener_rules |  |
+| sidekiq_monitoring_public_lb | ../../modules/aws/lb |  |
 | static_public_lb | ../../modules/aws/lb |  |
 | support_api_public_lb | ../../modules/aws/lb |  |
 | whitehall_backend_public_lb | ../../modules/aws/lb |  |
@@ -168,6 +169,7 @@ This project adds global resources for app components:
 | search\_api\_public\_service\_names | n/a | `list` | `[]` | no |
 | search\_internal\_service\_cnames | n/a | `list` | `[]` | no |
 | search\_internal\_service\_names | n/a | `list` | `[]` | no |
+| sidekiq\_monitoring\_public\_service\_names | n/a | `list` | `[]` | no |
 | stackname | Stackname | `string` | n/a | yes |
 | static\_public\_service\_names | n/a | `list` | `[]` | no |
 | support\_api\_public\_service\_names | n/a | `list` | `[]` | no |

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -184,6 +184,7 @@ No Modules.
 | sg\_search\_elb\_id | n/a |
 | sg\_search\_id | n/a |
 | sg\_shared\_documentdb\_id | n/a |
+| sg\_sidekiq-monitoring\_external\_elb\_id | n/a |
 | sg\_static\_carrenza\_alb\_id | n/a |
 | sg\_support-api\_external\_elb\_id | n/a |
 | sg\_transition-db-admin\_elb\_id | n/a |

--- a/terraform/projects/infra-security-groups/backend.tf
+++ b/terraform/projects/infra-security-groups/backend.tf
@@ -61,6 +61,19 @@ resource "aws_security_group_rule" "support-api_ingress_elb_external_http" {
   source_security_group_id = "${aws_security_group.support-api_external_elb.id}"
 }
 
+resource "aws_security_group_rule" "sidekiq-monitoring_ingress_elb_external_http" {
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.backend.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.sidekiq-monitoring_external_elb.id}"
+}
+
 resource "aws_security_group" "backend_elb_internal" {
   name        = "${var.stackname}_backend_elb_internal_access"
   vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -510,6 +510,10 @@ output "sg_support-api_external_elb_id" {
   value = "${aws_security_group.support-api_external_elb.id}"
 }
 
+output "sg_sidekiq-monitoring_external_elb_id" {
+  value = "${aws_security_group.sidekiq-monitoring_external_elb.id}"
+}
+
 output "sg_related-links_id" {
   value = "${aws_security_group.related-links.id}"
 }

--- a/terraform/projects/infra-security-groups/sidekiq-monitoring.tf
+++ b/terraform/projects/infra-security-groups/sidekiq-monitoring.tf
@@ -1,0 +1,39 @@
+# == Manifest: Project: Security Groups: sidekiq-monitoring
+#
+# The sidekiq-monitoring needs to be accessible on ports:
+#   - 443 from the other VMs
+
+# === Variables:
+# stackname - string
+#
+# === Outputs:
+# sg_sidekiq-monitoring_elb_id
+
+resource "aws_security_group" "sidekiq-monitoring_external_elb" {
+  name        = "${var.stackname}_sidekiq-monitoring_external_elb_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Access the sidekiq-monitoring external ELB"
+
+  tags {
+    Name = "${var.stackname}_sidekiq-monitoring_external_elb_access"
+  }
+}
+
+resource "aws_security_group_rule" "sidekiq-monitoring_ingress_external-elb_https" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id = "${aws_security_group.sidekiq-monitoring_external_elb.id}"
+  cidr_blocks       = ["${var.office_ips}"]
+}
+
+resource "aws_security_group_rule" "sidekiq-monitoring_egress_external_elb_any_any" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.sidekiq-monitoring_external_elb.id}"
+}


### PR DESCRIPTION
Adds an application load balancer for the our Sidekiq Monitoring app.
Sidekiq monitoring resides on the backend instances, but we only want to
be able to access it externally via the VPN (office_ips).

Taken inspiration from: https://github.com/alphagov/govuk-aws/commit/6e60f91a27d40c886f39409e2a15887ff09dfeb7.

Trello:
https://trello.com/c/m8O8dC41/2414-add-dns-for-sidekiq-monitoring
