### PR TITLE
Allow specifying RDS engine parameter group family

### DIFF
--- a/terraform/projects/app-govuk-rds/rds.tf
+++ b/terraform/projects/app-govuk-rds/rds.tf
@@ -9,7 +9,7 @@ resource "aws_db_parameter_group" "engine_params" {
   for_each = var.databases
 
   name_prefix = "${each.value.name}-${each.value.engine}-"
-  family      = "${each.value.engine}${each.value.engine_version}"
+  family      = merge({ engine_params_family = "${each.value.engine}${each.value.engine_version}" }, each.value)["engine_params_family"]
 
   dynamic "parameter" {
     for_each = each.value.engine_params


### PR DESCRIPTION
"${engine}${version}" works for postgres, as the family name is
"postgres13", but it doesn't work for mysql, as the family name is
"mysql8.0" rather than "mysql8".

---

[Trello card](https://trello.com/c/rB7CoPoG/42-terraform-up-all-the-new-rds-instances-and-db-admin-ec2-instances)