### PR TITLE
Permamently delete items in aws-logging buckets

### DIFF
--- a/terraform/projects/infra-monitoring/main.tf
+++ b/terraform/projects/infra-monitoring/main.tf
@@ -113,16 +113,22 @@ resource "aws_s3_bucket" "aws-logging" {
     Environment = "${var.aws_environment}"
   }
 
-  # Expire everything after 30 days
   lifecycle_rule {
     enabled = true
 
+    # 'Soft delete' everything after 30 days (because versioning is enabled)
     expiration {
       days = 30
+    }
+
+    # Permanently delete everything after 31 days
+    noncurrent_version_expiration {
+      days = "1"
     }
   }
 
   versioning {
+    # Needs to be enabled because we have replication configured
     enabled = true
   }
 


### PR DESCRIPTION
The `govuk-{env}-aws-logging` buckets have a 30 day expiration policy, but also had versioning enabled. This means that files are only soft deleted after 30 days, and continue to exist in the background as old versions taking up storage space.

The straightforward approach would be to disable versioning on the bucket so that files are permanently deleted when they expire. However versioning needs to remain enabled on the bucket because there is a replica configured.

Instead, this change configures a non-current version expiry so that old versions of files are permanently deleted after 1 day.

In real terms, this means that files will be permanently deleted from the bucket after 31 days (expiring at 30 days, and being deleted 1 day later).