### PR TITLE
Add splat operator to sg_postgresql-primary_id

### DIFF
--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -23,7 +23,7 @@ output "sg_asset-master-efs_id" {
 }
 
 output "sg_postgresql-primary_id" {
-  value = "${aws_security_group.postgresql-primary.id}"
+  value = "${aws_security_group.postgresql-primary.*.id}"
 }
 
 output "sg_apt_external_elb_id" {


### PR DESCRIPTION
In PR https://github.com/alphagov/govuk-aws/pull/1526 we set a count of 0 for the postgres related
resources in the infra-security-group. The plan suceeded, but the apply failed. See [1] for error
message, which suggests we need the splat operator.

[1] https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2135/console