### PR TITLE
Remove duplicate bucket parameter

### DIFF
--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -25,7 +25,6 @@ resource "aws_wafregional_web_acl" "default" {
 }
 
 resource "aws_s3_bucket" "aws_waf_logs" {
-  bucket = "aws-waf-logs-splunk"
   acl    = "private"
   bucket = "govuk-${var.aws_environment}-aws-waf-logs"
   region = "${var.aws_region}"


### PR DESCRIPTION
This is set again two lines further down. It looks like the second time
wins, because the bucket in integration is called
govuk-integration-aws-waf-logs.