### PR TITLE
Allow infra-security to run against the hmggds account

### DIFF
--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -74,7 +74,7 @@ Infrastructure security settings:
 | <a name="input_role_poweruser_user_arns"></a> [role\_poweruser\_user\_arns](#input\_role\_poweruser\_user\_arns) | List of ARNs of external users that can assume the role | `list` | `[]` | no |
 | <a name="input_role_user_policy_arns"></a> [role\_user\_policy\_arns](#input\_role\_user\_policy\_arns) | List of ARNs of policies to attach to the role | `list` | `[]` | no |
 | <a name="input_role_user_user_arns"></a> [role\_user\_user\_arns](#input\_role\_user\_user\_arns) | List of ARNs of external users that can assume the role | `list` | `[]` | no |
-| <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The public part of an SSH keypair | `string` | n/a | yes |
+| <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The public part of an SSH keypair | `string` | `null` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | `""` | no |
 
 ## Outputs

--- a/terraform/projects/infra-security/hmggds.govuk.backend
+++ b/terraform/projects/infra-security/hmggds.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-hmggds"
+key     = "govuk/infra-security.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -101,6 +101,7 @@ variable "role_user_policy_arns" {
 variable "ssh_public_key" {
   type        = string
   description = "The public part of an SSH keypair"
+  default     = null
 }
 
 variable "office_ips" {
@@ -206,6 +207,7 @@ resource "aws_iam_account_password_policy" "tighten_passwords" {
 
 # default key pair for all ssh instances. All other keys are puppet managed
 resource "aws_key_pair" "govuk-infra-key" {
+  count      = var.ssh_public_key == null ? 0 : 1
   key_name   = "govuk-infra"
   public_key = var.ssh_public_key
 }


### PR DESCRIPTION
Previously this account did not have its IAM managed in code, which
means we tend to have to use the root account creds to access it.

This brings it into line with GOV.UK's other AWS accounts.

https://github.com/alphagov/govuk-aws-data/pull/862 needs to be merged first.

Note: I've already applied this terraform, so you can test that it works by using one of the new roles in the console (e.g. sign in to gds-users, then switch role to 605357578900 / `firstname.lastname-admin`). gds-cli doesn't have support for this account yet - I'll do a follow up PR for that.