### PR TITLE
Give account access to the backend-redis

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -209,6 +209,7 @@ No modules.
 | [aws_security_group_rule.backend-elb-external_ingress_public_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.backend-elb-internal_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.backend-elb-internal_ingress_management_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.backend-redis_ingress_account_redis](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.backend-redis_ingress_backend_redis](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.backend-redis_ingress_ckan_redis](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.backend-redis_ingress_db-admin_redis](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |

--- a/terraform/projects/infra-security-groups/backend-redis.tf
+++ b/terraform/projects/infra-security-groups/backend-redis.tf
@@ -163,3 +163,16 @@ resource "aws_security_group_rule" "backend-redis_ingress_draft-frontend_redis" 
   # Which security group can use this rule
   source_security_group_id = "${aws_security_group.draft-frontend.id}"
 }
+
+resource "aws_security_group_rule" "backend-redis_ingress_account_redis" {
+  type      = "ingress"
+  from_port = 6379
+  to_port   = 6379
+  protocol  = "tcp"
+
+  # Which security group is the rule assigned to
+  security_group_id = "${aws_security_group.backend-redis.id}"
+
+  # Which security group can use this rule
+  source_security_group_id = "${aws_security_group.account.id}"
+}


### PR DESCRIPTION
This is necessary now that account-api is using sidekiq for background
job processing.

---

[Trello card](https://trello.com/c/uRW8OS61/907-move-expired-authrequest-deletion-to-sidekiq)
[Plan](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1350/console)