### PR TITLE
Correctly set name for new db-admin instances

### DIFF
--- a/terraform/projects/app-govuk-rds/db_admin.tf
+++ b/terraform/projects/app-govuk-rds/db_admin.tf
@@ -184,7 +184,7 @@ resource "aws_autoscaling_group" "node" {
 
   tags = concat(
     [for k, v in local.tags : { key = k, value = v, propagate_at_launch = true }],
-    [{ key = "name", value = "${var.stackname}-govuk-rds-${each.value.name}", propagate_at_launch = true }],
+    [{ key = "Name", value = "${var.stackname}-govuk-rds-${each.value.name}", propagate_at_launch = true }],
     [{ key = "aws_migration", value = "${replace(each.value.name, "-", "_")}_db_admin", propagate_at_launch = true }],
     [{ key = "aws_hostname", value = "${each.value.name}-db-admin-1", propagate_at_launch = true }]
   )


### PR DESCRIPTION
The tag is called "Name" not "name" - this matches the legacy db-admin
machines and the behaviour of the node_group module.  Changing the
tags of one of the new db-admin instances through the AWS console
makes the name show up in the instance list.

[Terraform plan](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2035/console)

---

[Trello card](https://trello.com/c/ZxgxywAY/91-new-db-admin-machines-dont-have-a-name-in-aws-ec2)