### PR TITLE
Make Prometheus storage volume configurable and upgrade to gp3.

### DIFF
--- a/terraform/projects/app-prometheus/README.md
+++ b/terraform/projects/app-prometheus/README.md
@@ -51,6 +51,7 @@ Prometheus node
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
+| <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | EBS volume size | `string` | `"64"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name (e.g. *.production.govuk-internal.digital) to find the ARN of | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"t3.medium"` | no |

--- a/terraform/projects/app-prometheus/main.tf
+++ b/terraform/projects/app-prometheus/main.tf
@@ -53,6 +53,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "ebs_volume_size" {
+  type        = "string"
+  description = "EBS volume size"
+  default     = "64"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -83,8 +89,8 @@ keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map),
 
 resource "aws_ebs_volume" "prometheus-1" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.prometheus_1_subnet)}"
-  size              = 64
-  type              = "gp2"
+  size              = "${var.ebs_volume_size}"
+  type              = "gp3"
 
   tags {
     Name            = "${var.stackname}-prometheus-1"


### PR DESCRIPTION
This enables us to add more timeseries storage space in prod, which was running out.

gp3 is cheaper and faster, so no reason not to use it.