### PR TITLE
Fix a dependency ordering issue between datascience IAM resources.

### DIFF
--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -47,7 +47,6 @@ Infrastructure security settings:
 | [aws_iam_policy.pass_step_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.event_bridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.role_step_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.datascience_pass_step_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.event_bridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.role_step_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_key_pair.govuk-infra-key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -190,7 +190,7 @@ module "role_datascienceuser" {
   source           = "../../modules/aws/iam/role_user"
   role_name        = "govuk-datascienceusers"
   role_user_arns   = var.role_datascienceuser_user_arns
-  role_policy_arns = var.role_datascienceuser_policy_arns
+  role_policy_arns = concat(var.role_datascienceuser_policy_arns, [aws_iam_policy.pass_step_function.arn])
 }
 
 resource "aws_iam_role" "role_step_function" {
@@ -229,11 +229,6 @@ resource "aws_iam_policy" "pass_step_function" {
   name        = "govuk-pass-step-function-role"
   description = "Allows user to assign step function role to a new step function"
   policy      = data.aws_iam_policy_document.pass_step_function.json
-}
-
-resource "aws_iam_role_policy_attachment" "datascience_pass_step_function" {
-  role       = "govuk-datascienceusers"
-  policy_arn = aws_iam_policy.pass_step_function.arn
 }
 
 resource "aws_iam_role" "event_bridge" {


### PR DESCRIPTION
A policy attachment was referring to a role created in the same TF module by name, defeating TF's ability to infer the dependency and causing first-time apply to fail.

Instead of duplicating the policy name, refer to it by ARN so that the graph can be inferred correctly.

Fixes #1466.

TF plan in integration:

      # aws_iam_role_policy_attachment.datascience_pass_step_function will be destroyed
      - resource "aws_iam_role_policy_attachment" "datascience_pass_step_function" {
          - id         = "govuk-datascienceusers-20210813..." -> null
          - policy_arn = "arn:aws:iam::...:policy/govuk-pass-step-function-role" -> null
          - role       = "govuk-datascienceusers" -> null
        }

      # module.role_datascienceuser.aws_iam_role_policy_attachment.user_policy_attachment[8] will be created
      + resource "aws_iam_role_policy_attachment" "user_policy_attachment" {
          + id         = (known after apply)
          + policy_arn = "arn:aws:iam::...:policy/govuk-pass-step-function-role"
          + role       = "govuk-datascienceusers"
        }

    Plan: 1 to add, 0 to change, 1 to destroy.

#### Alternatives considered

The (pre-existing) use of count() here is not ideal because when inserting/removing a list item, all the subsequent items will be renumbered and therefore TF will delete and re-create them. In practice this is probably tolerable since the outage would normally only last a few seconds during apply, but when it fails mid-way it can sometimes be tedious to recover from. An alternative in this case would be to keep the separate `aws_iam_role_policy_attachment` resource and have module.role_datascienceuser return the `role_name` as an output so that policy attachments in the parent module can refer to it. I don't think this is worth doing here though, because all the other IAM stuff here already uses the count() approach so we'd be introducing inconsistency unless we refactored all the existing stuff.