### PR TITLE
fix new mapit 3 and 4 not being added to the Mapit loadbalancer/target group

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -69,6 +69,8 @@ This project adds global resources for app components:
 | [aws_autoscaling_attachment.licensify_frontend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.mapit-1_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.mapit-2_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
+| [aws_autoscaling_attachment.mapit-3_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
+| [aws_autoscaling_attachment.mapit-4_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.monitoring_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.prometheus_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.search_api_backend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
@@ -194,6 +196,8 @@ This project adds global resources for app components:
 | [aws_autoscaling_groups.licensify_frontend](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_groups) | data source |
 | [aws_autoscaling_groups.mapit-1](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_groups) | data source |
 | [aws_autoscaling_groups.mapit-2](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_groups) | data source |
+| [aws_autoscaling_groups.mapit-3](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_groups) | data source |
+| [aws_autoscaling_groups.mapit-4](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_groups) | data source |
 | [aws_autoscaling_groups.monitoring](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_groups) | data source |
 | [aws_autoscaling_groups.prometheus](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_groups) | data source |
 | [aws_autoscaling_groups.search](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_groups) | data source |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1858,6 +1858,42 @@ resource "aws_autoscaling_attachment" "mapit-2_asg_attachment_alb" {
   alb_target_group_arn   = "${element(module.mapit_public_lb.target_group_arns, 0)}"
 }
 
+data "aws_autoscaling_groups" "mapit-3" {
+  filter {
+    name   = "key"
+    values = ["Name"]
+  }
+
+  filter {
+    name   = "value"
+    values = ["blue-mapit-3"]
+  }
+}
+
+resource "aws_autoscaling_attachment" "mapit-3_asg_attachment_alb" {
+  count                  = "${length(data.aws_autoscaling_groups.mapit-3.names) > 0 ? 1 : 0}"
+  autoscaling_group_name = "${element(data.aws_autoscaling_groups.mapit-3.names, 0)}"
+  alb_target_group_arn   = "${element(module.mapit_public_lb.target_group_arns, 0)}"
+}
+
+data "aws_autoscaling_groups" "mapit-4" {
+  filter {
+    name   = "key"
+    values = ["Name"]
+  }
+
+  filter {
+    name   = "value"
+    values = ["blue-mapit-4"]
+  }
+}
+
+resource "aws_autoscaling_attachment" "mapit-4_asg_attachment_alb" {
+  count                  = "${length(data.aws_autoscaling_groups.mapit-4.names) > 0 ? 1 : 0}"
+  autoscaling_group_name = "${element(data.aws_autoscaling_groups.mapit-4.names, 0)}"
+  alb_target_group_arn   = "${element(module.mapit_public_lb.target_group_arns, 0)}"
+}
+
 resource "aws_route53_record" "mapit_cache_name" {
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
   name    = "mapit-memcached.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"


### PR DESCRIPTION
this fixes https://github.com/alphagov/govuk-aws/commit/404c03c45265f6b07ff29257bc25ccabdb37f16e where new mapit instances 3 and 4 were added to the infrastructure but no logic was included to add them to the Mapit load balancer/target group