### PR TITLE
Skip final snap shot for postgres replica

### DIFF
--- a/terraform/projects/app-postgresql/main.tf
+++ b/terraform/projects/app-postgresql/main.tf
@@ -192,7 +192,7 @@ module "postgresql-standby_rds_instance" {
   max_allocated_storage      = "${var.max_allocated_storage}"
   replicate_source_db        = "${module.postgresql-primary_rds_instance.rds_instance_id}"
   event_sns_topic_arn        = "${data.terraform_remote_state.infra_monitoring.sns_topic_rds_events_arn}"
-  skip_final_snapshot        = "${var.skip_final_snapshot}"
+  skip_final_snapshot        = true
   parameter_group_name       = "${aws_db_parameter_group.postgresql_pg.name}"
 }
 


### PR DESCRIPTION
Set skip final snap shot to true to allow module to be deleted as otherwise the destroy action is prevented:

https://trello.com/c/ewzHAr6A/56-remove-postgresql-primary-and-postgresql-standby-infrastructure-and-configuration

https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2137/console