### PR TITLE
Add redis_parameter_group_name variable to aws/elasticache_redis_cluster

### DIFF
--- a/terraform/modules/aws/elasticache_redis_cluster/README.md
+++ b/terraform/modules/aws/elasticache_redis_cluster/README.md
@@ -34,6 +34,7 @@ No modules.
 | <a name="input_enable_clustering"></a> [enable\_clustering](#input\_enable\_clustering) | Set to true to enable clustering mode | `string` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | The common name for all the resources created by this module | `string` | n/a | yes |
 | <a name="input_redis_engine_version"></a> [redis\_engine\_version](#input\_redis\_engine\_version) | The Elasticache Redis engine version. | `string` | n/a | yes |
+| <a name="input_redis_parameter_group_name"></a> [redis\_parameter\_group\_name](#input\_redis\_parameter\_group\_name) | The Elasticache Redis parameter group name. | `string` | n/a | yes |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security group IDs to apply to this cluster | `list` | n/a | yes |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to assign to the aws\_elasticache\_subnet\_group | `list` | n/a | yes |
 

--- a/terraform/modules/aws/elasticache_redis_cluster/main.tf
+++ b/terraform/modules/aws/elasticache_redis_cluster/main.tf
@@ -48,6 +48,11 @@ variable "redis_engine_version" {
   description = "The Elasticache Redis engine version."
 }
 
+variable "redis_parameter_group_name" {
+  type        = "string"
+  description = "The Elasticache Redis parameter group name."
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -64,7 +69,7 @@ resource "aws_elasticache_replication_group" "redis_cluster" {
   replication_group_description = "${var.name} redis cluster"
   node_type                     = "${var.elasticache_node_type}"
   port                          = 6379
-  parameter_group_name          = "default.redis3.2.cluster.on"
+  parameter_group_name          = "${var.redis_parameter_group_name}.cluster.on"
   automatic_failover_enabled    = true
   engine_version                = "${var.redis_engine_version}"
   subnet_group_name             = "${aws_elasticache_subnet_group.redis_cluster_subnet_group.name}"
@@ -85,8 +90,8 @@ resource "aws_elasticache_replication_group" "redis_master_with_replica" {
   node_type                     = "${var.elasticache_node_type}"
   number_cache_clusters         = "${var.elasticache_node_number}"
   port                          = 6379
-  parameter_group_name          = "default.redis3.2"
-  engine_version                = "3.2.10"
+  parameter_group_name          = "${var.redis_parameter_group_name}"
+  engine_version                = "${var.redis_engine_version}"
   automatic_failover_enabled    = true
 
   subnet_group_name  = "${aws_elasticache_subnet_group.redis_cluster_subnet_group.name}"

--- a/terraform/projects/app-backend-redis/README.md
+++ b/terraform/projects/app-backend-redis/README.md
@@ -48,6 +48,7 @@ Backend VDC Redis Elasticache cluster
 | <a name="input_internal_zone_name"></a> [internal\_zone\_name](#input\_internal\_zone\_name) | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | <a name="input_node_number"></a> [node\_number](#input\_node\_number) | Override the number of nodes per cluster specified by the module. | `string` | `"2"` | no |
 | <a name="input_redis_engine_version"></a> [redis\_engine\_version](#input\_redis\_engine\_version) | The Elasticache Redis engine version. | `string` | `"3.2.10"` | no |
+| <a name="input_redis_parameter_group_name"></a> [redis\_parameter\_group\_name](#input\_redis\_parameter\_group\_name) | The Elasticache Redis parameter group name. | `string` | `"default.redis3.2"` | no |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | <a name="input_remote_state_infra_monitoring_key_stack"></a> [remote\_state\_infra\_monitoring\_key\_stack](#input\_remote\_state\_infra\_monitoring\_key\_stack) | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_networking_key_stack"></a> [remote\_state\_infra\_networking\_key\_stack](#input\_remote\_state\_infra\_networking\_key\_stack) | Override infra\_networking remote state path | `string` | `""` | no |

--- a/terraform/projects/app-backend-redis/main.tf
+++ b/terraform/projects/app-backend-redis/main.tf
@@ -53,6 +53,12 @@ variable "redis_engine_version" {
   default     = "3.2.10"
 }
 
+variable "redis_parameter_group_name" {
+  type        = "string"
+  description = "The Elasticache Redis parameter group name."
+  default     = "default.redis3.2"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -79,15 +85,16 @@ resource "aws_route53_record" "service_record" {
 }
 
 module "backend_redis_cluster" {
-  source                  = "../../modules/aws/elasticache_redis_cluster"
-  enable_clustering       = "${var.enable_clustering}"
-  name                    = "${var.stackname}-backend-redis"
-  default_tags            = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend-redis")}"
-  subnet_ids              = "${data.terraform_remote_state.infra_networking.private_subnet_elasticache_ids}"
-  security_group_ids      = ["${data.terraform_remote_state.infra_security_groups.sg_backend-redis_id}"]
-  elasticache_node_type   = "${var.instance_type}"
-  elasticache_node_number = "${var.node_number}"
-  redis_engine_version    = "${var.redis_engine_version}"
+  source                     = "../../modules/aws/elasticache_redis_cluster"
+  enable_clustering          = "${var.enable_clustering}"
+  name                       = "${var.stackname}-backend-redis"
+  default_tags               = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "backend-redis")}"
+  subnet_ids                 = "${data.terraform_remote_state.infra_networking.private_subnet_elasticache_ids}"
+  security_group_ids         = ["${data.terraform_remote_state.infra_security_groups.sg_backend-redis_id}"]
+  elasticache_node_type      = "${var.instance_type}"
+  elasticache_node_number    = "${var.node_number}"
+  redis_engine_version       = "${var.redis_engine_version}"
+  redis_parameter_group_name = "${var.redis_parameter_group_name}"
 }
 
 module "alarms-elasticache-backend-redis" {


### PR DESCRIPTION
This was incorrectly ommitted when setting redis_engine_version in
a previous commit - we need to update both the parameter group name
and the engine version name at the same time.