### PR TITLE
Increase backend-public ALB timeout to 400 seconds

### DIFF
--- a/terraform/modules/aws/lb/README.md
+++ b/terraform/modules/aws/lb/README.md
@@ -78,6 +78,7 @@ No modules.
 | <a name="input_httpcode_elb_5xx_count_threshold"></a> [httpcode\_elb\_5xx\_count\_threshold](#input\_httpcode\_elb\_5xx\_count\_threshold) | The value against which the HTTPCode\_ELB\_5XX\_Count metric is compared. | `string` | `"80"` | no |
 | <a name="input_httpcode_target_4xx_count_threshold"></a> [httpcode\_target\_4xx\_count\_threshold](#input\_httpcode\_target\_4xx\_count\_threshold) | The value against which the HTTPCode\_Target\_4XX\_Count metric is compared. | `string` | `"0"` | no |
 | <a name="input_httpcode_target_5xx_count_threshold"></a> [httpcode\_target\_5xx\_count\_threshold](#input\_httpcode\_target\_5xx\_count\_threshold) | The value against which the HTTPCode\_Target\_5XX\_Count metric is compared. | `string` | `"80"` | no |
+| <a name="input_idle_timeout"></a> [idle\_timeout](#input\_idle\_timeout) | The time in seconds that the connection is allowed to be idle. | `string` | `"60"` | no |
 | <a name="input_internal"></a> [internal](#input\_internal) | If true, the LB will be internal. | `string` | `true` | no |
 | <a name="input_listener_action"></a> [listener\_action](#input\_listener\_action) | A map of Load Balancer Listener and default target group action, both specified as PROTOCOL:PORT. | `map` | n/a | yes |
 | <a name="input_listener_certificate_domain_name"></a> [listener\_certificate\_domain\_name](#input\_listener\_certificate\_domain\_name) | HTTPS Listener certificate domain name. | `string` | `""` | no |

--- a/terraform/modules/aws/lb/main.tf
+++ b/terraform/modules/aws/lb/main.tf
@@ -51,6 +51,12 @@ variable "load_balancer_type" {
   default     = "application"
 }
 
+variable "idle_timeout" {
+  type        = "string"
+  description = "The time in seconds that the connection is allowed to be idle."
+  default     = "60"
+}
+
 variable "access_logs_bucket_name" {
   type        = "string"
   description = "The S3 bucket name to store the logs in."
@@ -205,6 +211,7 @@ resource "aws_lb" "lb" {
   security_groups    = ["${var.security_groups}"]
   subnets            = ["${var.subnets}"]
   load_balancer_type = "${var.load_balancer_type}"
+  idle_timeout       = "${var.idle_timeout}"
 
   access_logs {
     enabled = true

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -669,6 +669,7 @@ module "backend_public_lb" {
   security_groups                            = ["${data.terraform_remote_state.infra_security_groups.sg_backend_elb_external_id}"]
   alarm_actions                              = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
   default_tags                               = "${map("Project", var.stackname, "aws_migration", "backend", "aws_environment", var.aws_environment)}"
+  idle_timeout                               = 400
 }
 
 resource "aws_wafregional_web_acl_association" "backend_public_lb" {


### PR DESCRIPTION
This was set at 60 seconds, which was too low for some queries to `hmrc-manuals-api`, therefore increasing to be consistent with other load balancers.

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4712404)