### PR TITLE
Add Route53 record for internal Locations API DNS

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -146,6 +146,8 @@ This project adds global resources for app components:
 | [aws_route53_record.licensify_frontend_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.licensify_frontend_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.licensify_frontend_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
+| [aws_route53_record.locations_api_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
+| [aws_route53_record.locations_api_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.mapit_cache_name](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.mapit_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.mapit_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
@@ -288,6 +290,8 @@ This project adds global resources for app components:
 | <a name="input_licensify_frontend_internal_service_names"></a> [licensify\_frontend\_internal\_service\_names](#input\_licensify\_frontend\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_licensify_frontend_public_service_cnames"></a> [licensify\_frontend\_public\_service\_cnames](#input\_licensify\_frontend\_public\_service\_cnames) | n/a | `list` | `[]` | no |
 | <a name="input_licensify_frontend_public_service_names"></a> [licensify\_frontend\_public\_service\_names](#input\_licensify\_frontend\_public\_service\_names) | n/a | `list` | `[]` | no |
+| <a name="input_locations_api_internal_service_names"></a> [locations\_api\_internal\_service\_names](#input\_locations\_api\_internal\_service\_names) | n/a | `list` | `[]` | no |
+| <a name="input_locations_api_public_service_cnames"></a> [locations\_api\_public\_service\_cnames](#input\_locations\_api\_public\_service\_cnames) | n/a | `list` | `[]` | no |
 | <a name="input_mapit_internal_service_names"></a> [mapit\_internal\_service\_names](#input\_mapit\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_mapit_public_service_names"></a> [mapit\_public\_service\_names](#input\_mapit\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_mongo_internal_service_names"></a> [mongo\_internal\_service\_names](#input\_mongo\_internal\_service\_names) | n/a | `list` | `[]` | no |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -181,6 +181,16 @@ variable "graphite_public_service_names" {
   default = []
 }
 
+variable "locations_api_internal_service_names" {
+  type    = "list"
+  default = []
+}
+
+variable "locations_api_public_service_cnames" {
+  type    = "list"
+  default = []
+}
+
 variable "prometheus_public_service_names" {
   type    = "list"
   default = []
@@ -1581,6 +1591,28 @@ resource "aws_route53_record" "graphite_internal_service_names" {
   name    = "${element(var.graphite_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
   type    = "CNAME"
   records = ["${element(var.graphite_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+#
+# locations-api
+#
+
+resource "aws_route53_record" "locations_api_internal_service_names" {
+  count   = "${length(var.locations_api_internal_service_names)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.internal_root_zone_id}"
+  name    = "${element(var.locations_api_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.locations_api_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.internal_root_domain_name}"]
+  ttl     = "300"
+}
+
+resource "aws_route53_record" "locations_api_public_service_cnames" {
+  count   = "${length(var.locations_api_public_service_cnames)}"
+  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
+  name    = "${element(var.locations_api_public_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
+  type    = "CNAME"
+  records = ["${element(var.locations_api_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"]
   ttl     = "300"
 }
 

--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -25,7 +25,6 @@ resource "aws_wafregional_web_acl" "default" {
 }
 
 resource "aws_s3_bucket" "aws_waf_logs" {
-  bucket = "aws-waf-logs-splunk"
   acl    = "private"
   bucket = "govuk-${var.aws_environment}-aws-waf-logs"
   region = "${var.aws_region}"


### PR DESCRIPTION
Currently, Locations API's internal DNS only allows connections
through the 'blue' stack:

```
$ curl https://locations-api.integration.govuk-internal.digital
curl: (6) Could not resolve host: locations-api.integration.govuk-internal.digital
$ curl https://locations-api.blue.integration.govuk-internal.digital
(resolves)
```

Other APIs (including email-alert-apil, publishing-api and
account-api) are only available on the non-blue domain. This
commit (taken from Account API config) is to make Locations API
consistent with that.

Trello: https://trello.com/c/gPRVvLXh/2848-set-up-remaining-infrastructure-for-locations-api-5