### PR TITLE
Remove unused var from infra-security

### DIFF
--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -83,7 +83,6 @@ Infrastructure security settings:
 | <a name="input_role_poweruser_policy_arns"></a> [role\_poweruser\_policy\_arns](#input\_role\_poweruser\_policy\_arns) | List of ARNs of policies to attach to the role | `list` | `[]` | no |
 | <a name="input_role_poweruser_user_arns"></a> [role\_poweruser\_user\_arns](#input\_role\_poweruser\_user\_arns) | List of ARNs of external users that can assume the role | `list` | `[]` | no |
 | <a name="input_role_step_function_role_policy_arns"></a> [role\_step\_function\_role\_policy\_arns](#input\_role\_step\_function\_role\_policy\_arns) | List of ARNs of policies to attach to the role | `list` | `[]` | no |
-| <a name="input_role_step_function_role_user_arns"></a> [role\_step\_function\_role\_user\_arns](#input\_role\_step\_function\_role\_user\_arns) | List of ARNs of users to attach to the role | `list` | `[]` | no |
 | <a name="input_role_user_policy_arns"></a> [role\_user\_policy\_arns](#input\_role\_user\_policy\_arns) | List of ARNs of policies to attach to the role | `list` | `[]` | no |
 | <a name="input_role_user_user_arns"></a> [role\_user\_user\_arns](#input\_role\_user\_user\_arns) | List of ARNs of external users that can assume the role | `list` | `[]` | no |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The public part of an SSH keypair | `string` | `null` | no |

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -98,12 +98,6 @@ variable "role_dataengineeruser_policy_arns" {
   default     = []
 }
 
-variable "role_step_function_role_user_arns" {
-  type        = list
-  description = "List of ARNs of users to attach to the role"
-  default     = []
-}
-
 variable "role_step_function_role_policy_arns" {
   type        = list
   description = "List of ARNs of policies to attach to the role"


### PR DESCRIPTION
This var is not used - the list tfvar provided by aws-data is now empty - see https://github.com/alphagov/govuk-aws-data/pull/965.