### PR TITLE
Use liveness healthchecks for ELBs, readiness healthchecks for ALBs

### DIFF
--- a/terraform/projects/app-account/main.tf
+++ b/terraform/projects/app-account/main.tf
@@ -99,7 +99,7 @@ resource "aws_elb" "account_elb_internal" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:80/_healthcheck_account-api"
+    target              = "HTTP:80/_healthcheck-live_account-api"
     interval            = 30
   }
 

--- a/terraform/projects/app-bouncer/main.tf
+++ b/terraform/projects/app-bouncer/main.tf
@@ -137,7 +137,7 @@ module "bouncer_internal_lb" {
   listener_certificate_domain_name           = "${var.elb_internal_certname}"
   listener_secondary_certificate_domain_name = ""
   listener_action                            = "${local.internal_lb_map}"
-  target_group_health_check_path             = "/healthcheck"
+  target_group_health_check_path             = "/healthcheck/ready"
   subnets                                    = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups                            = ["${data.terraform_remote_state.infra_security_groups.sg_bouncer_internal_elb_id}"]
   alarm_actions                              = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]

--- a/terraform/projects/app-content-store/main.tf
+++ b/terraform/projects/app-content-store/main.tf
@@ -131,7 +131,7 @@ resource "aws_elb" "content-store_external_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:80/_healthcheck_content-store"
+    target              = "HTTP:80/_healthcheck-live_content-store"
     interval            = 30
   }
 
@@ -182,7 +182,7 @@ resource "aws_elb" "content-store_internal_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:80/_healthcheck_content-store"
+    target              = "HTTP:80/_healthcheck-live_content-store"
     interval            = 30
   }
 

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -131,7 +131,7 @@ resource "aws_elb" "draft-content-store_external_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:80/_healthcheck_draft-content-store"
+    target              = "HTTP:80/_healthcheck-live_draft-content-store"
     interval            = 30
   }
 
@@ -182,7 +182,7 @@ resource "aws_elb" "draft-content-store_internal_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:80/_healthcheck_draft-content-store"
+    target              = "HTTP:80/_healthcheck-live_draft-content-store"
     interval            = 30
   }
 

--- a/terraform/projects/app-email-alert-api/main.tf
+++ b/terraform/projects/app-email-alert-api/main.tf
@@ -99,7 +99,7 @@ resource "aws_elb" "email-alert-api_elb_internal" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:80/_healthcheck_email-alert-api"
+    target              = "HTTP:80/_healthcheck-live_email-alert-api"
     interval            = 30
   }
 

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -134,7 +134,7 @@ resource "aws_elb" "publishing-api_elb_internal" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:80/_healthcheck_publishing-api"
+    target              = "HTTP:80/_healthcheck-live_publishing-api"
     interval            = 30
   }
 
@@ -185,7 +185,7 @@ resource "aws_elb" "publishing-api_elb_external" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:80/_healthcheck_publishing-api"
+    target              = "HTTP:80/_healthcheck-live_publishing-api"
     interval            = 30
   }
 

--- a/terraform/projects/app-router-backend/main.tf
+++ b/terraform/projects/app-router-backend/main.tf
@@ -145,7 +145,7 @@ resource "aws_elb" "router_api_elb" {
     unhealthy_threshold = 2
     timeout             = 3
 
-    target   = "HTTP:80/_healthcheck_router-api"
+    target   = "HTTP:80/_healthcheck-live_router-api"
     interval = 30
   }
 

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -123,7 +123,7 @@ resource "aws_elb" "search_elb" {
     unhealthy_threshold = 2
     timeout             = 3
 
-    target   = "HTTP:80/_healthcheck_search-api"
+    target   = "HTTP:80/_healthcheck-live_search-api"
     interval = 30
   }
 

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -78,7 +78,7 @@ module "internal_lb" {
   access_logs_bucket_name          = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
   access_logs_bucket_prefix        = "elb/whitehall-backend-internal-elb"
   listener_certificate_domain_name = "${var.elb_internal_certname}"
-  target_group_health_check_path   = "/_healthcheck_whitehall-admin"
+  target_group_health_check_path   = "/_healthcheck-ready_whitehall-admin"
 
   listener_action = {
     "HTTPS:443" = "HTTP:80"

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -99,7 +99,7 @@ resource "aws_elb" "whitehall-frontend_elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:80/_healthcheck_whitehall-frontend"
+    target              = "HTTP:80/_healthcheck-live_whitehall-frontend"
     interval            = 30
   }
 

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -2196,7 +2196,7 @@ module "support_api_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/_healthcheck"
+  target_group_health_check_path = "/_healthcheck-ready_support-api"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_support-api_external_elb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -2086,7 +2086,7 @@ module "search_api_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/_healthcheck"
+  target_group_health_check_path = "/_healthcheck-ready_search-api"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_search-api_external_elb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -2388,7 +2388,7 @@ module "whitehall_frontend_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/_healthcheck_whitehall-frontend"
+  target_group_health_check_path = "/_healthcheck-ready_whitehall-frontend"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-frontend_external_elb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -2142,7 +2142,7 @@ module "static_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/_healthcheck"
+  target_group_health_check_path = "/_healthcheck-ready_static"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_static_carrenza_alb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1259,7 +1259,7 @@ module "email_alert_api_public_lb" {
   listener_certificate_domain_name           = "${var.elb_public_certname}"
   listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
   listener_action                            = "${map("HTTPS:443", "HTTP:80")}"
-  target_group_health_check_path             = "/_healthcheck_email-alert-api"
+  target_group_health_check_path             = "/_healthcheck-ready_email-alert-api"
   subnets                                    = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                            = ["${data.terraform_remote_state.infra_security_groups.sg_email-alert-api_elb_external_id}"]
   alarm_actions                              = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -713,7 +713,7 @@ module "bouncer_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/healthcheck"
+  target_group_health_check_path = "/healthcheck/ready"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_bouncer_elb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -2240,7 +2240,7 @@ module "sidekiq_monitoring_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/_healthcheck"
+  target_group_health_check_path = "/_healthcheck-ready_sidekiq-monitoring"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_sidekiq-monitoring_external_elb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -991,7 +991,7 @@ module "content-store_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/_healthcheck_content-store"
+  target_group_health_check_path = "/_healthcheck-ready_content-store"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_external_elb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1324,7 +1324,7 @@ module "feedback_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/healthcheck"
+  target_group_health_check_path = "/_healthcheck-ready_feedback"
   subnets                        = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_feedback_elb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -2310,7 +2310,7 @@ module "whitehall_backend_public_lb" {
     "HTTPS:443" = "HTTP:80"
   }
 
-  target_group_health_check_path = "/_healthcheck_whitehall-admin"
+  target_group_health_check_path = "/_healthcheck-ready_whitehall-admin"
   subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
   security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_external_elb_id}"]
   alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]


### PR DESCRIPTION
Currently govuk-aws healthchecks an app with the `/_healthcheck_app-name` endpoint, which is a liveness check (it always returns a status of 200) which communicates readiness data in the response body.  [RFC 141][] splits those responsibilities out, giving separate liveness healthchecks (which always return a 200) and readiness healthchecks (which return a 200 or a 500).

We use a mix of ELBs and ALBs in govuk-aws.  These have different behaviour in the case where every instance of an app fails its healthcheck:

- ELBs reject traffic until some instances become healthy again (fail-closed).
- ALBs ignore the healthcheck and send traffic to random instances (fail-open).

The fail-open behaviour is better, because it means that a misconfigured healthcheck or transient but non-critical problem can't take down an app.  Since ELBs fail-closed, we need to be more conservative about what constitutes a failure, so:

- ELBs should check the liveness healthcheck (because if the liveness healthchecks all fail simultaneously, we likely have some sort of big infrastructure outage)
- ALBs should check the readiness healthcheck

Note that ELBs using a liveness healthcheck isn't a change (the only thing that's changed is the path they query), because the current healthcheck *is* a liveness healthcheck.  So the only behavioural change in this PR is to the ALBs.

Once this PR is deployed, we can:

- Update [GovukHealthcheck][] to return a 500 status code on failure.
- Remove the old healthchecks from govuk-puppet.
- Remove the old healthchecks from the apps.

---

Terraform plans:

- [app-account](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1034/console)
- [app-bouncer](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1035/console)
- [app-content-store](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1036/console)
- [app-draft-content-store](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1037/console)
- [app-email-alert-api](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1038/console)
- [app-publishing-api](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1039/console)
- [app-router-backend](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1040/console)
- [app-search](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1041/console)
- [app-whitehall-backend](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1042/console)
- [app-whitehall-frontend](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1043/console)
- [infra-public-services](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1044/console)

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)

[RFC 141]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-141-application-healthchecks.md
[GovukHealthcheck]: https://github.com/alphagov/govuk_app_config/blob/master/lib/govuk_app_config/govuk_healthcheck.rb