### PR TITLE
Use cheaper and faster gp3 storage for CI agent EBS volumes.

### DIFF
--- a/terraform/projects/app-ci-agents/README.md
+++ b/terraform/projects/app-ci-agents/README.md
@@ -108,7 +108,10 @@ CI agents
 | <a name="input_ci_agent_6_subnet"></a> [ci\_agent\_6\_subnet](#input\_ci\_agent\_6\_subnet) | subnet to deploy EC2 and EBS of CI agent 6 | `string` | `"govuk_private_c"` | no |
 | <a name="input_ci_agent_7_subnet"></a> [ci\_agent\_7\_subnet](#input\_ci\_agent\_7\_subnet) | subnet to deploy EC2 and EBS of CI agent 7 | `string` | `"govuk_private_a"` | no |
 | <a name="input_ci_agent_8_subnet"></a> [ci\_agent\_8\_subnet](#input\_ci\_agent\_8\_subnet) | subnet to deploy EC2 and EBS of CI agent 8 | `string` | `"govuk_private_b"` | no |
+| <a name="input_data_block_device_volume_size"></a> [data\_block\_device\_volume\_size](#input\_data\_block\_device\_volume\_size) | Size of the data volume in GB | `string` | `"130"` | no |
+| <a name="input_docker_block_device_volume_size"></a> [docker\_block\_device\_volume\_size](#input\_docker\_block\_device\_volume\_size) | Size of the Docker volume in GB | `string` | `"130"` | no |
 | <a name="input_ebs_encrypted"></a> [ebs\_encrypted](#input\_ebs\_encrypted) | whether or not the EBS volume is encrypted | `string` | `"true"` | no |
+| <a name="input_ebs_volume_type"></a> [ebs\_volume\_type](#input\_ebs\_volume\_type) | Volume type to use for data and Docker EBS volumes; see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html | `string` | `"gp3"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.2xlarge"` | no |

--- a/terraform/projects/app-ci-agents/main.tf
+++ b/terraform/projects/app-ci-agents/main.tf
@@ -58,6 +58,24 @@ variable "root_block_device_volume_size" {
   default     = "50"
 }
 
+variable "data_block_device_volume_size" {
+  type        = "string"
+  description = "Size of the data volume in GB"
+  default     = "130"
+}
+
+variable "docker_block_device_volume_size" {
+  type        = "string"
+  description = "Size of the Docker volume in GB"
+  default     = "130"
+}
+
+variable "ebs_volume_type" {
+  type        = "string"
+  description = "Volume type to use for data and Docker EBS volumes; see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html"
+  default     = "gp3"
+}
+
 variable "ebs_encrypted" {
   type        = "string"
   description = "whether or not the EBS volume is encrypted"
@@ -211,8 +229,8 @@ module "ci-agent-1" {
 resource "aws_ebs_volume" "ci-agent-1-data" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_1_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.data_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-1-data"
@@ -228,8 +246,8 @@ resource "aws_ebs_volume" "ci-agent-1-data" {
 resource "aws_ebs_volume" "ci-agent-1-docker" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_1_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.docker_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-1-docker"
@@ -331,8 +349,8 @@ module "ci-agent-2" {
 resource "aws_ebs_volume" "ci-agent-2-data" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_2_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.data_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-2-data"
@@ -348,8 +366,8 @@ resource "aws_ebs_volume" "ci-agent-2-data" {
 resource "aws_ebs_volume" "ci-agent-2-docker" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_2_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.docker_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-2-docker"
@@ -457,8 +475,8 @@ module "ci-agent-3" {
 resource "aws_ebs_volume" "ci-agent-3-data" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_3_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.data_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-3-data"
@@ -474,8 +492,8 @@ resource "aws_ebs_volume" "ci-agent-3-data" {
 resource "aws_ebs_volume" "ci-agent-3-docker" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_3_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.docker_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-3-docker"
@@ -577,8 +595,8 @@ module "ci-agent-4" {
 resource "aws_ebs_volume" "ci-agent-4-data" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_4_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.data_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-4-data"
@@ -594,8 +612,8 @@ resource "aws_ebs_volume" "ci-agent-4-data" {
 resource "aws_ebs_volume" "ci-agent-4-docker" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_4_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.docker_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-4-docker"
@@ -697,8 +715,8 @@ module "ci-agent-5" {
 resource "aws_ebs_volume" "ci-agent-5-data" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_5_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.data_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-5-data"
@@ -714,8 +732,8 @@ resource "aws_ebs_volume" "ci-agent-5-data" {
 resource "aws_ebs_volume" "ci-agent-5-docker" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_5_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.docker_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-5-docker"
@@ -817,8 +835,8 @@ module "ci-agent-6" {
 resource "aws_ebs_volume" "ci-agent-6-data" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_6_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.data_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-6-data"
@@ -834,8 +852,8 @@ resource "aws_ebs_volume" "ci-agent-6-data" {
 resource "aws_ebs_volume" "ci-agent-6-docker" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_6_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.docker_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-6-docker"
@@ -937,8 +955,8 @@ module "ci-agent-7" {
 resource "aws_ebs_volume" "ci-agent-7-data" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_7_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.data_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-7-data"
@@ -954,8 +972,8 @@ resource "aws_ebs_volume" "ci-agent-7-data" {
 resource "aws_ebs_volume" "ci-agent-7-docker" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_7_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.docker_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-7-docker"
@@ -1057,8 +1075,8 @@ module "ci-agent-8" {
 resource "aws_ebs_volume" "ci-agent-8-data" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_8_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.data_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-8-data"
@@ -1074,8 +1092,8 @@ resource "aws_ebs_volume" "ci-agent-8-data" {
 resource "aws_ebs_volume" "ci-agent-8-docker" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.ci_agent_8_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
-  size              = "130"
-  type              = "gp2"
+  size              = "${var.docker_block_device_volume_size}"
+  type              = "${var.ebs_volume_type}"
 
   tags {
     Name            = "${var.stackname}-ci-agent-8-docker"


### PR DESCRIPTION
gp3 is 20% cheaper than gp2 and includes 3000 IOPS at any size instead of 3 IOPS/GB. This should speed up builds at least a bit.

While we're there, define the values once instead of copy-pasting.

The volumes can be upgraded in place without downtime.