### PR TITLE
Add sagemaker:CreateCodeRepository to infra-security

### DIFF
--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -375,6 +375,7 @@ resource "aws_iam_policy" "data-science-access-glue" {
 data "aws_iam_policy_document" "data-science-access-sagemaker" {
   statement {
     actions = [
+      "sagemaker:CreateCodeRepository",
       "sagemaker:CreateNotebookInstance",
       "sagemaker:CreatePresignedNotebookInstanceUrl",
       "sagemaker:DescribeNotebookInstance",


### PR DESCRIPTION
This is so a sagemaker user can create internal sagemaker git repositories, needed for some applications to run.
See https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateCodeRepository.html