### PR TITLE
Make elb_public_secondary_certname optional

### DIFF
--- a/terraform/projects/app-apt/README.md
+++ b/terraform/projects/app-apt/README.md
@@ -56,7 +56,7 @@ Apt node
 | <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | EBS volume size | `string` | `"40"` | no |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
-| <a name="input_elb_public_secondary_certname"></a> [elb\_public\_secondary\_certname](#input\_elb\_public\_secondary\_certname) | The ACM secondary cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_elb_public_secondary_certname"></a> [elb\_public\_secondary\_certname](#input\_elb\_public\_secondary\_certname) | The ACM secondary cert domain name to find the ARN of | `string` | `""` | no |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-apt/main.tf
+++ b/terraform/projects/app-apt/main.tf
@@ -43,6 +43,7 @@ variable "elb_external_certname" {
 variable "elb_public_secondary_certname" {
   type        = "string"
   description = "The ACM secondary cert domain name to find the ARN of"
+  default     = ""
 }
 
 variable "apt_1_subnet" {

--- a/terraform/projects/app-ci-master/README.md
+++ b/terraform/projects/app-ci-master/README.md
@@ -64,7 +64,7 @@ CI Master Node
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of, will be attached to external classic ELB | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of, will be attached to internal classic ELB | `string` | n/a | yes |
 | <a name="input_elb_public_certname"></a> [elb\_public\_certname](#input\_elb\_public\_certname) | The ACM cert domain name to find the ARN of, will be attached to external ALB | `string` | n/a | yes |
-| <a name="input_elb_public_secondary_certname"></a> [elb\_public\_secondary\_certname](#input\_elb\_public\_secondary\_certname) | The ACM secondary cert domain name to find the ARN of, will be attached to external ALB | `string` | n/a | yes |
+| <a name="input_elb_public_secondary_certname"></a> [elb\_public\_secondary\_certname](#input\_elb\_public\_secondary\_certname) | The ACM secondary cert domain name to find the ARN of, will be attached to external ALB | `string` | `""` | no |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-ci-master/main.tf
+++ b/terraform/projects/app-ci-master/main.tf
@@ -48,6 +48,7 @@ variable "elb_public_certname" {
 variable "elb_public_secondary_certname" {
   type        = "string"
   description = "The ACM secondary cert domain name to find the ARN of, will be attached to external ALB"
+  default     = ""
 }
 
 variable "deploy_subnet" {

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -274,7 +274,7 @@ This project adds global resources for app components:
 | <a name="input_elasticsearch6_internal_service_names"></a> [elasticsearch6\_internal\_service\_names](#input\_elasticsearch6\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_elb_public_certname"></a> [elb\_public\_certname](#input\_elb\_public\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_public_internal_certname"></a> [elb\_public\_internal\_certname](#input\_elb\_public\_internal\_certname) | The ACM secondary cert domain name to find the ARN of | `string` | n/a | yes |
-| <a name="input_elb_public_secondary_certname"></a> [elb\_public\_secondary\_certname](#input\_elb\_public\_secondary\_certname) | The ACM secondary cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_elb_public_secondary_certname"></a> [elb\_public\_secondary\_certname](#input\_elb\_public\_secondary\_certname) | The ACM secondary cert domain name to find the ARN of | `string` | `""` | no |
 | <a name="input_email_alert_api_internal_service_names"></a> [email\_alert\_api\_internal\_service\_names](#input\_email\_alert\_api\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_email_alert_api_public_service_names"></a> [email\_alert\_api\_public\_service\_names](#input\_email\_alert\_api\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_enable_lb_app_healthchecks"></a> [enable\_lb\_app\_healthchecks](#input\_enable\_lb\_app\_healthchecks) | Use application specific target groups and healthchecks based on the list of services in the cname variable. | `string` | `false` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -30,6 +30,7 @@ variable "elb_public_certname" {
 variable "elb_public_secondary_certname" {
   type        = "string"
   description = "The ACM secondary cert domain name to find the ARN of"
+  default     = ""
 }
 
 variable "elb_public_internal_certname" {


### PR DESCRIPTION
Making `elb_public_secondary_certname` optional by adding an empty
string as default value. This will allow use to "migrate" from
using 2 certificate to only one certificate on the load balancers.

Ref:
1. [lb secondary cert code](https://github.com/alphagov/govuk-aws/blob/498581043d26e4e4e3474edf5d1718ad735f589f/terraform/modules/aws/lb/main.tf#L196)