### PR TITLE
Fix ITHC HTTPS access for mapit and support-api

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -135,7 +135,6 @@ No modules.
 | [aws_security_group.mapit_cache](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.mapit_carrenza_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.mapit_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
-| [aws_security_group.mapit_ithc_access](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.mirrorer](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.mongo](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.monitoring](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
@@ -171,7 +170,6 @@ No modules.
 | [aws_security_group.static](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.static_carrenza_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.support-api_external_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
-| [aws_security_group.support-api_ithc_access](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.transition-db-admin](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.transition-db-admin_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.transition-postgresql-primary](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |

--- a/terraform/projects/infra-security-groups/mapit.tf
+++ b/terraform/projects/infra-security-groups/mapit.tf
@@ -130,17 +130,6 @@ resource "aws_security_group_rule" "mapit-carrenza-alb_egress_any_any" {
   security_group_id = "${aws_security_group.mapit_carrenza_alb.id}"
 }
 
-resource "aws_security_group" "mapit_ithc_access" {
-  count       = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
-  name        = "${var.stackname}_mapit_ithc_access"
-  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  description = "Control access to ITHC"
-
-  tags {
-    Name = "${var.stackname}_mapit_ithc_access"
-  }
-}
-
 resource "aws_security_group_rule" "ithc_ingress_mapit_https" {
   count             = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
   type              = "ingress"
@@ -148,5 +137,5 @@ resource "aws_security_group_rule" "ithc_ingress_mapit_https" {
   from_port         = 443
   protocol          = "tcp"
   cidr_blocks       = "${var.ithc_access_ips}"
-  security_group_id = "${aws_security_group.mapit_ithc_access.id}"
+  security_group_id = "${aws_security_group.mapit_carrenza_alb.id}"
 }

--- a/terraform/projects/infra-security-groups/support-api.tf
+++ b/terraform/projects/infra-security-groups/support-api.tf
@@ -40,17 +40,6 @@ resource "aws_security_group_rule" "support-api_egress_external_elb_any_any" {
   security_group_id = "${aws_security_group.support-api_external_elb.id}"
 }
 
-resource "aws_security_group" "support-api_ithc_access" {
-  count       = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
-  name        = "${var.stackname}_support-api_ithc_access"
-  vpc_id      = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  description = "Control access to ITHC"
-
-  tags {
-    Name = "${var.stackname}_support-api_ithc_access"
-  }
-}
-
 resource "aws_security_group_rule" "ithc_ingress_support-api_https" {
   count             = "${length(var.ithc_access_ips) > 0 ? 1 : 0}"
   type              = "ingress"
@@ -58,5 +47,5 @@ resource "aws_security_group_rule" "ithc_ingress_support-api_https" {
   from_port         = 443
   protocol          = "tcp"
   cidr_blocks       = "${var.ithc_access_ips}"
-  security_group_id = "${aws_security_group.support-api_ithc_access.id}"
+  security_group_id = "${aws_security_group.support-api_external_elb.id}"
 }


### PR DESCRIPTION
HTTPS rules need to belong to a security group which is attached to a
load balancer, which the previous groups weren't.  Since we already
have security groups attached to the public load balancers (defined in
infra-public-services), I've added the rules to them.