### PR TITLE
Pin awscli version

### DIFF
--- a/terraform/projects/app-knowledge-graph/userdata-sandbox.tpl
+++ b/terraform/projects/app-knowledge-graph/userdata-sandbox.tpl
@@ -23,7 +23,8 @@ pip install --upgrade pip
 
 # Install pip and dependencies used in this start-up script
 sudo apt install -y python-pip
-pip install awscli
+pip install awscli==1.19.112
+pip install futures
 
 # Install Python 3.7
 sudo add-apt-repository ppa:deadsnakes/ppa -y && sudo apt-get update

--- a/terraform/projects/app-knowledge-graph/userdata.tpl
+++ b/terraform/projects/app-knowledge-graph/userdata.tpl
@@ -23,7 +23,8 @@ pip install --upgrade pip
 
 # Install pip and dependencies used in this start-up script
 sudo apt install -y python-pip
-pip install awscli
+pip install awscli==1.19.112
+pip install futures
 
 # Install Python 3.7
 sudo add-apt-repository ppa:deadsnakes/ppa -y && sudo apt-get update


### PR DESCRIPTION
Newer versions drop support for python 2.7
We should migrate from python 2.7 as
its EOL