### PR TITLE
Add backend config for infra-root-dns-zones in test account.

### DIFF
--- a/terraform/projects/infra-root-dns-zones/test.govuk.backend
+++ b/terraform/projects/infra-root-dns-zones/test.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-test"
+key     = "govuk/infra-root-dns-zones.tfstate"
+encrypt = true
+region  = "eu-west-1"


### PR DESCRIPTION
The outputs from this module are needed in order to keep the new [govuk-infrastructure](https://github.com/alphagov/govuk-infrastructure) Terraform DRY.

Requires alphagov/govuk-aws-data#918.

[Trello card](https://trello.com/c/hqCr1ozs/625)

Tested: already applied, produced no diff and generated the expected outputs to match the existing zones in the test account.

```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

external_root_domain_name = test.govuk.digital.
external_root_zone_id = (redacted)
internal_root_dns_validation_zone_id = (redacted)
internal_root_domain_name = test.govuk-internal.digital.
internal_root_zone_id = (redacted)
```