### PR TITLE
Output the policy used to access the search-api s3 buckets

### DIFF
--- a/terraform/projects/app-search/README.md
+++ b/terraform/projects/app-search/README.md
@@ -101,4 +101,6 @@ Search application servers
 | <a name="output_ltr_role_arn"></a> [ltr\_role\_arn](#output\_ltr\_role\_arn) | LTR role ARN |
 | <a name="output_scale_learntorank_asg_policy_arn"></a> [scale\_learntorank\_asg\_policy\_arn](#output\_scale\_learntorank\_asg\_policy\_arn) | ARN of the policy used by to scale the ASG for learn to rank |
 | <a name="output_search_elb_dns_name"></a> [search\_elb\_dns\_name](#output\_search\_elb\_dns\_name) | DNS name to access the search service |
+| <a name="output_search_relevancy_s3_policy_arn"></a> [search\_relevancy\_s3\_policy\_arn](#output\_search\_relevancy\_s3\_policy\_arn) | ARN of the policy used to access the search-relevancy S3 bucket |
 | <a name="output_service_dns_name"></a> [service\_dns\_name](#output\_service\_dns\_name) | DNS name to access the node service |
+| <a name="output_sitemaps_s3_policy_arn"></a> [sitemaps\_s3\_policy\_arn](#output\_sitemaps\_s3\_policy\_arn) | ARN of the policy used to access the sitemaps S3 bucket |

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -560,3 +560,13 @@ output "ecr_repository_url" {
   value       = "${aws_ecr_repository.repo.repository_url}"
   description = "URL of the ECR repository"
 }
+
+output "search_relevancy_s3_policy_arn" {
+  value       = "${aws_iam_policy.search_relevancy_bucket_access.arn}"
+  description = "ARN of the policy used to access the search-relevancy S3 bucket"
+}
+
+output "sitemaps_s3_policy_arn" {
+  value       = "${aws_iam_policy.sitemaps_bucket_access.arn}"
+  description = "ARN of the policy used to access the sitemaps S3 bucket"
+}


### PR DESCRIPTION
This is needed so that search-api in EKS is able to access
these buckets.