### PR TITLE
Update the instance role for LTR instances

### DIFF
--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -372,6 +372,11 @@ data "aws_iam_policy_document" "learntorank-assume-role" {
       type        = "Service"
       identifiers = ["sagemaker.amazonaws.com"]
     }
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
   }
 }
 
@@ -452,7 +457,7 @@ data "aws_iam_policy_document" "ecr-usage" {
 
 resource "aws_iam_instance_profile" "learntorank-generation" {
   name = "govuk-${var.aws_environment}-search-ltr-generation"
-  role = "${module.search.instance_iam_role_name}"
+  role = "${aws_iam_role.learntorank.name}"
 }
 
 resource "aws_key_pair" "learntorank-generation-key" {


### PR DESCRIPTION
This updates the instance role for instances created in the Learn to rank ASG to an existing role with correct permissions for accessing the SageMaker and the relevant S3 buckets.