### PR TITLE
Switch RDS log exporter lambda to Python 3.8 + cleanup.

### DIFF
--- a/terraform/lambda/RDSLogsToS3/Makefile
+++ b/terraform/lambda/RDSLogsToS3/Makefile
@@ -1,0 +1,12 @@
+testenv : virtualenv localstack
+
+virtualenv:
+	python3 -m venv env
+	source env/bin/activate && python3 -m pip install -r requirements.txt
+
+localstack:
+	brew install localstack
+	localstack start
+
+test:
+	source env/bin/activate && python3 -m unittest main_test.py

--- a/terraform/lambda/RDSLogsToS3/README.md
+++ b/terraform/lambda/RDSLogsToS3/README.md
@@ -3,28 +3,26 @@
 This Lambda function retrieves RDS logs and stores them in the S3 logging bucket. It's
 based on https://github.com/vcardillo/rdslogs_to_s3
 
-It is triggered by an scheduled event.
+It is triggered by a CloudWatch scheduled event.
 
-### Requirements
+### Testing locally
 
-Install [AWS sam-local](https://github.com/awslabs/aws-sam-local)
+1. Install [AWS sam-local](https://github.com/awslabs/aws-sam-local):
 
-### Tests
+    - `brew tap aws/tap`
+    - `brew install aws-sam-cli`
+    - Install Docker if you don't already have it.
 
-Generate event JSON:
+2. Generate event JSON:
 
-```
-sam local generate-event schedule --region eu-west-1 > event.json
-```
+        sam local generate-event cloudwatch scheduled-event --region eu-west-1 > event.json
 
-Configure the following environment variables in `template.yaml`:
- - RDS_INSTANCE_NAME: RDS test instance name
- - S3_BUCKET_NAME: logging bucket name
- - S3_BUCKET_PREFIX: rds/<rds_instance_name>/
+3. Configure the following environment variables in `template.yaml`:
 
-Test the Lambda function:
+    - RDS_INSTANCE_NAME: RDS test instance name (e.g. `blue-transition-postgresql-standby`)
+    - S3_BUCKET_NAME: logging bucket name (e.g. `govuk-integration-aws-logging`)
+    - S3_BUCKET_PREFIX: rds/<rds_instance_name>/
 
-```
-sam local invoke RDSLogsToS3 -e event.json
-```
+4. Test the Lambda function:
 
+        sam local invoke RDSLogsToS3 -e event.json

--- a/terraform/lambda/RDSLogsToS3/README.md
+++ b/terraform/lambda/RDSLogsToS3/README.md
@@ -5,7 +5,7 @@ based on https://github.com/vcardillo/rdslogs_to_s3
 
 It is triggered by a CloudWatch scheduled event.
 
-### Testing locally
+### Running locally
 
 1. Install [AWS sam-local](https://github.com/awslabs/aws-sam-local):
 
@@ -26,3 +26,9 @@ It is triggered by a CloudWatch scheduled event.
 4. Test the Lambda function:
 
         sam local invoke RDSLogsToS3 -e event.json
+
+### Running tests
+
+There are a couple of automated tests. These use [LocalStack](https://github.com/localstack/localstack).
+
+Run `make testenv` to install the prerequisites, then `make test` to run the tests. (The makefile probably only works smoothly on macOS at the time of writing).

--- a/terraform/lambda/RDSLogsToS3/main.py
+++ b/terraform/lambda/RDSLogsToS3/main.py
@@ -1,3 +1,12 @@
+"""Lambda to copy log files from RDS to S3.
+
+The copy is incremental, based on recording the timestamp of the latest log
+copied at the end of each run (stored as an integer in
+s3://$S3_BUCKET_NAME/$LOG_NAME_PREFIX/$LAST_RECEIVED_FILE).
+
+Loosely based on https://github.com/vcardillo/rdslogs_to_s3
+"""
+
 import boto3
 import botocore
 import io

--- a/terraform/lambda/RDSLogsToS3/main.py
+++ b/terraform/lambda/RDSLogsToS3/main.py
@@ -1,8 +1,6 @@
 import boto3
 import botocore
-import json
 import os
-from StringIO import StringIO
 
 
 def lambda_handler(event, context):

--- a/terraform/lambda/RDSLogsToS3/main.py
+++ b/terraform/lambda/RDSLogsToS3/main.py
@@ -4,89 +4,132 @@ import json
 import os
 from StringIO import StringIO
 
+
 def lambda_handler(event, context):
 
-  RDSInstanceName = os.environ['RDS_INSTANCE_NAME']
-  S3BucketName = os.environ['S3_BUCKET_NAME']
-  S3BucketPrefix = os.environ['S3_BUCKET_PREFIX']
-  logNamePrefix = os.environ['LOG_NAME_PREFIX']
-  lastReceivedFile = S3BucketPrefix + os.environ['LAST_RECEIVED_FILE']
-  region = event['region']
+    RDSInstanceName = os.environ["RDS_INSTANCE_NAME"]
+    S3BucketName = os.environ["S3_BUCKET_NAME"]
+    S3BucketPrefix = os.environ["S3_BUCKET_PREFIX"]
+    logNamePrefix = os.environ["LOG_NAME_PREFIX"]
+    lastReceivedFile = S3BucketPrefix + os.environ["LAST_RECEIVED_FILE"]
+    region = event["region"]
 
-  S3client = boto3.client('s3',region_name=region)
-  RDSclient = boto3.client('rds',region_name=region)
-  dbLogs = RDSclient.describe_db_log_files( DBInstanceIdentifier=RDSInstanceName, FilenameContains=logNamePrefix)
-  lastWrittenTime = 0
-  lastWrittenThisRun = None
-  firstRun = False
-  logFileData = ""
+    S3client = boto3.client("s3", region_name=region)
+    RDSclient = boto3.client("rds", region_name=region)
+    dbLogs = RDSclient.describe_db_log_files(
+        DBInstanceIdentifier=RDSInstanceName, FilenameContains=logNamePrefix
+    )
+    lastWrittenTime = 0
+    lastWrittenThisRun = None
+    firstRun = False
+    logFileData = ""
 
-  try:
-    S3client.head_bucket(Bucket=S3BucketName)
-  except botocore.exceptions.ClientError as e:
-    error_code = int(e.response['ResponseMetadata']['HTTPStatusCode'])
-    if error_code == 404:
-      raise Exception("Error: Bucket name provided not found")
-    else:
-      raise Exception("Error: Unable to access bucket name, error: " + e.response['Error']['Message'])
-
-  try:
-    lrfHandle = S3client.get_object(Bucket=S3BucketName, Key=lastReceivedFile)
-  except botocore.exceptions.ClientError as e:
-    error_code = int(e.response['ResponseMetadata']['HTTPStatusCode'])
-    if error_code == 404:
-      print("It appears this is the first log import, so all files will be retrieved from RDS.")
-      firstRun = True
-    else:
-      raise Exception("Error: Unable to access lastReceivedFile name, error: " + e.response['Error']['Message'])
-
-  if firstRun == False:
-    lastWrittenTime = int(lrfHandle['Body'].read())
-    if lastWrittenTime == 0 or lastWrittenTime == None:
-      raise Exception("Error: Existing lastWrittenTime is " + lastWrittenTime)
-    print("Found marker from last log download, retrieving log files with lastWritten time after %s" % str(lastWrittenTime))
-	
-  writes = 0;
-  hasRun = False;
-
-  for dbLog in dbLogs['DescribeDBLogFiles']:
-    if ( int(dbLog['LastWritten']) > lastWrittenTime ) or firstRun:
-      print("Downloading DB log file: %s found with LastWritten value of: %s " % (dbLog['LogFileName'], dbLog['LastWritten']))
-			
-      if int(dbLog['LastWritten']) > lastWrittenThisRun:
-        lastWrittenThisRun = int(dbLog['LastWritten'])
-
-      logFile = RDSclient.download_db_log_file_portion(DBInstanceIdentifier=RDSInstanceName, LogFileName=dbLog['LogFileName'], Marker='0')
-      logFileData = logFile['LogFileData']
-			
-      while logFile['AdditionalDataPending']:
-        logFile = RDSclient.download_db_log_file_portion(DBInstanceIdentifier=RDSInstanceName, LogFileName=dbLog['LogFileName'], Marker=logFile['Marker'])
-        logFileData += logFile['LogFileData']
-      byteData = str.encode(logFileData)
-			
-      try:
-        objectName = S3BucketPrefix + dbLog['LogFileName']
-        print("Attempting to write log file %s to S3 bucket %s" % (objectName, S3BucketName))
-        S3client.put_object(Bucket=S3BucketName, Key=objectName, Body=byteData)
-      except botocore.exceptions.ClientError as e:
-        raise Exception("Error writing log file to S3 bucket, S3 ClientError: " + e.response['Error']['Message'])
-			
-      hasRun = True;
-      writes+=1;
-      print("Successfully wrote log file %s to S3 bucket %s" % (objectName, S3BucketName))
-		
-  # Otherwise, leave it alone
-  if hasRun == True:	
     try:
-      S3client.put_object(Bucket=S3BucketName, Key=lastReceivedFile, Body=str.encode(str(lastWrittenThisRun)))
+        S3client.head_bucket(Bucket=S3BucketName)
     except botocore.exceptions.ClientError as e:
-      raise Exception("Error writing marker to S3 bucket, S3 ClientError: " + e.response['Error']['Message'])
-  else:
-    print("No new log files were written during this execution.")
+        error_code = int(e.response["ResponseMetadata"]["HTTPStatusCode"])
+        if error_code == 404:
+            raise Exception("Error: Bucket name provided not found")
+        else:
+            raise Exception(
+                "Error: Unable to access bucket name, error: "
+                + e.response["Error"]["Message"]
+            )
 
-  print("------------ Writing of files to S3 complete:")
-  print("Successfully wrote %s log files." % (writes))
-  print("Successfully wrote new Last Written Marker to %s in Bucket %s" % (lastReceivedFile, S3BucketName))
-	
-  return "Log file export complete."
+    try:
+        lrfHandle = S3client.get_object(Bucket=S3BucketName, Key=lastReceivedFile)
+    except botocore.exceptions.ClientError as e:
+        error_code = int(e.response["ResponseMetadata"]["HTTPStatusCode"])
+        if error_code == 404:
+            print(
+                "It appears this is the first log import, so all files will be retrieved from RDS."
+            )
+            firstRun = True
+        else:
+            raise Exception(
+                "Error: Unable to access lastReceivedFile name, error: "
+                + e.response["Error"]["Message"]
+            )
 
+    if firstRun == False:
+        lastWrittenTime = int(lrfHandle["Body"].read())
+        if lastWrittenTime == 0 or lastWrittenTime == None:
+            raise Exception("Error: Existing lastWrittenTime is " + lastWrittenTime)
+        print(
+            "Found marker from last log download, retrieving log files with lastWritten time after %s"
+            % str(lastWrittenTime)
+        )
+
+    writes = 0
+    hasRun = False
+
+    for dbLog in dbLogs["DescribeDBLogFiles"]:
+        if (int(dbLog["LastWritten"]) > lastWrittenTime) or firstRun:
+            print(
+                "Downloading DB log file: %s found with LastWritten value of: %s "
+                % (dbLog["LogFileName"], dbLog["LastWritten"])
+            )
+
+            if int(dbLog["LastWritten"]) > lastWrittenThisRun:
+                lastWrittenThisRun = int(dbLog["LastWritten"])
+
+            logFile = RDSclient.download_db_log_file_portion(
+                DBInstanceIdentifier=RDSInstanceName,
+                LogFileName=dbLog["LogFileName"],
+                Marker="0",
+            )
+            logFileData = logFile["LogFileData"]
+
+            while logFile["AdditionalDataPending"]:
+                logFile = RDSclient.download_db_log_file_portion(
+                    DBInstanceIdentifier=RDSInstanceName,
+                    LogFileName=dbLog["LogFileName"],
+                    Marker=logFile["Marker"],
+                )
+                logFileData += logFile["LogFileData"]
+            byteData = str.encode(logFileData)
+
+            try:
+                objectName = S3BucketPrefix + dbLog["LogFileName"]
+                print(
+                    "Attempting to write log file %s to S3 bucket %s"
+                    % (objectName, S3BucketName)
+                )
+                S3client.put_object(Bucket=S3BucketName, Key=objectName, Body=byteData)
+            except botocore.exceptions.ClientError as e:
+                raise Exception(
+                    "Error writing log file to S3 bucket, S3 ClientError: "
+                    + e.response["Error"]["Message"]
+                )
+
+            hasRun = True
+            writes += 1
+            print(
+                "Successfully wrote log file %s to S3 bucket %s"
+                % (objectName, S3BucketName)
+            )
+
+    # Otherwise, leave it alone
+    if hasRun == True:
+        try:
+            S3client.put_object(
+                Bucket=S3BucketName,
+                Key=lastReceivedFile,
+                Body=str.encode(str(lastWrittenThisRun)),
+            )
+        except botocore.exceptions.ClientError as e:
+            raise Exception(
+                "Error writing marker to S3 bucket, S3 ClientError: "
+                + e.response["Error"]["Message"]
+            )
+    else:
+        print("No new log files were written during this execution.")
+
+    print("------------ Writing of files to S3 complete:")
+    print("Successfully wrote %s log files." % (writes))
+    print(
+        "Successfully wrote new Last Written Marker to %s in Bucket %s"
+        % (lastReceivedFile, S3BucketName)
+    )
+
+    return "Log file export complete."

--- a/terraform/lambda/RDSLogsToS3/main.py
+++ b/terraform/lambda/RDSLogsToS3/main.py
@@ -17,7 +17,7 @@ def lambda_handler(event, context):
         DBInstanceIdentifier=RDSInstanceName, FilenameContains=logNamePrefix
     )
     lastWrittenTime = 0
-    lastWrittenThisRun = None
+    lastWrittenThisRun = 0
     firstRun = False
     logFileData = ""
 

--- a/terraform/lambda/RDSLogsToS3/main.py
+++ b/terraform/lambda/RDSLogsToS3/main.py
@@ -5,6 +5,23 @@ import os
 import posixpath
 
 
+def get_last_received_timestamp(s3_client, bucket_name, key):
+    """Read an integer from a file in S3 or return 0 if not found."""
+    print(f"Reading last received timestamp from s3://{bucket_name}/{key}")
+    try:
+        obj = s3_client.get_object(Bucket=bucket_name, Key=key)
+        timestamp = int(obj["Body"].read())
+        print(f"Retrieving log files with LastWritten time after {timestamp}")
+        return timestamp
+    except botocore.exceptions.ClientError as e:
+        error_code = int(e.response["ResponseMetadata"]["HTTPStatusCode"])
+        if error_code == 404:
+            print("No last received timestamp file found. All files will be retrieved from RDS.")
+            return 0
+        else:
+            raise Exception(f"Unable to access s3://{bucket_name}/{key}: {e}")
+
+
 def lambda_handler(event, context):
     rds_instance_name = os.environ["RDS_INSTANCE_NAME"]
     s3_bucket_name = os.environ["S3_BUCKET_NAME"]
@@ -22,28 +39,7 @@ def lambda_handler(event, context):
     time_copied_up_to_this_run = 0
     writes = 0
 
-    try:
-        s3_client.head_bucket(Bucket=s3_bucket_name)
-    except botocore.exceptions.ClientError as e:
-        raise Exception(f"Unable to access bucket {s3_bucket_name}: {e}")
-
-    try:
-        lrf = s3_client.get_object(Bucket=s3_bucket_name, Key=last_received_file)
-        time_copied_up_to = int(lrf["Body"].read())
-        print(
-            f"Found s3://{s3_bucket_name}/{last_received_file} from previous run; "
-            f"retrieving log files with LastWritten time after {time_copied_up_to}"
-        )
-    except botocore.exceptions.ClientError as e:
-        error_code = int(e.response["ResponseMetadata"]["HTTPStatusCode"])
-        if error_code == 404:
-            print(
-                f"{last_received_file} not found; seems this is the first run. "
-                "All files will be retrieved from RDS."
-            )
-            time_copied_up_to = 0
-        else:
-            raise Exception(f"Unable to access {last_received_file}: {e}")
+    time_copied_up_to = get_last_received_timestamp(s3_client, s3_bucket_name, last_received_file)
 
     for db_log in db_logs["DescribeDBLogFiles"]:
         if int(db_log["LastWritten"]) > time_copied_up_to:

--- a/terraform/lambda/RDSLogsToS3/main.py
+++ b/terraform/lambda/RDSLogsToS3/main.py
@@ -4,7 +4,6 @@ import os
 
 
 def lambda_handler(event, context):
-
     RDSInstanceName = os.environ["RDS_INSTANCE_NAME"]
     S3BucketName = os.environ["S3_BUCKET_NAME"]
     S3BucketPrefix = os.environ["S3_BUCKET_PREFIX"]
@@ -49,9 +48,9 @@ def lambda_handler(event, context):
                 + e.response["Error"]["Message"]
             )
 
-    if firstRun == False:
+    if not firstRun:
         lastWrittenTime = int(lrfHandle["Body"].read())
-        if lastWrittenTime == 0 or lastWrittenTime == None:
+        if lastWrittenTime == 0:
             raise Exception("Error: Existing lastWrittenTime is " + lastWrittenTime)
         print(
             "Found marker from last log download, retrieving log files with lastWritten time after %s"
@@ -108,7 +107,7 @@ def lambda_handler(event, context):
             )
 
     # Otherwise, leave it alone
-    if hasRun == True:
+    if hasRun:
         try:
             S3client.put_object(
                 Bucket=S3BucketName,

--- a/terraform/lambda/RDSLogsToS3/main_test.py
+++ b/terraform/lambda/RDSLogsToS3/main_test.py
@@ -1,0 +1,42 @@
+"""Tests for RDSLogsToS3 lambda.
+
+Run `make testenv` to bring up dependencies then `make test` to run tests.
+"""
+
+import os
+import unittest
+
+import boto3
+
+from main import get_last_received_timestamp
+
+LOCALSTACK_URL = "http://localhost:4566"
+BUCKET = "test-bucket"
+
+
+class TestGetLastReceivedTimestamp(unittest.TestCase):
+    def setUp(self):
+        os.environ["AWS_ACCESS_KEY_ID"] = "test"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "test"
+        self.s3_client = boto3.client("s3", endpoint_url=LOCALSTACK_URL)
+        self.s3 = boto3.resource("s3", endpoint_url=LOCALSTACK_URL)
+        self.s3.create_bucket(Bucket=BUCKET)
+
+    def test_reads_int_from_file(self):
+        expected = 123456789
+        self.s3.Object(BUCKET, "timestamp-file").put(Body=str(expected))
+        actual = get_last_received_timestamp(self.s3_client, BUCKET, "timestamp-file")
+        self.assertEqual(actual, expected)
+
+    def test_returns_zero_when_file_not_found(self):
+        actual = get_last_received_timestamp(self.s3_client, BUCKET, "timestamp-file")
+        self.assertEqual(actual, 0)
+
+    def tearDown(self):
+        b = self.s3.Bucket(BUCKET)
+        b.objects.all().delete()
+        b.delete()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/terraform/lambda/RDSLogsToS3/requirements.txt
+++ b/terraform/lambda/RDSLogsToS3/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+botocore

--- a/terraform/lambda/RDSLogsToS3/template.yaml
+++ b/terraform/lambda/RDSLogsToS3/template.yaml
@@ -7,12 +7,13 @@ Resources:
   RDSLogsToS3:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python2.7
+      Runtime: python3.8
+      Timeout: 60
       Handler: main.lambda_handler
       Environment:
         Variables:
-          RDS_INSTANCE_NAME:
-          S3_BUCKET_NAME:
-          S3_BUCKET_PREFIX:
+          RDS_INSTANCE_NAME: blue-transition-postgresql-standby
+          S3_BUCKET_NAME: govuk-integration-aws-logging
+          S3_BUCKET_PREFIX: rds/blue-transition-postgresql-standby/
           LAST_RECEIVED_FILE: last_received.log
           LOG_NAME_PREFIX: error/

--- a/terraform/modules/aws/rds_log_exporter/main.tf
+++ b/terraform/modules/aws/rds_log_exporter/main.tf
@@ -64,8 +64,8 @@ resource "aws_lambda_function" "lambda_rds_logs_to_s3" {
   function_name = "RDSLogsToS3-${var.rds_instance_id}"
   role          = "${var.lambda_role_arn}"
   handler       = "main.lambda_handler"
-  runtime       = "python2.7"
-  timeout       = "60"
+  runtime       = "python3.8"
+  timeout       = "300"
 
   environment {
     variables = {


### PR DESCRIPTION
* Make it work with Python 3.8.
* Increase the timeout so that in case it runs slowly for any reason, it'll be less likely to fail and never recover because after a failed run there would be an ever-increasing set of files to copy. (It only writes the timestamp file at the end of a successful run; it doesn't save intermediate progress.)
* Fix the instructions in the README so that it's possible to test locally.
* Format to PEP8, remove unused imports, fix lint errors and poorly-written conditionals.
* Simplify the logic and remove some redundant variables.
* Simplify error handling and include the original error messages from the API so the messages are more informative as to what failed.
* Use a buffer instead of concatenating immutable strings on every read.
* Start decomposing the logic into functions (only factored out one function so far but it's a start).
* Add a couple of tests.

This still isn't what I would consider production-grade because of the lack of tests, but at least it's in a much better state than before.

Tested:
* Fairly extensive manual testing in the integration account using `sam local invoke RDSLogsToS3 -e event.json` (see README) that the behaviour is still the same as before. Tested both the first-run (no timestamp file) case and the incremental (timestamp file exists so only copy newer files).
* The unit tests are passing (for what they're worth). They only cover reading the timestamp file though.