### PR TITLE
Enable ELB health checks on calc_frontend instances

### DIFF
--- a/terraform/modules/aws/node_group/README.md
+++ b/terraform/modules/aws/node_group/README.md
@@ -55,6 +55,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_asg_desired_capacity"></a> [asg\_desired\_capacity](#input\_asg\_desired\_capacity) | The autoscaling groups desired capacity | `string` | `"1"` | no |
 | <a name="input_asg_health_check_grace_period"></a> [asg\_health\_check\_grace\_period](#input\_asg\_health\_check\_grace\_period) | The time to wait after creation before checking the status of the instance | `string` | `"60"` | no |
+| <a name="input_asg_health_check_type"></a> [asg\_health\_check\_type](#input\_asg\_health\_check\_type) | The ASG health check Type: should Target Group health checks be ignored | `string` | `"EC2"` | no |
 | <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | The autoscaling groups max\_size | `string` | `"1"` | no |
 | <a name="input_asg_min_size"></a> [asg\_min\_size](#input\_asg\_min\_size) | The autoscaling groups max\_size | `string` | `"1"` | no |
 | <a name="input_asg_notification_topic_arn"></a> [asg\_notification\_topic\_arn](#input\_asg\_notification\_topic\_arn) | The Topic ARN for Autoscaling Group notifications to be sent to | `string` | `""` | no |

--- a/terraform/modules/aws/node_group/main.tf
+++ b/terraform/modules/aws/node_group/main.tf
@@ -116,6 +116,12 @@ variable "asg_health_check_grace_period" {
   default     = "60"
 }
 
+variable "asg_health_check_type" {
+  type        = "string"
+  description = "The ASG health check Type: should Target Group health checks be ignored"
+  default     = "EC2"
+}
+
 variable "asg_desired_capacity" {
   type        = "string"
   description = "The autoscaling groups desired capacity"
@@ -330,7 +336,7 @@ resource "aws_autoscaling_group" "node_autoscaling_group" {
   min_size                  = "${var.asg_min_size}"
   max_size                  = "${var.asg_max_size}"
   health_check_grace_period = "${var.asg_health_check_grace_period}"
-  health_check_type         = "EC2"
+  health_check_type         = "${var.asg_health_check_type}"
   force_delete              = false
   wait_for_capacity_timeout = 0
   launch_configuration      = "${local.launch_configuration_name}"

--- a/terraform/projects/app-calculators-frontend/main.tf
+++ b/terraform/projects/app-calculators-frontend/main.tf
@@ -182,6 +182,7 @@ module "calculators-frontend" {
   source                            = "../../modules/aws/node_group"
   name                              = "${var.stackname}-calculators-frontend"
   default_tags                      = "${map("Project", var.stackname, "aws_stackname", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "calculators_frontend", "aws_hostname", "calculators-frontend-1")}"
+  asg_health_check_type             = "ELB"
   instance_subnet_ids               = "${data.terraform_remote_state.infra_networking.private_subnet_ids}"
   instance_security_group_ids       = ["${data.terraform_remote_state.infra_security_groups.sg_calculators-frontend_id}", "${data.terraform_remote_state.infra_security_groups.sg_management_id}"]
   instance_type                     = "${var.instance_type}"


### PR DESCRIPTION
This will mean that both EC2 and ELB checks are used to determine whether an instance of a calculators_frontend is healthy or should be removed from an ASG and terminated.

The result is that an app failing a /healthcheck/ready check on an instance will lead to the instance being removed from an AutoScalingGroup.

As far as I can see until now we have needed to terminate instances manually when application level checks had failed.

I'm starting with calculators_frontend and will roll this out to other instances in future.

Docs: https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-add-elb-healthcheck.html