### PR TITLE
Configure postgresql-primary and mysql-primary for DMS replication

### DIFF
--- a/terraform/projects/app-mysql/main.tf
+++ b/terraform/projects/app-mysql/main.tf
@@ -127,6 +127,22 @@ resource "aws_db_parameter_group" "mysql-primary" {
     value = 1
   }
 
+  # Configure database for AWS DMS as per: https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
+  parameter {
+    name  = "binlog_checksum"
+    value = "NONE"
+  }
+
+  parameter {
+    name  = "binlog_format"
+    value = "ROW"
+  }
+
+  parameter {
+    name  = "binlog_row_image"
+    value = "Full"
+  }
+
   tags {
     aws_stackname = "${var.stackname}"
   }

--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -126,6 +126,25 @@ resource "aws_db_parameter_group" "postgresql_pg" {
     name  = "log_lock_waits"
     value = true
   }
+
+  # Configure database for AWS DMS as per: https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.PostgreSQL.html#CHAP_Source.PostgreSQL.RDSPostgreSQL.CDC
+  parameter {
+    name         = "rds.logical_replication"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "wal_sender_timeout"
+    value = "0"
+  }
+
+  # AWS DMS process raises an error if this isn't enabled
+  parameter {
+    name         = "shared_preload_libraries"
+    value        = "pglogical"
+    apply_method = "pending-reboot"
+  }
 }
 
 module "postgresql-primary_rds_instance" {


### PR DESCRIPTION
Trello: https://trello.com/c/OFuRPguC/35-investigate-whether-aws-dms-is-a-suitable-tool-for-large-postgresql-databases

This applies the configuration that AWS suggest (and what I've been using in the test environment) to our multi-tenant RDS instances so that they can be used as source database endpoints for DMS (Database Migration Service). The intention is to use this to start experiments migrating some of the bigger databases we host to gain confidence that this will be successful in production as a tool to minimise user downtime.

The PostgreSQL change is going to require a reboot to take effect and the MySQL one requires an additional manual query to be run.

More details in the commits.