### PR TITLE
Output role names and ARNs for roles created via gds_user_role module

### DIFF
--- a/terraform/modules/aws/iam/gds_user_role/README.md
+++ b/terraform/modules/aws/iam/gds_user_role/README.md
@@ -38,4 +38,6 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_roles_and_arns"></a> [roles\_and\_arns](#output\_roles\_and\_arns) | Map of '$username-$role' to role ARN. e.g. {'joe.bloggs-admin': 'arn:aws:iam::123467890123:role/joe.bloggs-admin'} |

--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -84,6 +84,9 @@ Infrastructure security settings:
 
 | Name | Description |
 |------|-------------|
+| <a name="output_admin_roles_and_arns"></a> [admin\_roles\_and\_arns](#output\_admin\_roles\_and\_arns) | Map of '$username-admin' to role ARN, for the *-admin roles. e.g. {'joe.bloggs-admin': 'arn:aws:iam::123467890123:role/joe.bloggs-admin'} |
 | <a name="output_licensify_documentdb_kms_key_arn"></a> [licensify\_documentdb\_kms\_key\_arn](#output\_licensify\_documentdb\_kms\_key\_arn) | The ARN of the Licensify DocumentDB KMS key |
+| <a name="output_poweruser_roles_and_arns"></a> [poweruser\_roles\_and\_arns](#output\_poweruser\_roles\_and\_arns) | Map of '$username-poweruser' to role ARN, for the *-poweruser roles. e.g. {'joe.bloggs-poweruser': 'arn:aws:iam::123467890123:role/joe.bloggs-poweruser'} |
 | <a name="output_shared_documentdb_kms_key_arn"></a> [shared\_documentdb\_kms\_key\_arn](#output\_shared\_documentdb\_kms\_key\_arn) | The ARN of the Shared DocumentDB KMS key |
 | <a name="output_sops_kms_key_arn"></a> [sops\_kms\_key\_arn](#output\_sops\_kms\_key\_arn) | The ARN of the Sops KMS key |
+| <a name="output_user_roles_and_arns"></a> [user\_roles\_and\_arns](#output\_user\_roles\_and\_arns) | Map of '$username-user' to role ARN, for the *-user roles. e.g. {'joe.bloggs-user': 'arn:aws:iam::123467890123:role/joe.bloggs-user'} |

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -419,6 +419,21 @@ resource "aws_kms_key" "shared_documentdb" {
 # Outputs
 # --------------------------------------------------------------
 
+output "admin_roles_and_arns" {
+  value       = module.gds_role_admin.roles_and_arns
+  description = "Map of '$username-admin' to role ARN, for the *-admin roles. e.g. {'joe.bloggs-admin': 'arn:aws:iam::123467890123:role/joe.bloggs-admin'}"
+}
+
+output "poweruser_roles_and_arns" {
+  value       = module.gds_role_poweruser.roles_and_arns
+  description = "Map of '$username-poweruser' to role ARN, for the *-poweruser roles. e.g. {'joe.bloggs-poweruser': 'arn:aws:iam::123467890123:role/joe.bloggs-poweruser'}"
+}
+
+output "user_roles_and_arns" {
+  value       = module.gds_role_user.roles_and_arns
+  description = "Map of '$username-user' to role ARN, for the *-user roles. e.g. {'joe.bloggs-user': 'arn:aws:iam::123467890123:role/joe.bloggs-user'}"
+}
+
 output "sops_kms_key_arn" {
   value       = aws_kms_key.sops.arn
   description = "The ARN of the Sops KMS key"


### PR DESCRIPTION
This PR updates the `gds_user_role` module to output a map containing the role name and role ARN for each created role.

For example, creating a role of `*-admin` will output all of the generated role names and ARNs in a map of the format:

```
{
  ...,

  'joe.bloggs-admin': 'arn:aws:iam::123467890123:role/joe.bloggs-admin',

  ...,
}
```

This is being used in `infra-security` to output the role names and ARNs when creating `admin`, `poweruser` and `user` roles, allowing us to use this when creating resources elsewhere, such as in our new EKS cluster.