### PR TITLE
Do not set snapshot identifier for RDS instances

### DIFF
--- a/terraform/projects/app-govuk-rds/rds.tf
+++ b/terraform/projects/app-govuk-rds/rds.tf
@@ -41,7 +41,6 @@ resource "aws_db_instance" "instance" {
   backup_retention_period = var.backup_retention_period
   backup_window           = var.backup_window
   copy_tags_to_snapshot   = true
-  snapshot_identifier     = "${each.value.name}-snapshot"
   monitoring_interval     = 60
   monitoring_role_arn     = data.terraform_remote_state.infra_monitoring.outputs.rds_enhanced_monitoring_role_arn
   vpc_security_group_ids  = [aws_security_group.rds[each.key].id]


### PR DESCRIPTION
This is the name of the snapshot to create the database from - not, as
I thought, the name it'll use to create snapshots.  We're not creating
these databases from snapshots, so creation is failing because they
don't exist.

---

[Trello card](https://trello.com/c/rB7CoPoG/42-terraform-up-all-the-new-rds-instances-and-db-admin-ec2-instances)