### PR TITLE
no time_zone support so start sooner

### DIFF
--- a/terraform/projects/app-data-science-data/main.tf
+++ b/terraform/projects/app-data-science-data/main.tf
@@ -217,8 +217,7 @@ resource "aws_autoscaling_group" "data-science-data_asg" {
 resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-up" {
   autoscaling_group_name = "${aws_autoscaling_group.data-science-data_asg.name}"
   scheduled_action_name  = "data-science-data_schedule-spin-up"
-  recurrence             = "29 4 * * MON-SUN"
-  time_zone              = "Europe/London"
+  recurrence             = "29 3 * * MON-SUN"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 1
@@ -227,8 +226,7 @@ resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-up" {
 resource "aws_autoscaling_schedule" "data-science-data_schedule-spin-down" {
   autoscaling_group_name = "${aws_autoscaling_group.data-science-data_asg.name}"
   scheduled_action_name  = "data-science-data_schedule-spin-down"
-  recurrence             = "29 08 * * MON-SUN"
-  time_zone              = "Europe/London"
+  recurrence             = "29 07 * * MON-SUN"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 0

--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -304,8 +304,7 @@ resource "aws_autoscaling_group" "knowledge-graph_asg" {
 resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-up" {
   autoscaling_group_name = "${aws_autoscaling_group.knowledge-graph_asg.name}"
   scheduled_action_name  = "knowledge-graph_schedule-spin-up"
-  recurrence             = "30 8 * * MON-FRI"
-  time_zone              = "Europe/London"
+  recurrence             = "30 7 * * MON-FRI"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 1
@@ -315,7 +314,6 @@ resource "aws_autoscaling_schedule" "knowledge-graph_schedule-spin-down" {
   autoscaling_group_name = "${aws_autoscaling_group.knowledge-graph_asg.name}"
   scheduled_action_name  = "knowledge-graph_schedule-spin-down"
   recurrence             = "29 19 * * MON-FRI"
-  time_zone              = "Europe/London"
   min_size               = -1
   max_size               = -1
   desired_capacity       = 0


### PR DESCRIPTION
The version of terraform currently used in this repo (0.11.15) doesn't support `time_zone` so instead we're changing the generation and start time to an hour earlier