### PR TITLE
Remove use_split_database variables

### DIFF
--- a/terraform/projects/app-account/README.md
+++ b/terraform/projects/app-account/README.md
@@ -62,7 +62,6 @@ account node
 | <a name="input_remote_state_infra_stack_dns_zones_key_stack"></a> [remote\_state\_infra\_stack\_dns\_zones\_key\_stack](#input\_remote\_state\_infra\_stack\_dns\_zones\_key\_stack) | Override stackname path to infra\_stack\_dns\_zones remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override infra\_vpc remote state path | `string` | `""` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
-| <a name="input_use_split_database"></a> [use\_split\_database](#input\_use\_split\_database) | Set to 1 to use the new split database instances | `string` | `"0"` | no |
 | <a name="input_user_data_snippets"></a> [user\_data\_snippets](#input\_user\_data\_snippets) | List of user-data snippets | `list` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/app-account/main.tf
+++ b/terraform/projects/app-account/main.tf
@@ -52,12 +52,6 @@ variable "instance_type" {
   default     = "m5.xlarge"
 }
 
-variable "use_split_database" {
-  type        = "string"
-  description = "Set to 1 to use the new split database instances"
-  default     = "0"
-}
-
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -161,14 +155,10 @@ module "alarms-elb-account-internal" {
 }
 
 data "aws_security_group" "account-api-rds" {
-  count = "${var.use_split_database}"
-
   name = "${var.stackname}_account-api_rds_access"
 }
 
 resource "aws_security_group_rule" "account-api-rds_ingress_account_postgres" {
-  count = "${var.use_split_database}"
-
   type      = "ingress"
   from_port = 5432
   to_port   = 5432

--- a/terraform/projects/app-backend/README.md
+++ b/terraform/projects/app-backend/README.md
@@ -90,8 +90,6 @@ Backend node
 | <a name="input_renamed_app_service_records_alb"></a> [renamed\_app\_service\_records\_alb](#input\_renamed\_app\_service\_records\_alb) | List of renamed application service names that get traffic via internal alb | `list` | `[]` | no |
 | <a name="input_rules_for_existing_target_groups"></a> [rules\_for\_existing\_target\_groups](#input\_rules\_for\_existing\_target\_groups) | create an additional rule for a target group already created via rules\_host | `map` | `{}` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
-| <a name="input_use_split_mysql_database"></a> [use\_split\_mysql\_database](#input\_use\_split\_mysql\_database) | Set to 1 to use the new split mysql database instances | `string` | `"0"` | no |
-| <a name="input_use_split_postgres_database"></a> [use\_split\_postgres\_database](#input\_use\_split\_postgres\_database) | Set to 1 to use the new split postgres database instances | `string` | `"0"` | no |
 | <a name="input_user_data_snippets"></a> [user\_data\_snippets](#input\_user\_data\_snippets) | List of user-data snippets | `list` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/app-backend/main.tf
+++ b/terraform/projects/app-backend/main.tf
@@ -76,18 +76,6 @@ variable "rules_for_existing_target_groups" {
   default     = {}
 }
 
-variable "use_split_mysql_database" {
-  type        = "string"
-  description = "Set to 1 to use the new split mysql database instances"
-  default     = "0"
-}
-
-variable "use_split_postgres_database" {
-  type        = "string"
-  description = "Set to 1 to use the new split postgres database instances"
-  default     = "0"
-}
-
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -195,14 +183,10 @@ resource "aws_route53_record" "app_service_records_redirected_public_alb" {
 }
 
 data "aws_security_group" "collections-publisher-rds" {
-  count = "${var.use_split_mysql_database}"
-
   name = "${var.stackname}_collections-publisher_rds_access"
 }
 
 resource "aws_security_group_rule" "collections-publisher-rds_ingress_backend_mysql" {
-  count = "${var.use_split_mysql_database}"
-
   type      = "ingress"
   from_port = 3306
   to_port   = 3306
@@ -213,14 +197,10 @@ resource "aws_security_group_rule" "collections-publisher-rds_ingress_backend_my
 }
 
 data "aws_security_group" "contacts-admin-rds" {
-  count = "${var.use_split_mysql_database}"
-
   name = "${var.stackname}_contacts-admin_rds_access"
 }
 
 resource "aws_security_group_rule" "contacts-admin-rds_ingress_backend_mysql" {
-  count = "${var.use_split_mysql_database}"
-
   type      = "ingress"
   from_port = 3306
   to_port   = 3306
@@ -231,14 +211,10 @@ resource "aws_security_group_rule" "contacts-admin-rds_ingress_backend_mysql" {
 }
 
 data "aws_security_group" "content-data-admin-rds" {
-  count = "${var.use_split_postgres_database}"
-
   name = "${var.stackname}_content-data-admin_rds_access"
 }
 
 resource "aws_security_group_rule" "content-data-admin-rds_ingress_backend_postgres" {
-  count = "${var.use_split_postgres_database}"
-
   type      = "ingress"
   from_port = 5432
   to_port   = 5432
@@ -249,14 +225,10 @@ resource "aws_security_group_rule" "content-data-admin-rds_ingress_backend_postg
 }
 
 data "aws_security_group" "content-publisher-rds" {
-  count = "${var.use_split_postgres_database}"
-
   name = "${var.stackname}_content-publisher_rds_access"
 }
 
 resource "aws_security_group_rule" "content-publisher-rds_ingress_backend_postgres" {
-  count = "${var.use_split_postgres_database}"
-
   type      = "ingress"
   from_port = 5432
   to_port   = 5432
@@ -267,14 +239,10 @@ resource "aws_security_group_rule" "content-publisher-rds_ingress_backend_postgr
 }
 
 data "aws_security_group" "content-tagger-rds" {
-  count = "${var.use_split_postgres_database}"
-
   name = "${var.stackname}_content-tagger_rds_access"
 }
 
 resource "aws_security_group_rule" "content-tagger-rds_ingress_backend_postgres" {
-  count = "${var.use_split_postgres_database}"
-
   type      = "ingress"
   from_port = 5432
   to_port   = 5432
@@ -285,14 +253,10 @@ resource "aws_security_group_rule" "content-tagger-rds_ingress_backend_postgres"
 }
 
 data "aws_security_group" "link-checker-api-rds" {
-  count = "${var.use_split_postgres_database}"
-
   name = "${var.stackname}_link-checker-api_rds_access"
 }
 
 resource "aws_security_group_rule" "link-checker-api-rds_ingress_backend_postgres" {
-  count = "${var.use_split_postgres_database}"
-
   type      = "ingress"
   from_port = 5432
   to_port   = 5432
@@ -303,14 +267,10 @@ resource "aws_security_group_rule" "link-checker-api-rds_ingress_backend_postgre
 }
 
 data "aws_security_group" "local-links-manager-rds" {
-  count = "${var.use_split_postgres_database}"
-
   name = "${var.stackname}_local-links-manager_rds_access"
 }
 
 resource "aws_security_group_rule" "local-links-manager-rds_ingress_backend_postgres" {
-  count = "${var.use_split_postgres_database}"
-
   type      = "ingress"
   from_port = 5432
   to_port   = 5432
@@ -321,14 +281,10 @@ resource "aws_security_group_rule" "local-links-manager-rds_ingress_backend_post
 }
 
 data "aws_security_group" "release-rds" {
-  count = "${var.use_split_mysql_database}"
-
   name = "${var.stackname}_release_rds_access"
 }
 
 resource "aws_security_group_rule" "release-rds_ingress_backend_mysql" {
-  count = "${var.use_split_mysql_database}"
-
   type      = "ingress"
   from_port = 3306
   to_port   = 3306
@@ -339,14 +295,10 @@ resource "aws_security_group_rule" "release-rds_ingress_backend_mysql" {
 }
 
 data "aws_security_group" "search-admin-rds" {
-  count = "${var.use_split_mysql_database}"
-
   name = "${var.stackname}_search-admin_rds_access"
 }
 
 resource "aws_security_group_rule" "search-admin-rds_ingress_backend_mysql" {
-  count = "${var.use_split_mysql_database}"
-
   type      = "ingress"
   from_port = 3306
   to_port   = 3306
@@ -357,14 +309,10 @@ resource "aws_security_group_rule" "search-admin-rds_ingress_backend_mysql" {
 }
 
 data "aws_security_group" "service-manual-publisher-rds" {
-  count = "${var.use_split_postgres_database}"
-
   name = "${var.stackname}_service-manual-publisher_rds_access"
 }
 
 resource "aws_security_group_rule" "service-manual-publisher-rds_ingress_backend_postgres" {
-  count = "${var.use_split_postgres_database}"
-
   type      = "ingress"
   from_port = 5432
   to_port   = 5432
@@ -375,14 +323,10 @@ resource "aws_security_group_rule" "service-manual-publisher-rds_ingress_backend
 }
 
 data "aws_security_group" "signon-rds" {
-  count = "${var.use_split_mysql_database}"
-
   name = "${var.stackname}_signon_rds_access"
 }
 
 resource "aws_security_group_rule" "signon-rds_ingress_backend_mysql" {
-  count = "${var.use_split_mysql_database}"
-
   type      = "ingress"
   from_port = 3306
   to_port   = 3306
@@ -393,14 +337,10 @@ resource "aws_security_group_rule" "signon-rds_ingress_backend_mysql" {
 }
 
 data "aws_security_group" "support-api-rds" {
-  count = "${var.use_split_postgres_database}"
-
   name = "${var.stackname}_support-api_rds_access"
 }
 
 resource "aws_security_group_rule" "support-api-rds_ingress_backend_postgres" {
-  count = "${var.use_split_postgres_database}"
-
   type      = "ingress"
   from_port = 5432
   to_port   = 5432

--- a/terraform/projects/app-ckan/README.md
+++ b/terraform/projects/app-ckan/README.md
@@ -71,7 +71,6 @@ CKAN node
 | <a name="input_remote_state_infra_stack_dns_zones_key_stack"></a> [remote\_state\_infra\_stack\_dns\_zones\_key\_stack](#input\_remote\_state\_infra\_stack\_dns\_zones\_key\_stack) | Override stackname path to infra\_stack\_dns\_zones remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override infra\_vpc remote state path | `string` | `""` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
-| <a name="input_use_split_database"></a> [use\_split\_database](#input\_use\_split\_database) | Set to 1 to use the new split database instances | `string` | `"0"` | no |
 | <a name="input_user_data_snippets"></a> [user\_data\_snippets](#input\_user\_data\_snippets) | List of user-data snippets | `list` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/app-ckan/main.tf
+++ b/terraform/projects/app-ckan/main.tf
@@ -57,12 +57,6 @@ variable "instance_type" {
   default     = "m5.xlarge"
 }
 
-variable "use_split_database" {
-  type        = "string"
-  description = "Set to 1 to use the new split database instances"
-  default     = "0"
-}
-
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -271,14 +265,10 @@ module "alarms-elb-ckan-external" {
 }
 
 data "aws_security_group" "ckan-rds" {
-  count = "${var.use_split_database}"
-
   name = "${var.stackname}_ckan_rds_access"
 }
 
 resource "aws_security_group_rule" "ckan-rds_ingress_ckan_postgres" {
-  count = "${var.use_split_database}"
-
   type      = "ingress"
   from_port = 5432
   to_port   = 5432

--- a/terraform/projects/app-data-science-data/README.md
+++ b/terraform/projects/app-data-science-data/README.md
@@ -79,7 +79,6 @@ No modules.
 | <a name="input_remote_state_infra_stack_dns_zones_key_stack"></a> [remote\_state\_infra\_stack\_dns\_zones\_key\_stack](#input\_remote\_state\_infra\_stack\_dns\_zones\_key\_stack) | Override stackname path to infra\_stack\_dns\_zones remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override infra\_vpc remote state path | `string` | `""` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
-| <a name="input_use_split_database"></a> [use\_split\_database](#input\_use\_split\_database) | Set to 1 to use the new split database instances | `string` | `"0"` | no |
 
 ## Outputs
 

--- a/terraform/projects/app-data-science-data/main.tf
+++ b/terraform/projects/app-data-science-data/main.tf
@@ -21,12 +21,6 @@ variable "stackname" {
   description = "Stackname"
 }
 
-variable "use_split_database" {
-  type        = "string"
-  description = "Set to 1 to use the new split database instances"
-  default     = "0"
-}
-
 locals {
   data_infrastructure_bucket_name = "${data.terraform_remote_state.app_knowledge_graph.data-infrastructure-bucket_name}"
 }
@@ -239,14 +233,10 @@ resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-down" {
 }
 
 data "aws_security_group" "publishing-api-rds" {
-  count = "${var.use_split_database}"
-
   name = "blue_publishing-api_rds_access"
 }
 
 resource "aws_security_group_rule" "publishing-api-rds_ingress_data-science-data_postgres" {
-  count = "${var.use_split_database}"
-
   type      = "ingress"
   from_port = 5432
   to_port   = 5432

--- a/terraform/projects/app-email-alert-api/README.md
+++ b/terraform/projects/app-email-alert-api/README.md
@@ -62,7 +62,6 @@ email-alert-api node
 | <a name="input_remote_state_infra_stack_dns_zones_key_stack"></a> [remote\_state\_infra\_stack\_dns\_zones\_key\_stack](#input\_remote\_state\_infra\_stack\_dns\_zones\_key\_stack) | Override stackname path to infra\_stack\_dns\_zones remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override infra\_vpc remote state path | `string` | `""` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
-| <a name="input_use_split_database"></a> [use\_split\_database](#input\_use\_split\_database) | Set to 1 to use the new split database instances | `string` | `"0"` | no |
 | <a name="input_user_data_snippets"></a> [user\_data\_snippets](#input\_user\_data\_snippets) | List of user-data snippets | `list` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/app-email-alert-api/main.tf
+++ b/terraform/projects/app-email-alert-api/main.tf
@@ -52,12 +52,6 @@ variable "instance_type" {
   default     = "m5.xlarge"
 }
 
-variable "use_split_database" {
-  type        = "string"
-  description = "Set to 1 to use the new split database instances"
-  default     = "0"
-}
-
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -161,14 +155,10 @@ module "alarms-elb-email-alert-api-internal" {
 }
 
 data "aws_security_group" "email-alert-api-rds" {
-  count = "${var.use_split_database}"
-
   name = "${var.stackname}_email-alert-api_rds_access"
 }
 
 resource "aws_security_group_rule" "email-alert-api-rds_ingress_email-alert-api_postgres" {
-  count = "${var.use_split_database}"
-
   type      = "ingress"
   from_port = 5432
   to_port   = 5432

--- a/terraform/projects/app-publishing-api/README.md
+++ b/terraform/projects/app-publishing-api/README.md
@@ -73,7 +73,6 @@ publishing-api node
 | <a name="input_remote_state_infra_stack_dns_zones_key_stack"></a> [remote\_state\_infra\_stack\_dns\_zones\_key\_stack](#input\_remote\_state\_infra\_stack\_dns\_zones\_key\_stack) | Override stackname path to infra\_stack\_dns\_zones remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override infra\_vpc remote state path | `string` | `""` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
-| <a name="input_use_split_database"></a> [use\_split\_database](#input\_use\_split\_database) | Set to 1 to use the new split database instances | `string` | `"0"` | no |
 | <a name="input_user_data_snippets"></a> [user\_data\_snippets](#input\_user\_data\_snippets) | List of user-data snippets | `list` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/app-publishing-api/main.tf
+++ b/terraform/projects/app-publishing-api/main.tf
@@ -72,12 +72,6 @@ variable "instance_type" {
   default     = "m5.large"
 }
 
-variable "use_split_database" {
-  type        = "string"
-  description = "Set to 1 to use the new split database instances"
-  default     = "0"
-}
-
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -287,14 +281,10 @@ module "alarms-elb-publishing-api-external" {
 }
 
 data "aws_security_group" "publishing-api-rds" {
-  count = "${var.use_split_database}"
-
   name = "${var.stackname}_publishing-api_rds_access"
 }
 
 resource "aws_security_group_rule" "publishing-api-rds_ingress_publishing-api_postgres" {
-  count = "${var.use_split_database}"
-
   type      = "ingress"
   from_port = 5432
   to_port   = 5432

--- a/terraform/projects/app-whitehall-backend/README.md
+++ b/terraform/projects/app-whitehall-backend/README.md
@@ -66,7 +66,6 @@ Whitehall Backend nodes
 | <a name="input_remote_state_infra_stack_dns_zones_key_stack"></a> [remote\_state\_infra\_stack\_dns\_zones\_key\_stack](#input\_remote\_state\_infra\_stack\_dns\_zones\_key\_stack) | Override stackname path to infra\_stack\_dns\_zones remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override infra\_vpc remote state path | `string` | `""` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
-| <a name="input_use_split_database"></a> [use\_split\_database](#input\_use\_split\_database) | Set to 1 to use the new split database instances | `string` | `"0"` | no |
 | <a name="input_user_data_snippets"></a> [user\_data\_snippets](#input\_user\_data\_snippets) | List of user-data snippets | `list` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/app-whitehall-backend/main.tf
+++ b/terraform/projects/app-whitehall-backend/main.tf
@@ -48,12 +48,6 @@ variable "instance_type" {
   default     = "m5.large"
 }
 
-variable "use_split_database" {
-  type        = "string"
-  description = "Set to 1 to use the new split database instances"
-  default     = "0"
-}
-
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -184,14 +178,10 @@ resource "aws_iam_role_policy_attachment" "whitehall_csvs_attach" {
 }
 
 data "aws_security_group" "whitehall-rds" {
-  count = "${var.use_split_database}"
-
   name = "${var.stackname}_whitehall_rds_access"
 }
 
 resource "aws_security_group_rule" "whitehall-rds_ingress_whitehall-backend_mysql" {
-  count = "${var.use_split_database}"
-
   type      = "ingress"
   from_port = 3306
   to_port   = 3306

--- a/terraform/projects/app-whitehall-frontend/README.md
+++ b/terraform/projects/app-whitehall-frontend/README.md
@@ -62,7 +62,6 @@ Whitehall Frontend nodes
 | <a name="input_remote_state_infra_stack_dns_zones_key_stack"></a> [remote\_state\_infra\_stack\_dns\_zones\_key\_stack](#input\_remote\_state\_infra\_stack\_dns\_zones\_key\_stack) | Override stackname path to infra\_stack\_dns\_zones remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override infra\_vpc remote state path | `string` | `""` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
-| <a name="input_use_split_database"></a> [use\_split\_database](#input\_use\_split\_database) | Set to 1 to use the new split database instances | `string` | `"0"` | no |
 | <a name="input_user_data_snippets"></a> [user\_data\_snippets](#input\_user\_data\_snippets) | List of user-data snippets | `list` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/app-whitehall-frontend/main.tf
+++ b/terraform/projects/app-whitehall-frontend/main.tf
@@ -52,12 +52,6 @@ variable "instance_type" {
   default     = "m5.large"
 }
 
-variable "use_split_database" {
-  type        = "string"
-  description = "Set to 1 to use the new split database instances"
-  default     = "0"
-}
-
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -161,14 +155,10 @@ module "alarms-elb-whitehall-frontend-internal" {
 }
 
 data "aws_security_group" "whitehall-rds" {
-  count = "${var.use_split_database}"
-
   name = "${var.stackname}_whitehall_rds_access"
 }
 
 resource "aws_security_group_rule" "whitehall-rds_ingress_whitehall-frontend_mysql" {
-  count = "${var.use_split_database}"
-
   type      = "ingress"
   from_port = 3306
   to_port   = 3306


### PR DESCRIPTION
These were introduced so we could create (or not create) the security
group rules only in environments where the new RDS instances had been
deployed.  We now have all the new RDS instances, so these variables
are unnecessary.

---

Terraform plans (all no-ops):

- [app-account](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2094/console)
- [app-backend](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2095/console)
- [app-ckan](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2096/console)
- [app-data-science-data](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2102/console) (has an unrelated launch configuration change)
- [app-email-alert-api](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2097/console)
- [app-publishing-api](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2098/console)
- [app-whitehall-backend](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2099/console)
- [app-whitehall-frontend](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2100/console)

---

[Trello card](https://trello.com/c/cVBkq9Sg/83-remove-usesplitpostgresdatabase-usesplitmysqldatabase-and-usesplitdatabase-terraform-vars)