### PR TITLE
Automatically replace unhealthy Apt instances

### DIFF
--- a/terraform/modules/aws/node_group/main.tf
+++ b/terraform/modules/aws/node_group/main.tf
@@ -116,6 +116,12 @@ variable "asg_health_check_grace_period" {
   default     = "60"
 }
 
+variable "asg_health_check_type" {
+  type        = "string"
+  description = "Controls how health checking is done. Permitted values: EC2 or ELB."
+  default     = "EC2"
+}
+
 variable "asg_desired_capacity" {
   type        = "string"
   description = "The autoscaling groups desired capacity"
@@ -330,7 +336,7 @@ resource "aws_autoscaling_group" "node_autoscaling_group" {
   min_size                  = "${var.asg_min_size}"
   max_size                  = "${var.asg_max_size}"
   health_check_grace_period = "${var.asg_health_check_grace_period}"
-  health_check_type         = "EC2"
+  health_check_type         = "${var.asg_health_check_type}"
   force_delete              = false
   wait_for_capacity_timeout = 0
   launch_configuration      = "${local.launch_configuration_name}"

--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -192,6 +192,11 @@ resource "aws_route53_record" "gemstash_external_service_record" {
 module "apt" {
   source                            = "../../modules/aws/node_group"
   name                              = "${var.stackname}-apt"
+  asg_health_check_grace_period     = "300"
+  asg_health_check_type             = "ELB"
+  asg_desired_capacity              = "2"
+  asg_max_size                      = "3"
+  asg_min_size                      = "2"
   default_tags                      = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "apt", "aws_hostname", "apt-1")}"
   instance_subnet_ids               = "${matchkeys(values(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), keys(data.terraform_remote_state.infra_networking.private_subnet_names_ids_map), list(var.apt_1_subnet))}"
   instance_security_group_ids       = ["${data.terraform_remote_state.infra_security_groups.sg_apt_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]


### PR DESCRIPTION
This changes the health check type to ELB for the Apt autoscaling group, and increases the `asg_max_size` to 3.

The effect of this will be that apt instances will be deregistered from the ASG and replaced when their ELB
health checks fail.

I have also increased the grace period for a new instance to 5 minutes as this instance may take a while to start.