### PR TITLE
Fix references to new RDS security groups

### DIFF
--- a/terraform/projects/app-account/main.tf
+++ b/terraform/projects/app-account/main.tf
@@ -174,7 +174,7 @@ resource "aws_security_group_rule" "account-api-rds_ingress_account_postgres" {
   to_port   = 5432
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.account-api-rds[0].id}"
+  security_group_id        = "${data.aws_security_group.account-api-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_account_id}"
 }
 

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -202,7 +202,7 @@ resource "aws_security_group_rule" "collections-publisher-rds_ingress_backend_my
   to_port   = 3306
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.collections-publisher-rds.id}"
+  security_group_id        = "${data.aws_security_group.collections-publisher-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_backend_id}"
 }
 
@@ -220,7 +220,7 @@ resource "aws_security_group_rule" "contacts-admin-rds_ingress_backend_mysql" {
   to_port   = 3306
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.contacts-admin-rds.id}"
+  security_group_id        = "${data.aws_security_group.contacts-admin-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_backend_id}"
 }
 
@@ -238,7 +238,7 @@ resource "aws_security_group_rule" "content-data-admin-rds_ingress_backend_postg
   to_port   = 5432
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.content-data-admin-rds.id}"
+  security_group_id        = "${data.aws_security_group.content-data-admin-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_backend_id}"
 }
 
@@ -256,7 +256,7 @@ resource "aws_security_group_rule" "content-publisher-rds_ingress_backend_postgr
   to_port   = 5432
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.content-publisher-rds.id}"
+  security_group_id        = "${data.aws_security_group.content-publisher-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_backend_id}"
 }
 
@@ -274,7 +274,7 @@ resource "aws_security_group_rule" "content-tagger-rds_ingress_backend_postgres"
   to_port   = 5432
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.content-tagger-rds.id}"
+  security_group_id        = "${data.aws_security_group.content-tagger-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_backend_id}"
 }
 
@@ -292,7 +292,7 @@ resource "aws_security_group_rule" "link-checker-api-rds_ingress_backend_postgre
   to_port   = 5432
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.link-checker-api-rds.id}"
+  security_group_id        = "${data.aws_security_group.link-checker-api-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_backend_id}"
 }
 
@@ -310,7 +310,7 @@ resource "aws_security_group_rule" "local-links-manager-rds_ingress_backend_post
   to_port   = 5432
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.local-links-manager-rds.id}"
+  security_group_id        = "${data.aws_security_group.local-links-manager-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_backend_id}"
 }
 
@@ -328,7 +328,7 @@ resource "aws_security_group_rule" "release-rds_ingress_backend_mysql" {
   to_port   = 3306
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.release-rds.id}"
+  security_group_id        = "${data.aws_security_group.release-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_backend_id}"
 }
 
@@ -346,7 +346,7 @@ resource "aws_security_group_rule" "search-admin-rds_ingress_backend_mysql" {
   to_port   = 3306
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.search-admin-rds.id}"
+  security_group_id        = "${data.aws_security_group.search-admin-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_backend_id}"
 }
 
@@ -364,7 +364,7 @@ resource "aws_security_group_rule" "service-manual-publisher-rds_ingress_backend
   to_port   = 5432
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.service-manual-publisher-rds.id}"
+  security_group_id        = "${data.aws_security_group.service-manual-publisher-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_backend_id}"
 }
 
@@ -382,7 +382,7 @@ resource "aws_security_group_rule" "signon-rds_ingress_backend_mysql" {
   to_port   = 3306
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.signon-rds.id}"
+  security_group_id        = "${data.aws_security_group.signon-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_backend_id}"
 }
 
@@ -400,7 +400,7 @@ resource "aws_security_group_rule" "support-api-rds_ingress_backend_postgres" {
   to_port   = 5432
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.support-api-rds.id}"
+  security_group_id        = "${data.aws_security_group.support-api-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_backend_id}"
 }
 

--- a/terraform/projects/app-ckan/main.tf
+++ b/terraform/projects/app-ckan/main.tf
@@ -284,7 +284,7 @@ resource "aws_security_group_rule" "ckan-rds_ingress_ckan_postgres" {
   to_port   = 5432
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.ckan-rds.id}"
+  security_group_id        = "${data.aws_security_group.ckan-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_ckan_id}"
 }
 

--- a/terraform/projects/app-data-science-data/main.tf
+++ b/terraform/projects/app-data-science-data/main.tf
@@ -226,6 +226,6 @@ resource "aws_security_group_rule" "publishing-api-rds_ingress_data-science-data
   to_port   = 5432
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.publishing-api-rds.id}"
+  security_group_id        = "${data.aws_security_group.publishing-api-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_data-science-data_id}"
 }

--- a/terraform/projects/app-data-science-data/main.tf
+++ b/terraform/projects/app-data-science-data/main.tf
@@ -215,7 +215,7 @@ resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-down" {
 data "aws_security_group" "publishing-api-rds" {
   count = "${var.use_split_database}"
 
-  name = "${var.stackname}_publishing-api_rds_access"
+  name = "blue_publishing-api_rds_access"
 }
 
 resource "aws_security_group_rule" "publishing-api-rds_ingress_data-science-data_postgres" {

--- a/terraform/projects/app-email-alert-api/main.tf
+++ b/terraform/projects/app-email-alert-api/main.tf
@@ -174,7 +174,7 @@ resource "aws_security_group_rule" "email-alert-api-rds_ingress_email-alert-api_
   to_port   = 5432
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.email-alert-api-rds.id}"
+  security_group_id        = "${data.aws_security_group.email-alert-api-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_email-alert-api_id}"
 }
 

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -300,7 +300,7 @@ resource "aws_security_group_rule" "publishing-api-rds_ingress_publishing-api_po
   to_port   = 5432
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.publishing-api-rds.id}"
+  security_group_id        = "${data.aws_security_group.publishing-api-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_publishing-api_id}"
 }
 

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -197,7 +197,7 @@ resource "aws_security_group_rule" "whitehall-rds_ingress_whitehall-backend_mysq
   to_port   = 3306
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.whitehall-rds.id}"
+  security_group_id        = "${data.aws_security_group.whitehall-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_whitehall-backend_id}"
 }
 

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -174,7 +174,7 @@ resource "aws_security_group_rule" "whitehall-rds_ingress_whitehall-frontend_mys
   to_port   = 3306
   protocol  = "tcp"
 
-  security_group_id        = "${aws_security_group.whitehall-rds.id}"
+  security_group_id        = "${data.aws_security_group.whitehall-rds.0.id}"
   source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_whitehall-frontend_id}"
 }
 


### PR DESCRIPTION
Incorrect syntax for the old version of terraform + the stackname for app-data-science-data.

Plans:

- [app-account](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1887/console)
- [app-backend](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1888/console)
- [app-ckan](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1889/console)
- [app-data-science-data](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1897/console)
- [app-email-alert-api](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1892/console)
- [app-publishing-api](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1893/console)
- [app-whitehall-backend](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1894/console)
- [app-whitehall-frontend](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/1895/console)

---

[Trello card](https://trello.com/c/rB7CoPoG/42-terraform-up-all-the-new-rds-instances-and-db-admin-ec2-instances)