### PR TITLE
Give ITHC HTTPS access to content-data, mapit, and support-api

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -135,6 +135,7 @@ No modules.
 | [aws_security_group.mapit_cache](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.mapit_carrenza_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.mapit_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
+| [aws_security_group.mapit_ithc_access](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.mirrorer](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.mongo](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.monitoring](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
@@ -170,6 +171,7 @@ No modules.
 | [aws_security_group.static](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.static_carrenza_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.support-api_external_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
+| [aws_security_group.support-api_ithc_access](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.transition-db-admin](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.transition-db-admin_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.transition-postgresql-primary](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
@@ -389,6 +391,7 @@ No modules.
 | [aws_security_group_rule.graphite_ingress_graphite_internal_elb_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ithc_ingress_account_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ithc_ingress_apt_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ithc_ingress_backend_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ithc_ingress_backend_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ithc_ingress_bouncer_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ithc_ingress_cache_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
@@ -403,10 +406,12 @@ No modules.
 | [aws_security_group_rule.ithc_ingress_frontend_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ithc_ingress_licensify_backend_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ithc_ingress_licensify_frontend_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ithc_ingress_mapit_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ithc_ingress_publishing-api_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ithc_ingress_router-backend_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ithc_ingress_search-api_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ithc_ingress_search_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ithc_ingress_support-api_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ithc_ingress_whitehall-frontend_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ithc_ingress_whitehall_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.jumpbox_ingress_offsite-ssh_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |

--- a/terraform/projects/infra-security-groups/backend.tf
+++ b/terraform/projects/infra-security-groups/backend.tf
@@ -154,3 +154,13 @@ resource "aws_security_group_rule" "ithc_ingress_backend_ssh" {
   cidr_blocks       = "${var.ithc_access_ips}"
   security_group_id = "${aws_security_group.backend_ithc_access.id}"
 }
+
+resource "aws_security_group_rule" "ithc_ingress_backend_https" {
+  count             = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  type              = "ingress"
+  to_port           = 443
+  from_port         = 443
+  protocol          = "tcp"
+  cidr_blocks       = "${var.ithc_access_ips}"
+  security_group_id = "${aws_security_group.backend_ithc_access.id}"
+}

--- a/terraform/projects/infra-security-groups/mapit.tf
+++ b/terraform/projects/infra-security-groups/mapit.tf
@@ -129,3 +129,24 @@ resource "aws_security_group_rule" "mapit-carrenza-alb_egress_any_any" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.mapit_carrenza_alb.id}"
 }
+
+resource "aws_security_group" "mapit_ithc_access" {
+  count       = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  name        = "${var.stackname}_mapit_ithc_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Control access to ITHC"
+
+  tags {
+    Name = "${var.stackname}_mapit_ithc_access"
+  }
+}
+
+resource "aws_security_group_rule" "ithc_ingress_mapit_https" {
+  count             = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  type              = "ingress"
+  to_port           = 443
+  from_port         = 443
+  protocol          = "tcp"
+  cidr_blocks       = "${var.ithc_access_ips}"
+  security_group_id = "${aws_security_group.mapit_ithc_access.id}"
+}

--- a/terraform/projects/infra-security-groups/support-api.tf
+++ b/terraform/projects/infra-security-groups/support-api.tf
@@ -39,3 +39,24 @@ resource "aws_security_group_rule" "support-api_egress_external_elb_any_any" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.support-api_external_elb.id}"
 }
+
+resource "aws_security_group" "support-api_ithc_access" {
+  count       = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  name        = "${var.stackname}_support-api_ithc_access"
+  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  description = "Control access to ITHC"
+
+  tags {
+    Name = "${var.stackname}_support-api_ithc_access"
+  }
+}
+
+resource "aws_security_group_rule" "ithc_ingress_support-api_https" {
+  count             = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
+  type              = "ingress"
+  to_port           = 443
+  from_port         = 443
+  protocol          = "tcp"
+  cidr_blocks       = "${var.ithc_access_ips}"
+  security_group_id = "${aws_security_group.support-api_ithc_access.id}"
+}


### PR DESCRIPTION
The ITHC team have asked for access to content-data, mapit, and support-api via HTTPS.  There doesn't seem to be a file for content-data, but it runs on the backend machines.

I don't really understand how these security rules work (for instance, where does it specify what the ITHC security groups actually have access to?), so I'm not sure if these are right.