### PR TITLE
Drop TLS 1.0 and 1.1 support from ALB's

### DIFF
--- a/terraform/modules/aws/lb/README.md
+++ b/terraform/modules/aws/lb/README.md
@@ -84,7 +84,7 @@ No modules.
 | <a name="input_listener_certificate_domain_name"></a> [listener\_certificate\_domain\_name](#input\_listener\_certificate\_domain\_name) | HTTPS Listener certificate domain name. | `string` | `""` | no |
 | <a name="input_listener_internal_certificate_domain_name"></a> [listener\_internal\_certificate\_domain\_name](#input\_listener\_internal\_certificate\_domain\_name) | HTTPS Listener internal certificate domain name. | `string` | `""` | no |
 | <a name="input_listener_secondary_certificate_domain_name"></a> [listener\_secondary\_certificate\_domain\_name](#input\_listener\_secondary\_certificate\_domain\_name) | HTTPS Listener secondary certificate domain name. | `string` | `""` | no |
-| <a name="input_listener_ssl_policy"></a> [listener\_ssl\_policy](#input\_listener\_ssl\_policy) | The name of the SSL Policy for HTTPS listeners. | `string` | `"ELBSecurityPolicy-2016-08"` | no |
+| <a name="input_listener_ssl_policy"></a> [listener\_ssl\_policy](#input\_listener\_ssl\_policy) | The name of the SSL Policy for HTTPS listeners. | `string` | `"ELBSecurityPolicy-TLS-1-2-2017-01"` | no |
 | <a name="input_load_balancer_type"></a> [load\_balancer\_type](#input\_load\_balancer\_type) | The type of load balancer to create. Possible values are application or network. The default value is application. | `string` | `"application"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters. | `string` | n/a | yes |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of security group IDs to assign to the LB. Only valid for Load Balancers of type application. | `list` | `[]` | no |

--- a/terraform/modules/aws/lb/main.tf
+++ b/terraform/modules/aws/lb/main.tf
@@ -94,7 +94,7 @@ variable "listener_internal_certificate_domain_name" {
 variable "listener_ssl_policy" {
   type        = "string"
   description = "The name of the SSL Policy for HTTPS listeners."
-  default     = "ELBSecurityPolicy-2016-08"
+  default     = "ELBSecurityPolicy-TLS-1-2-2017-01"
 }
 
 variable "internal" {


### PR DESCRIPTION
Trello: https://trello.com/c/C9hginSe/166-remove-tls-10-and-11-support-for-publishing-apps

This changes the default TLS security policy used in the application
load balancers to be a newer rule that drops support for TLS 1.0 and
1.1.

As no ALBs set a non-default listener_ssl_policy this rule will apply to
all of the public ALBs in GOV.UK infrastructure. So this will apply to
anything on publishing.service.gov.uk which is not behind the CDN (www,
assets and transition sites). I decided that it'd be better to apply
this broadly rather than individually as this change has been something
that has been put off for a while and it'd be good to set any exceptions
based on reasoning rather than caution.

This has been done because TLS versions below 1.2 are susceptible to
man-in-the-middle attacks and by continuing to allow support for the
older TLS versions we risk downgrade attacks [1].

The policy ELBSecurityPolicy-TLS-1-2-2017-01 only has support for TLS
1.2 (at the time of writing there isn't an ALB security policy that
supports TLS 1.3) and drops a number of weaker ciphers
(ECDHE-ECDSA-AES128-SHA, ECDHE-RSA-AES128-SHA, ECDHE-RSA-AES256-SHA,
ECDHE-ECDSA-AES256-SHA, AES128-SHA and AES256-SHA) [2]

The impact of this change is expected to be minimal, every browser in
the service manual [3] supports TLS 1.2 [4].

To analyse the impact I downloaded the 30 day log files for the following
public load balancers to compare:

| load balancer                       | TLS 1.2  | TLS 1.1 | TLS 1 | Percentage TLS 1.2 |
|-------------------------------------|----------|---------|-------|--------------------|
| govuk-account-public-elb            | 6460     | 83      | 89    | 97.337%            |
| govuk-backend-public-elb            | 10178549 | 71      | 2649  | 99.973%            |
| govuk-bouncer-public-elb            | 0        | 0       | 0     | N/A                |
| govuk-ckan-public-elb               | 3408231  | 75      | 2428  | 99.927%            |
| govuk-draft-cache-public-elb        | 984077   | 57      | 547   | 99.939%            |
| govuk-email-alert-api-public-elb    | 33348728 | 55      | 58    | 100%               |
| govuk-graphite-public-elb           | 14504    | 0       | 0     | 100%               |
| govuk-jumpbox-public-elb            | 0        | 0       | 0     | N/A                |
| govuk-licensify-frontend-public-elb | 33838    | 58      | 70    | 99.622%            |
| govuk-monitoring-public-elb         | 6751     | 0       | 0     | 100%               |
| govuk-prometheus-public-elb         | 144      | 0       | 0     | 100%               |
| govuk-sidekiq-monitoring-public-elb | 290      | 0       | 0     | 100%               |
| govuk-whitehall-backend-public-elb  | 1442461  | 79      | 117   | 99.986%            |
| licensify-backend-public-elb        | 792912   | 71      | 322   | 99.950%            |

I also analysed govuk-public-elb but, since that is massive, I only did
it for the last 5 days:

| load balancer          | TLS 1.2   | TLS 1.1 | TLS 1 | Percentage TLS 1.2 |
|------------------------|-----------|---------|-------|--------------------|
| govuk-cache-public-elb | 106137686 | 0       | 0     | 100%               |

The results show almost all connection are made using TLS 1.2, from my
brief investigations it seems that most of the TLS 1 and TLS 1.1 are
from probing.

E.g:

```
https 2022-01-14T01:12:05.115375Z app/govuk-email-alert-api-public/05a186ca4b2bde26 <redacted>:51796 - -1 -1 -1 400 - 0 0 "- https://govuk-email-alert-api-public-403570493.eu-west-1.elb.amazonaws.com:443- -" "-" ECDHE-RSA-AES128-SHA TLSv1.1 - "-" "-" "arn:aws:acm:eu-west-1:172025368201:certificate/063a18cc-d4bf-4eaf-b1c1-41e86bbdd69d" - 2022-01-14T01:12:05.115000Z "-" "-" "-" "-" "-" "-" "-"
https 2022-01-14T20:12:05.148956Z app/govuk-backend-public/169e0e0d325925ed <redacted>:41680 10.13.6.174:80 0.001 0.001 0.000 500 500 194 198 "GET https://54.77.206.251:443/ HTTP/1.1" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36" AES128-SHA TLSv1 arn:aws:elasticloadbalancing:eu-west-1:172025368201:targetgroup/govuk-backend-public-HTTP-80/e592c497dedb83be "Root=1-61e1d915-5267f5b907490f4f6069ad77" "54.77.206.251" "arn:aws:acm:eu-west-1:172025368201:certificate/063a18cc-d4bf-4eaf-b1c1-41e86bbdd69d" 0 2022-01-14T20:12:05.146000Z "waf,forward" "-" "-" "10.13.6.174:80" "500" "-" "-"
```

[1]: https://en.wikipedia.org/wiki/Downgrade_attack
[2]: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies
[3]: https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices
[4]: https://caniuse.com/tls1-2