### PR TITLE
Add Jenkins ssh ingress SG rule for LTR ASG instances

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -538,6 +538,7 @@ No modules.
 | [aws_security_group_rule.search-elb_ingress_management_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.search-ltr-generation_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.search-ltr-generation_ingress_concourse_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.search-ltr-generation_ingress_jenkins_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.search_ingress_search-elb_http](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.shared-documentdb_ingress_backend_asset_manager](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.shared-documentdb_ingress_db-admin_mongodb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |

--- a/terraform/projects/infra-security-groups/search-ltr-generation.tf
+++ b/terraform/projects/infra-security-groups/search-ltr-generation.tf
@@ -18,6 +18,16 @@ resource "aws_security_group_rule" "search-ltr-generation_ingress_concourse_ssh"
   security_group_id = "${aws_security_group.search-ltr-generation.id}"
 }
 
+resource "aws_security_group_rule" "search-ltr-generation_ingress_jenkins_ssh" {
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 22
+  to_port                  = 22
+  source_security_group_id = "${aws_security_group.deploy.id}"
+
+  security_group_id = "${aws_security_group.search-ltr-generation.id}"
+}
+
 resource "aws_security_group_rule" "search-ltr-generation_egress_any_any" {
   type        = "egress"
   protocol    = "-1"


### PR DESCRIPTION
This rule enable SSH ingress from the Jenkins (deploy) instance. This is needed as the learn to rank (LTR) Jenkins job needs SSH access into new instances.