### PR TITLE
Add overrides for instance type and number of nodes for redis

### DIFF
--- a/terraform/modules/aws/elasticache_redis_cluster/README.md
+++ b/terraform/modules/aws/elasticache_redis_cluster/README.md
@@ -29,6 +29,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Additional resource tags | `map` | `{}` | no |
+| <a name="input_elasticache_node_number"></a> [elasticache\_node\_number](#input\_elasticache\_node\_number) | The number of nodes per cluster. | `string` | `"2"` | no |
 | <a name="input_elasticache_node_type"></a> [elasticache\_node\_type](#input\_elasticache\_node\_type) | The node type to use. Must not be t.* in order to use failover. | `string` | `"cache.m3.medium"` | no |
 | <a name="input_enable_clustering"></a> [enable\_clustering](#input\_enable\_clustering) | Set to true to enable clustering mode | `string` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | The common name for all the resources created by this module | `string` | n/a | yes |

--- a/terraform/modules/aws/elasticache_redis_cluster/main.tf
+++ b/terraform/modules/aws/elasticache_redis_cluster/main.tf
@@ -26,6 +26,12 @@ variable "elasticache_node_type" {
   default     = "cache.m3.medium"
 }
 
+variable "elasticache_node_number" {
+  type        = "string"
+  description = "The number of nodes per cluster."
+  default     = "2"
+}
+
 variable "security_group_ids" {
   type        = "list"
   description = "Security group IDs to apply to this cluster"
@@ -72,7 +78,7 @@ resource "aws_elasticache_replication_group" "redis_master_with_replica" {
   replication_group_id          = "${var.name}"
   replication_group_description = "${var.name} redis master with replica"
   node_type                     = "${var.elasticache_node_type}"
-  number_cache_clusters         = 2
+  number_cache_clusters         = "${var.elasticache_node_number}"
   port                          = 6379
   parameter_group_name          = "default.redis3.2"
   engine_version                = "3.2.10"

--- a/terraform/projects/app-backend-redis/README.md
+++ b/terraform/projects/app-backend-redis/README.md
@@ -43,6 +43,7 @@ Backend VDC Redis Elasticache cluster
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_enable_clustering"></a> [enable\_clustering](#input\_enable\_clustering) | Enable clustering | `string` | `false` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for Elasticache nodes | `string` | `"cache.r4.large"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_internal_zone_name"></a> [internal\_zone\_name](#input\_internal\_zone\_name) | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |

--- a/terraform/projects/app-backend-redis/README.md
+++ b/terraform/projects/app-backend-redis/README.md
@@ -46,6 +46,7 @@ Backend VDC Redis Elasticache cluster
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for Elasticache nodes | `string` | `"cache.r4.large"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_internal_zone_name"></a> [internal\_zone\_name](#input\_internal\_zone\_name) | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
+| <a name="input_node_number"></a> [node\_number](#input\_node\_number) | Override the number of nodes per cluster specified by the module. | `string` | `"2"` | no |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | <a name="input_remote_state_infra_monitoring_key_stack"></a> [remote\_state\_infra\_monitoring\_key\_stack](#input\_remote\_state\_infra\_monitoring\_key\_stack) | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_networking_key_stack"></a> [remote\_state\_infra\_networking\_key\_stack](#input\_remote\_state\_infra\_networking\_key\_stack) | Override infra\_networking remote state path | `string` | `""` | no |

--- a/terraform/projects/app-backend-redis/main.tf
+++ b/terraform/projects/app-backend-redis/main.tf
@@ -25,6 +25,12 @@ variable "enable_clustering" {
   default     = false
 }
 
+variable "instance_type" {
+  type        = "string"
+  description = "Instance type used for Elasticache nodes"
+  default     = "cache.r4.large"
+}
+
 variable "internal_zone_name" {
   type        = "string"
   description = "The name of the Route53 zone that contains internal records"
@@ -67,7 +73,7 @@ module "backend_redis_cluster" {
   default_tags          = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend-redis")}"
   subnet_ids            = "${data.terraform_remote_state.infra_networking.private_subnet_elasticache_ids}"
   security_group_ids    = ["${data.terraform_remote_state.infra_security_groups.sg_backend-redis_id}"]
-  elasticache_node_type = "cache.r4.large"
+  elasticache_node_type = "${var.instance_type}"
 }
 
 module "alarms-elasticache-backend-redis" {

--- a/terraform/projects/app-backend-redis/main.tf
+++ b/terraform/projects/app-backend-redis/main.tf
@@ -41,6 +41,12 @@ variable "internal_domain_name" {
   description = "The domain name of the internal DNS records, it could be different from the zone name"
 }
 
+variable "node_number" {
+  type        = "string"
+  description = "Override the number of nodes per cluster specified by the module."
+  default     = "2"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -67,13 +73,14 @@ resource "aws_route53_record" "service_record" {
 }
 
 module "backend_redis_cluster" {
-  source                = "../../modules/aws/elasticache_redis_cluster"
-  enable_clustering     = "${var.enable_clustering}"
-  name                  = "${var.stackname}-backend-redis"
-  default_tags          = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend-redis")}"
-  subnet_ids            = "${data.terraform_remote_state.infra_networking.private_subnet_elasticache_ids}"
-  security_group_ids    = ["${data.terraform_remote_state.infra_security_groups.sg_backend-redis_id}"]
-  elasticache_node_type = "${var.instance_type}"
+  source                  = "../../modules/aws/elasticache_redis_cluster"
+  enable_clustering       = "${var.enable_clustering}"
+  name                    = "${var.stackname}-backend-redis"
+  default_tags            = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend-redis")}"
+  subnet_ids              = "${data.terraform_remote_state.infra_networking.private_subnet_elasticache_ids}"
+  security_group_ids      = ["${data.terraform_remote_state.infra_security_groups.sg_backend-redis_id}"]
+  elasticache_node_type   = "${var.instance_type}"
+  elasticache_node_number = "${var.node_number}"
 }
 
 module "alarms-elasticache-backend-redis" {


### PR DESCRIPTION
So that we can override for production with a different value in [govuk-aws-data](https://github.com/alphagov/govuk-aws-data/pull/889).

Due to increased memory usage caused by data.gov.uk recently which triggered an incident. This may get reduced once the underlying excessive memory consumption is addressed.