### PR TITLE
Parameterise app-backend-redis redis_engine_version

### DIFF
--- a/terraform/modules/aws/elasticache_redis_cluster/README.md
+++ b/terraform/modules/aws/elasticache_redis_cluster/README.md
@@ -33,6 +33,7 @@ No modules.
 | <a name="input_elasticache_node_type"></a> [elasticache\_node\_type](#input\_elasticache\_node\_type) | The node type to use. Must not be t.* in order to use failover. | `string` | `"cache.m3.medium"` | no |
 | <a name="input_enable_clustering"></a> [enable\_clustering](#input\_enable\_clustering) | Set to true to enable clustering mode | `string` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | The common name for all the resources created by this module | `string` | n/a | yes |
+| <a name="input_redis_engine_version"></a> [redis\_engine\_version](#input\_redis\_engine\_version) | The Elasticache Redis engine version. | `string` | n/a | yes |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security group IDs to apply to this cluster | `list` | n/a | yes |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to assign to the aws\_elasticache\_subnet\_group | `list` | n/a | yes |
 

--- a/terraform/modules/aws/elasticache_redis_cluster/main.tf
+++ b/terraform/modules/aws/elasticache_redis_cluster/main.tf
@@ -43,6 +43,11 @@ variable "enable_clustering" {
   default     = true
 }
 
+variable "redis_engine_version" {
+  type        = "string"
+  description = "The Elasticache Redis engine version."
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -61,7 +66,7 @@ resource "aws_elasticache_replication_group" "redis_cluster" {
   port                          = 6379
   parameter_group_name          = "default.redis3.2.cluster.on"
   automatic_failover_enabled    = true
-  engine_version                = "3.2.10"
+  engine_version                = "${var.redis_engine_version}"
   subnet_group_name             = "${aws_elasticache_subnet_group.redis_cluster_subnet_group.name}"
   security_group_ids            = ["${var.security_group_ids}"]
 

--- a/terraform/projects/app-backend-redis/README.md
+++ b/terraform/projects/app-backend-redis/README.md
@@ -47,6 +47,7 @@ Backend VDC Redis Elasticache cluster
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_internal_zone_name"></a> [internal\_zone\_name](#input\_internal\_zone\_name) | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | <a name="input_node_number"></a> [node\_number](#input\_node\_number) | Override the number of nodes per cluster specified by the module. | `string` | `"2"` | no |
+| <a name="input_redis_engine_version"></a> [redis\_engine\_version](#input\_redis\_engine\_version) | The Elasticache Redis engine version. | `string` | `"3.2.10"` | no |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | <a name="input_remote_state_infra_monitoring_key_stack"></a> [remote\_state\_infra\_monitoring\_key\_stack](#input\_remote\_state\_infra\_monitoring\_key\_stack) | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_networking_key_stack"></a> [remote\_state\_infra\_networking\_key\_stack](#input\_remote\_state\_infra\_networking\_key\_stack) | Override infra\_networking remote state path | `string` | `""` | no |

--- a/terraform/projects/app-backend-redis/main.tf
+++ b/terraform/projects/app-backend-redis/main.tf
@@ -47,6 +47,12 @@ variable "node_number" {
   default     = "2"
 }
 
+variable "redis_engine_version" {
+  type        = "string"
+  description = "The Elasticache Redis engine version."
+  default     = "3.2.10"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -81,6 +87,7 @@ module "backend_redis_cluster" {
   security_group_ids      = ["${data.terraform_remote_state.infra_security_groups.sg_backend-redis_id}"]
   elasticache_node_type   = "${var.instance_type}"
   elasticache_node_number = "${var.node_number}"
+  redis_engine_version    = "${var.redis_engine_version}"
 }
 
 module "alarms-elasticache-backend-redis" {


### PR DESCRIPTION
This enables us to run different redis engine versions per environment.

I've kept the default in govuk-aws the same. There is a
corresponding govuk-aws-data PR to enable us to set the
parameter per environment: https://github.com/alphagov/govuk-aws-data/pull/893.

Once this is merged we'll be able to upgrade Redis in each environment.

Testing: 

```
gds govuk terraform -b bilbof/redis-version -d bilbof/redis-version -a plan -e integration -s blue -p app-backend-redis -r govuk-integration-admin -u <github_username>
```

Test output:

```
No changes. Infrastructure is up-to-date.
```


https://trello.com/c/ft2pX8p2/603-redis-cluster-upgrade