### PR TITLE
Specify time zone for daily govgraph generation

### DIFF
--- a/terraform/projects/app-data-science-data/main.tf
+++ b/terraform/projects/app-data-science-data/main.tf
@@ -218,6 +218,7 @@ resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-up" {
   autoscaling_group_name = "${aws_autoscaling_group.data-science-data_asg.name}"
   scheduled_action_name  = "data-science-data_schedule-spin-up"
   recurrence             = "29 4 * * MON-SUN"
+  time_zone              = "Europe/London"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 1
@@ -227,6 +228,7 @@ resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-down" {
   autoscaling_group_name = "${aws_autoscaling_group.data-science-data_asg.name}"
   scheduled_action_name  = "data-science-data_schedule-spin-down"
   recurrence             = "29 08 * * MON-SUN"
+  time_zone              = "Europe/London"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 0

--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -305,6 +305,7 @@ resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-up" {
   autoscaling_group_name = "${aws_autoscaling_group.knowledge-graph_asg.name}"
   scheduled_action_name  = "knowledge-graph_schedule-spin-up"
   recurrence             = "30 8 * * MON-FRI"
+  time_zone              = "Europe/London"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 1
@@ -314,6 +315,7 @@ resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-down" {
   autoscaling_group_name = "${aws_autoscaling_group.knowledge-graph_asg.name}"
   scheduled_action_name  = "knowledge-graph_schedule-spin-down"
   recurrence             = "29 19 * * MON-FRI"
+  time_zone              = "Europe/London"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 0


### PR DESCRIPTION
By default the time zone is GMT so during summer time the govgraph is
generated one hour later (09:30) and isn't available to users early enough.
So adding the Europe/London IANA time zone parameter, as documented at
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_schedule\#argument-reference