### PR TITLE
Remove ID from outputs file

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -708,7 +708,6 @@ No modules.
 | <a name="output_sg_mysql-primary_id"></a> [sg\_mysql-primary\_id](#output\_sg\_mysql-primary\_id) | n/a |
 | <a name="output_sg_mysql-replica_id"></a> [sg\_mysql-replica\_id](#output\_sg\_mysql-replica\_id) | n/a |
 | <a name="output_sg_offsite_ssh_id"></a> [sg\_offsite\_ssh\_id](#output\_sg\_offsite\_ssh\_id) | n/a |
-| <a name="output_sg_postgresql-primary_id"></a> [sg\_postgresql-primary\_id](#output\_sg\_postgresql-primary\_id) | n/a |
 | <a name="output_sg_prometheus_external_elb_id"></a> [sg\_prometheus\_external\_elb\_id](#output\_sg\_prometheus\_external\_elb\_id) | n/a |
 | <a name="output_sg_prometheus_id"></a> [sg\_prometheus\_id](#output\_sg\_prometheus\_id) | n/a |
 | <a name="output_sg_prometheus_internal_elb_id"></a> [sg\_prometheus\_internal\_elb\_id](#output\_sg\_prometheus\_internal\_elb\_id) | n/a |

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -22,10 +22,6 @@ output "sg_asset-master-efs_id" {
   value = "${aws_security_group.asset-master-efs.id}"
 }
 
-output "sg_postgresql-primary_id" {
-  value = "${aws_security_group.postgresql-primary.id}"
-}
-
 output "sg_apt_external_elb_id" {
   value = "${aws_security_group.apt_external_elb.id}"
 }


### PR DESCRIPTION
The postgres primary is to be removed see https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/2139/ so the ID is not available for the output. Removing this allows us to remove the postgres primary resources from the infra-security group.

https://trello.com/c/ewzHAr6A/56-remove-postgresql-primary-and-postgresql-standby-infrastructure-and-configuration