### PR TITLE
Download puppetlabs GPG key over https

### DIFF
--- a/terraform/userdata/00-base
+++ b/terraform/userdata/00-base
@@ -28,7 +28,7 @@ rm $TMPFILE
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: install Puppetlabs package signing key ..."
 curl --silent --show-error --fail \
-  http://apt.puppetlabs.com/DEB-GPG-KEY-puppet-20250406 | apt-key add -
+  https://apt.puppetlabs.com/DEB-GPG-KEY-puppet-20250406 | apt-key add -
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: install Gov.UK package signing key and repositories ..."
 curl --silent --show-error --fail \


### PR DESCRIPTION
It might be a bit tinfoil hat to consider how downloading puppet's GPG
key over a plaintext connection could lead to a vulnerability, but it
seems like a good idea to download it over HTTPS since that seems to be
available.

Confirmed that it's the same key:

```
cmp <(curl --silent 'http://apt.puppetlabs.com/DEB-GPG-KEY-puppet-20250406') <(curl --silent 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppet-20250406')
```