### PR TITLE
Change m4 DB instances to m5

### DIFF
--- a/terraform/projects/app-content-data-api-postgresql/README.md
+++ b/terraform/projects/app-content-data-api-postgresql/README.md
@@ -43,7 +43,7 @@ RDS PostgreSQL instance for the Content Data API
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_cloudwatch_log_retention"></a> [cloudwatch\_log\_retention](#input\_cloudwatch\_log\_retention) | Number of days to retain Cloudwatch logs for | `string` | n/a | yes |
-| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for RDS resources | `string` | `"db.m4.large"` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for RDS resources | `string` | `"db.m5.large"` | no |
 | <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Enable multi-az. | `string` | `true` | no |
 | <a name="input_password"></a> [password](#input\_password) | DB password | `string` | n/a | yes |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |

--- a/terraform/projects/app-content-data-api-postgresql/main.tf
+++ b/terraform/projects/app-content-data-api-postgresql/main.tf
@@ -54,7 +54,7 @@ variable "snapshot_identifier" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for RDS resources"
-  default     = "db.m4.large"
+  default     = "db.m5.large"
 }
 
 # Resources

--- a/terraform/projects/app-transition-postgresql/README.md
+++ b/terraform/projects/app-transition-postgresql/README.md
@@ -47,7 +47,7 @@ RDS Transition PostgreSQL Primary instance
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_cloudwatch_log_retention"></a> [cloudwatch\_log\_retention](#input\_cloudwatch\_log\_retention) | Number of days to retain Cloudwatch logs for | `string` | n/a | yes |
-| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for RDS resources | `string` | `"db.m4.large"` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for RDS resources | `string` | `"db.m5.large"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_internal_zone_name"></a> [internal\_zone\_name](#input\_internal\_zone\_name) | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Enable multi-az. | `string` | `true` | no |

--- a/terraform/projects/app-transition-postgresql/main.tf
+++ b/terraform/projects/app-transition-postgresql/main.tf
@@ -64,7 +64,7 @@ variable "internal_domain_name" {
 variable "instance_type" {
   type        = "string"
   description = "Instance type used for RDS resources"
-  default     = "db.m4.large"
+  default     = "db.m5.large"
 }
 
 # Resources


### PR DESCRIPTION
https://trello.com/c/ybS7Dnns/41-upgrade-the-legacy-m4-database-machine-instances

These are being updated because the m4 instance class is legacy and will
not support newer versions of PostgreSQL. So this is a pre-requisite
before the Databases on these instances can be upgraded to newer
versions of PostgreSQL.

As I understand, we don't use a "apply_immediately" flag in our RDS
configuration so this change will take effect during the next
maintenance window - which will be early Monday morning.