### PR TITLE
Add scale learn to rank ASG policy to Jenkins

### DIFF
--- a/terraform/projects/app-deploy/README.md
+++ b/terraform/projects/app-deploy/README.md
@@ -35,6 +35,7 @@ Deploy node
 | [aws_iam_role_policy_attachment.allow_reads_from_artefact_bucket](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.allow_writes_from_artefact_bucket](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.deploy_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.learn_to_rank_jenkins](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.related_links_jenkins](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_route53_record.service_record](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.service_record_internal](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
@@ -44,6 +45,7 @@ Deploy node
 | [aws_route53_zone.external](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/route53_zone) | data source |
 | [aws_route53_zone.internal](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/route53_zone) | data source |
 | [terraform_remote_state.app_related_links](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.app_search](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.artefact_bucket](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_monitoring](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_networking](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -70,6 +72,7 @@ Deploy node
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_internal_zone_name"></a> [internal\_zone\_name](#input\_internal\_zone\_name) | The name of the Route53 zone that contains internal records | `string` | n/a | yes |
 | <a name="input_remote_state_app_related_links_key_stack"></a> [remote\_state\_app\_related\_links\_key\_stack](#input\_remote\_state\_app\_related\_links\_key\_stack) | Override app\_related\_links remote state path | `string` | `""` | no |
+| <a name="input_remote_state_app_search_key_stack"></a> [remote\_state\_app\_search\_key\_stack](#input\_remote\_state\_app\_search\_key\_stack) | Override app\_search remote state path | `string` | `""` | no |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | <a name="input_remote_state_infra_artefact_bucket_key_stack"></a> [remote\_state\_infra\_artefact\_bucket\_key\_stack](#input\_remote\_state\_infra\_artefact\_bucket\_key\_stack) | Override infra\_artefact\_bucket remote state path | `string` | `""` | no |
 | <a name="input_remote_state_infra_monitoring_key_stack"></a> [remote\_state\_infra\_monitoring\_key\_stack](#input\_remote\_state\_infra\_monitoring\_key\_stack) | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -292,6 +292,11 @@ resource "aws_iam_role_policy_attachment" "related_links_jenkins" {
   policy_arn = "${data.terraform_remote_state.app_related_links.policy_related_links_jenkins_policy_arn}"
 }
 
+resource "aws_iam_role_policy_attachment" "learn_to_rank_jenkins" {
+  role       = "${module.deploy.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.app_search.scale_learntorank_asg_policy_arn}"
+}
+
 locals {
   elb_httpcode_backend_5xx_threshold = "${var.create_external_elb ? 50 : 0}"
   elb_httpcode_elb_5xx_threshold     = "${var.create_external_elb ? 50 : 0}"

--- a/terraform/projects/app-deploy/remote_state.tf
+++ b/terraform/projects/app-deploy/remote_state.tf
@@ -17,6 +17,12 @@ variable "remote_state_app_related_links_key_stack" {
   default     = ""
 }
 
+variable "remote_state_app_search_key_stack" {
+  type        = "string"
+  description = "Override app_search remote state path"
+  default     = ""
+}
+
 variable "remote_state_infra_vpc_key_stack" {
   type        = "string"
   description = "Override infra_vpc remote state path"
@@ -55,6 +61,16 @@ variable "remote_state_infra_monitoring_key_stack" {
 
 # Resources
 # --------------------------------------------------------------
+
+data "terraform_remote_state" "app_search" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_app_search_key_stack, var.stackname)}/app-search.tfstate"
+    region = "${var.aws_region}"
+  }
+}
 
 data "terraform_remote_state" "app_related_links" {
   backend = "s3"

--- a/terraform/projects/app-search/README.md
+++ b/terraform/projects/app-search/README.md
@@ -100,5 +100,6 @@ Search application servers
 |------|-------------|
 | <a name="output_ecr_repository_url"></a> [ecr\_repository\_url](#output\_ecr\_repository\_url) | URL of the ECR repository |
 | <a name="output_ltr_role_arn"></a> [ltr\_role\_arn](#output\_ltr\_role\_arn) | LTR role ARN |
+| <a name="output_scale_learntorank_asg_policy_arn"></a> [scale\_learntorank\_asg\_policy\_arn](#output\_scale\_learntorank\_asg\_policy\_arn) | ARN of the policy used by to scale the ASG for learn to rank |
 | <a name="output_search_elb_dns_name"></a> [search\_elb\_dns\_name](#output\_search\_elb\_dns\_name) | DNS name to access the search service |
 | <a name="output_service_dns_name"></a> [service\_dns\_name](#output\_service\_dns\_name) | DNS name to access the node service |

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -569,6 +569,11 @@ output "service_dns_name" {
   description = "DNS name to access the node service"
 }
 
+output "scale_learntorank_asg_policy_arn" {
+  value       = "${aws_iam_policy.scale-learntorank-generation-asg-policy.arn}"
+  description = "ARN of the policy used by to scale the ASG for learn to rank"
+}
+
 output "ltr_role_arn" {
   value       = "${aws_iam_role.learntorank.arn}"
   description = "LTR role ARN"


### PR DESCRIPTION
This give Jenkins IAM permissions to scale the Search API's learn to rank autoscaling group. This is need for the Jenkins job to train and deploy a new learn to rank model.