### PR TITLE
Allow jumpboxes to use CloudWatch

### DIFF
--- a/terraform/projects/app-jumpbox/README.md
+++ b/terraform/projects/app-jumpbox/README.md
@@ -29,6 +29,7 @@ Jumpbox node
 | Name | Type |
 |------|------|
 | [aws_elb.jumpbox_external_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/elb) | resource |
+| [aws_iam_role_policy_attachment.ec2_access_cloudwatch_policy_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_route53_record.service_record](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [null_resource.user_data](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_route53_zone.external](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/route53_zone) | data source |

--- a/terraform/projects/app-jumpbox/main.tf
+++ b/terraform/projects/app-jumpbox/main.tf
@@ -134,6 +134,11 @@ module "jumpbox" {
   root_block_device_volume_size = "64"
 }
 
+resource "aws_iam_role_policy_attachment" "ec2_access_cloudwatch_policy_iam_role_policy_attachment" {
+  role       = "${module.jumpbox.instance_iam_role_name}"
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
 locals {
   surgequeuelength_threshold = "${var.create_external_elb ? 200 : 0}"
   healthyhostcount_threshold = "${var.create_external_elb ? 1 : 0}"


### PR DESCRIPTION
We'd like to ship SSH logs to Cyber. The standard way of doing this is
to ship the logs to CloudWatch Logs first, and then use Cyber's
[centralised security logging service](https://github.com/alphagov/centralised-security-logging-service)

This commit grants the jumpboxes permission to use CloudWatch.

https://trello.com/c/3PEIdbKp/2608-ship-ssh-logs-from-jumpboxes-to-splunk