### PR TITLE
fix GitHub IP range returning IPv6

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -9,7 +9,7 @@ Manage the security groups for the entire infrastructure
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 0.11.15 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 2.46.0 |
 | <a name="requirement_fastly"></a> [fastly](#requirement\_fastly) | ~> 0.26.0 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 4.9.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 4.14.0 |
 
 ## Providers
 
@@ -17,7 +17,7 @@ Manage the security groups for the entire infrastructure
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 2.46.0 |
 | <a name="provider_fastly"></a> [fastly](#provider\_fastly) | ~> 0.26.0 |
-| <a name="provider_github"></a> [github](#provider\_github) | ~> 4.9.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 4.14.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/terraform/projects/infra-security-groups/ci-master.tf
+++ b/terraform/projects/infra-security-groups/ci-master.tf
@@ -92,7 +92,7 @@ resource "aws_security_group_rule" "ci-master-elb_ingress_github_https" {
   protocol  = "tcp"
 
   security_group_id = "${aws_security_group.ci-master_elb.id}"
-  cidr_blocks       = ["${data.github_ip_ranges.github.hooks}"]
+  cidr_blocks       = ["${data.github_ip_ranges.github.hooks_ipv4}"]
 }
 
 resource "aws_security_group_rule" "ci-master-elb_egress_any_any" {

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -30,7 +30,7 @@ provider "fastly" {
 }
 
 provider "github" {
-  version = "~> 4.9.0"
+  version = "~> 4.14.0"
 }
 
 data "fastly_ip_ranges" "fastly" {}


### PR DESCRIPTION
Fix GitHub IP Ranges Returning IPv6
The GitHub provider is returning IPv6 IPs in addition to IPv4
IPs for the hooks. This is not compatible with AWS security
rules which require IPv4 and IPv6 IPs to be seperate.

This is a [fixed bug](integrations/terraform-provider-github#883)
in 4.14 version of the provider.