### PR TITLE
Set a two-year expiration time on the GOV.UK accounts backup

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/main.tf
+++ b/terraform/projects/infra-database-backups-bucket/main.tf
@@ -256,6 +256,28 @@ resource "aws_s3_bucket" "database_backups" {
       days = 365
     }
   }
+
+  # Lifecycle rule for GOV.UK accounts (pre digital identity) backup
+
+  lifecycle_rule {
+    id      = "govuk_accounts_pre_digital_identity_lifecycle_rule"
+    prefix  = "govuk-accounts-pre-digital-identity/"
+    enabled = true
+
+    transition {
+      storage_class = "STANDARD_IA"
+      days          = "${var.standard_s3_storage_time}"
+    }
+
+    transition {
+      storage_class = "GLACIER"
+      days          = "${var.glacier_storage_time}"
+    }
+
+    expiration {
+      days = 730
+    }
+  }
   versioning {
     enabled = true
   }


### PR DESCRIPTION
We've taken a snapshot of the account-manager[1] and
attribute-service[2] databases before terminating the apps.  This is
in case we need to refer to any historic data (most likely the audit
log in the security_activities table, which didn't get migrated to
Digital Identity). We've said in our privacy policy that we keep user
data for two years, so we should get rid of the data at that point.

[1] https://github.com/alphagov/govuk-account-manager-prototype
[2] https://github.com/alphagov/govuk-attribute-service-prototype

---

[Plan](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1650/console)

[Trello card](https://trello.com/c/OcGZ4Wys/1124-take-snapshots-of-the-pre-migration-databases)