### PR TITLE
Remove concourse permissions for LTR resources

### DIFF
--- a/terraform/projects/app-search/README.md
+++ b/terraform/projects/app-search/README.md
@@ -78,7 +78,6 @@ Search application servers
 | <a name="input_asg_min_size"></a> [asg\_min\_size](#input\_asg\_min\_size) | The minimum size of the autoscaling group | `string` | `"2"` | no |
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
-| <a name="input_concourse_aws_account_id"></a> [concourse\_aws\_account\_id](#input\_concourse\_aws\_account\_id) | AWS account ID which contains the Concourse role | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"c5.xlarge"` | no |

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -70,11 +70,6 @@ variable "instance_type" {
   default     = "c5.xlarge"
 }
 
-variable "concourse_aws_account_id" {
-  type        = "string"
-  description = "AWS account ID which contains the Concourse role"
-}
-
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -364,11 +359,6 @@ data "aws_iam_policy_document" "learntorank-assume-role" {
     actions = ["sts:AssumeRole"]
 
     principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.concourse_aws_account_id}:role/cd-govuk-tools-concourse-worker"]
-    }
-
-    principals {
       type        = "Service"
       identifiers = ["sagemaker.amazonaws.com"]
     }
@@ -426,7 +416,6 @@ data "aws_iam_policy_document" "ecr-usage" {
       type = "AWS"
 
       identifiers = [
-        "arn:aws:iam::${var.concourse_aws_account_id}:root",
         "${aws_iam_role.learntorank.arn}",
       ]
     }
@@ -434,23 +423,6 @@ data "aws_iam_policy_document" "ecr-usage" {
     principals {
       type        = "Service"
       identifiers = ["sagemaker.amazonaws.com"]
-    }
-  }
-
-  statement {
-    sid = "write"
-
-    actions = [
-      "ecr:BatchDeleteImage",
-      "ecr:CompleteLayerUpload",
-      "ecr:InitiateLayerUpload",
-      "ecr:PutImage",
-      "ecr:UploadLayerPart",
-    ]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.concourse_aws_account_id}:role/cd-govuk-tools-concourse-worker"]
     }
   }
 }

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -537,7 +537,6 @@ No modules.
 | [aws_security_group_rule.search-elb_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.search-elb_ingress_management_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.search-ltr-generation_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.search-ltr-generation_ingress_concourse_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.search-ltr-generation_ingress_jenkins_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.search_ingress_search-elb_http](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.shared-documentdb_ingress_backend_asset_manager](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
@@ -594,8 +593,6 @@ No modules.
 | <a name="input_carrenza_rabbitmq_ips"></a> [carrenza\_rabbitmq\_ips](#input\_carrenza\_rabbitmq\_ips) | An array of CIDR blocks that will be allowed to federate with the rabbitmq nodes. | `list` | <pre>[<br>  ""<br>]</pre> | no |
 | <a name="input_carrenza_staging_ips"></a> [carrenza\_staging\_ips](#input\_carrenza\_staging\_ips) | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | `list` | n/a | yes |
 | <a name="input_carrenza_vpn_subnet_cidr"></a> [carrenza\_vpn\_subnet\_cidr](#input\_carrenza\_vpn\_subnet\_cidr) | The Carrenza VPN subnet CIDR | `list` | `[]` | no |
-| <a name="input_concourse_aws_account_id"></a> [concourse\_aws\_account\_id](#input\_concourse\_aws\_account\_id) | AWS account ID which contains the Concourse role | `string` | n/a | yes |
-| <a name="input_concourse_ips"></a> [concourse\_ips](#input\_concourse\_ips) | An array of CIDR blocks that represent ingress Concourse | `list` | n/a | yes |
 | <a name="input_ithc_access_ips"></a> [ithc\_access\_ips](#input\_ithc\_access\_ips) | An array of CIDR blocks that will be allowed temporary access for ITHC purposes. | `list` | `[]` | no |
 | <a name="input_office_ips"></a> [office\_ips](#input\_office\_ips) | An array of CIDR blocks that will be allowed offsite access. | `list` | n/a | yes |
 | <a name="input_paas_ireland_egress_ips"></a> [paas\_ireland\_egress\_ips](#input\_paas\_ireland\_egress\_ips) | An array of CIDR blocks that are used for egress from the GOV.UK PaaS Ireland region | `list` | `[]` | no |

--- a/terraform/projects/infra-security-groups/search-ltr-generation.tf
+++ b/terraform/projects/infra-security-groups/search-ltr-generation.tf
@@ -8,16 +8,6 @@ resource "aws_security_group" "search-ltr-generation" {
   }
 }
 
-resource "aws_security_group_rule" "search-ltr-generation_ingress_concourse_ssh" {
-  type        = "ingress"
-  protocol    = "tcp"
-  from_port   = 22
-  to_port     = 22
-  cidr_blocks = ["${var.concourse_ips}"]
-
-  security_group_id = "${aws_security_group.search-ltr-generation.id}"
-}
-
 resource "aws_security_group_rule" "search-ltr-generation_ingress_jenkins_ssh" {
   type                     = "ingress"
   protocol                 = "tcp"

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -29,16 +29,6 @@ variable "office_ips" {
   description = "An array of CIDR blocks that will be allowed offsite access."
 }
 
-variable "concourse_ips" {
-  type        = "list"
-  description = "An array of CIDR blocks that represent ingress Concourse"
-}
-
-variable "concourse_aws_account_id" {
-  type        = "string"
-  description = "AWS account ID which contains the Concourse role"
-}
-
 variable "carrenza_integration_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will be allowed to SSH to the jumpbox."


### PR DESCRIPTION
This removes permissions for the shared concourse to access resources needed to run Search API's learn to rank pipeline. This is because the pipeline has now been migrated to Jenkins.