### PR TITLE
Upgrade ArtefactSync lambda to Python 3.8

### DIFF
--- a/terraform/lambda/ArtefactSync/main.py
+++ b/terraform/lambda/ArtefactSync/main.py
@@ -9,7 +9,7 @@ def lambda_handler(event, context):
     sns_message = ast.literal_eval(event['Records'][0]['Sns']['Message'])
     target_bucket = context.function_name
     source_bucket = str(sns_message['Records'][0]['s3']['bucket']['name'])
-    key = str(urllib.unquote_plus(sns_message['Records'][0]['s3']['object']['key']).decode('utf8'))
+    key = str(urllib.parse.unquote_plus(sns_message['Records'][0]['s3']['object']['key']).decode('utf8'))
     copy_source = {'Bucket':source_bucket, 'Key':key}
-    print "Copying %s from bucket %s to bucket %s ..." % (key, source_bucket, target_bucket)
+    print("Copying %s from bucket %s to bucket %s ..." % (key, source_bucket, target_bucket))
     s3.copy_object(Bucket=target_bucket, Key=key, CopySource=copy_source)

--- a/terraform/projects/infra-artefact-bucket/main.tf
+++ b/terraform/projects/infra-artefact-bucket/main.tf
@@ -312,7 +312,7 @@ resource "aws_lambda_function" "artefact_lambda_function" {
   function_name = "govuk-${var.aws_environment}-artefact"
   role          = "${aws_iam_role.govuk_artefact_lambda_role.arn}"
   handler       = "main.lambda_handler"
-  runtime       = "python2.7"
+  runtime       = "python3.8"
 }
 
 # AWS Lambda Role


### PR DESCRIPTION
AWS are deprecating the support for lambdas running Python 2.7 on the 15th July 2021, so this lambda needs updating to Python 3.

All other Python 2.7 lambdas are no longer needed, so will be removed in https://github.com/alphagov/govuk-aws/pull/1439.

Trello card: https://trello.com/c/7uaFnYGD