### PR TITLE
Set up public load balancer for account-api

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -24,6 +24,8 @@ This project adds global resources for app components:
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_account_public_lb"></a> [account\_public\_lb](#module\_account\_public\_lb) | ../../modules/aws/lb |  |
+| <a name="module_account_public_lb_rules"></a> [account\_public\_lb\_rules](#module\_account\_public\_lb\_rules) | ../../modules/aws/lb_listener_rules |  |
 | <a name="module_alarms-elb-jumpbox-public"></a> [alarms-elb-jumpbox-public](#module\_alarms-elb-jumpbox-public) | ../../modules/aws/alarms/elb |  |
 | <a name="module_backend_public_lb"></a> [backend\_public\_lb](#module\_backend\_public\_lb) | ../../modules/aws/lb |  |
 | <a name="module_backend_public_lb_rules"></a> [backend\_public\_lb\_rules](#module\_backend\_public\_lb\_rules) | ../../modules/aws/lb_listener_rules |  |
@@ -90,6 +92,8 @@ This project adds global resources for app components:
 | [aws_lb_listener_rule.backend_alb_blocked_host_headers](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/lb_listener_rule) | resource |
 | [aws_route53_record.account_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.account_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
+| [aws_route53_record.account_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
+| [aws_route53_record.account_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.apt_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.asset_master_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.backend_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
@@ -174,6 +178,7 @@ This project adds global resources for app components:
 | [aws_wafregional_regex_pattern_set.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_regex_pattern_set) | resource |
 | [aws_wafregional_rule.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_rule) | resource |
 | [aws_wafregional_web_acl.default](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_web_acl) | resource |
+| [aws_wafregional_web_acl_association.account_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_web_acl_association) | resource |
 | [aws_wafregional_web_acl_association.backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_web_acl_association) | resource |
 | [aws_wafregional_web_acl_association.cache_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_web_acl_association) | resource |
 | [aws_wafregional_web_acl_association.licensify_backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_web_acl_association) | resource |
@@ -181,6 +186,7 @@ This project adds global resources for app components:
 | [aws_wafregional_web_acl_association.whitehall_backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_web_acl_association) | resource |
 | [aws_wafregional_web_acl_association.whitehall_frontend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_web_acl_association) | resource |
 | [archive_file.aws_waf_log_trimmer](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_autoscaling_group.account](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_group) | data source |
 | [aws_autoscaling_group.backend](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_group) | data source |
 | [aws_autoscaling_group.cache](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_group) | data source |
 | [aws_autoscaling_groups.bouncer](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_groups) | data source |
@@ -217,6 +223,8 @@ This project adds global resources for app components:
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_internal_service_cnames"></a> [account\_internal\_service\_cnames](#input\_account\_internal\_service\_cnames) | n/a | `list` | `[]` | no |
 | <a name="input_account_internal_service_names"></a> [account\_internal\_service\_names](#input\_account\_internal\_service\_names) | n/a | `list` | `[]` | no |
+| <a name="input_account_public_service_cnames"></a> [account\_public\_service\_cnames](#input\_account\_public\_service\_cnames) | n/a | `list` | `[]` | no |
+| <a name="input_account_public_service_names"></a> [account\_public\_service\_names](#input\_account\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_app_stackname"></a> [app\_stackname](#input\_app\_stackname) | Stackname of the app projects in this environment | `string` | `"blue"` | no |
 | <a name="input_apt_internal_service_names"></a> [apt\_internal\_service\_names](#input\_apt\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_apt_public_service_cnames"></a> [apt\_public\_service\_cnames](#input\_apt\_public\_service\_cnames) | n/a | `list` | `[]` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -59,6 +59,16 @@ variable "account_internal_service_cnames" {
   default = []
 }
 
+variable "account_public_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "account_public_service_cnames" {
+  type    = "list"
+  default = []
+}
+
 variable "apt_public_service_names" {
   type    = "list"
   default = []
@@ -521,6 +531,66 @@ provider "archive" {
 #
 # account
 #
+
+module "account_public_lb" {
+  source                                     = "../../modules/aws/lb"
+  name                                       = "${var.stackname}-account-public"
+  internal                                   = false
+  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
+  access_logs_bucket_prefix                  = "elb/${var.stackname}-account-public-elb"
+  listener_certificate_domain_name           = "${var.elb_public_certname}"
+  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
+  listener_internal_certificate_domain_name  = "${var.elb_public_internal_certname}"
+  listener_action                            = "${map("HTTPS:443", "HTTP:80")}"
+  subnets                                    = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
+  security_groups                            = ["${data.terraform_remote_state.infra_security_groups.sg_account_elb_external_id}"]
+  alarm_actions                              = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
+  default_tags                               = "${map("Project", var.stackname, "aws_migration", "account", "aws_environment", var.aws_environment)}"
+  target_group_health_check_path             = "/_healthcheck-ready_account-api"
+}
+
+resource "aws_wafregional_web_acl_association" "account_public_lb" {
+  resource_arn = "${module.account_public_lb.lb_id}"
+  web_acl_id   = "${aws_wafregional_web_acl.default.id}"
+}
+
+module "account_public_lb_rules" {
+  source                 = "../../modules/aws/lb_listener_rules"
+  name                   = "account"
+  autoscaling_group_name = "${data.aws_autoscaling_group.account.name}"
+  rules_host_domain      = "*"
+  vpc_id                 = "${data.terraform_remote_state.infra_vpc.vpc_id}"
+  listener_arn           = "${module.account_public_lb.load_balancer_ssl_listeners[0]}"
+  rules_host             = ["${compact(split(",", var.enable_lb_app_healthchecks ? join(",", var.account_public_service_cnames) : ""))}"]
+  default_tags           = "${map("Project", var.stackname, "aws_migration", "account", "aws_environment", var.aws_environment)}"
+}
+
+resource "aws_route53_record" "account_public_service_names" {
+  count   = "${length(var.account_public_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.account_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${module.account_public_lb.lb_dns_name}"
+    zone_id                = "${module.account_public_lb.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "account_public_service_cnames" {
+  count   = "${length(var.account_public_service_cnames)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.account_public_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.account_public_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"]
+  ttl     = "300"
+}
+
+data "aws_autoscaling_group" "account" {
+  name = "${var.app_stackname}-account"
+}
 
 resource "aws_route53_record" "account_internal_service_names" {
   count   = "${length(var.account_internal_service_names)}"

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -187,7 +187,7 @@ No modules.
 | [aws_security_group_rule.accessibility-reports_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.accessibility-reports_ingress_office_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.account-elb-external_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.account-elb-external_ingress_office_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.account-elb-external_ingress_any_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.account-elb-internal_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.account-elb-internal_ingress_management_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.account_ingress_account-elb-external_http](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |

--- a/terraform/projects/infra-security-groups/account.tf
+++ b/terraform/projects/infra-security-groups/account.tf
@@ -92,7 +92,7 @@ resource "aws_security_group" "account_elb_external" {
   }
 }
 
-resource "aws_security_group_rule" "account-elb-external_ingress_office_https" {
+resource "aws_security_group_rule" "account-elb-external_ingress_any_https" {
   type      = "ingress"
   from_port = 443
   to_port   = 443
@@ -100,7 +100,7 @@ resource "aws_security_group_rule" "account-elb-external_ingress_office_https" {
 
   # Which security group is the rule assigned to
   security_group_id = "${aws_security_group.account_elb_external.id}"
-  cidr_blocks       = ["${var.office_ips}"]
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "account-elb-external_egress_any_any" {


### PR DESCRIPTION
This is safe because all the API endpoints are protected by Signon
bearer tokens.

---

Plans:

- [infra-public-services](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1309/console)
- [infra-security-groups](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1308/console)

[Trello card](https://trello.com/c/6CsImbRT/817-make-account-manager-able-to-communicate-with-account-api)