### PR TITLE
Remove obsolete public facing load balancers

### DIFF
--- a/terraform/projects/app-content-store/README.md
+++ b/terraform/projects/app-content-store/README.md
@@ -21,7 +21,6 @@ content-store node
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alarms-elb-content-store-external"></a> [alarms-elb-content-store-external](#module\_alarms-elb-content-store-external) | ../../modules/aws/alarms/elb | n/a |
 | <a name="module_alarms-elb-content-store-internal"></a> [alarms-elb-content-store-internal](#module\_alarms-elb-content-store-internal) | ../../modules/aws/alarms/elb | n/a |
 | <a name="module_content-store"></a> [content-store](#module\_content-store) | ../../modules/aws/node_group | n/a |
 
@@ -29,9 +28,7 @@ content-store node
 
 | Name | Type |
 |------|------|
-| [aws_elb.content-store_external_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/elb) | resource |
 | [aws_elb.content-store_internal_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/elb) | resource |
-| [aws_route53_record.external_service_record](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.internal_service_record](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [null_resource.user_data](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_acm_certificate.elb_external_cert](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/acm_certificate) | data source |
@@ -52,7 +49,7 @@ content-store node
 | <a name="input_asg_size"></a> [asg\_size](#input\_asg\_size) | The autoscaling groups desired/max/min capacity | `string` | `"2"` | no |
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
-| <a name="input_create_external_elb"></a> [create\_external\_elb](#input\_create\_external\_elb) | Create the external ELB | `bool` | `true` | no |
+| <a name="input_create_external_elb"></a> [create\_external\_elb](#input\_create\_external\_elb) | Create the external ELB | `bool` | `false` | no |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
@@ -75,6 +72,4 @@ content-store node
 
 | Name | Description |
 |------|-------------|
-| <a name="output_content-store_elb_address"></a> [content-store\_elb\_address](#output\_content-store\_elb\_address) | AWS' internal DNS name for the content-store ELB |
-| <a name="output_external_service_dns_name"></a> [external\_service\_dns\_name](#output\_external\_service\_dns\_name) | DNS name to access the node service |
 | <a name="output_internal_service_dns_name"></a> [internal\_service\_dns\_name](#output\_internal\_service\_dns\_name) | DNS name to access the node service |

--- a/terraform/projects/app-draft-content-store/README.md
+++ b/terraform/projects/app-draft-content-store/README.md
@@ -21,7 +21,6 @@ draft-content-store node
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alarms-elb-draft-content-store-external"></a> [alarms-elb-draft-content-store-external](#module\_alarms-elb-draft-content-store-external) | ../../modules/aws/alarms/elb | n/a |
 | <a name="module_alarms-elb-draft-content-store-internal"></a> [alarms-elb-draft-content-store-internal](#module\_alarms-elb-draft-content-store-internal) | ../../modules/aws/alarms/elb | n/a |
 | <a name="module_draft-content-store"></a> [draft-content-store](#module\_draft-content-store) | ../../modules/aws/node_group | n/a |
 
@@ -29,9 +28,7 @@ draft-content-store node
 
 | Name | Type |
 |------|------|
-| [aws_elb.draft-content-store_external_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/elb) | resource |
 | [aws_elb.draft-content-store_internal_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/elb) | resource |
-| [aws_route53_record.external_service_record](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.internal_service_record](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [null_resource.user_data](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_acm_certificate.elb_external_cert](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/acm_certificate) | data source |
@@ -52,7 +49,7 @@ draft-content-store node
 | <a name="input_asg_size"></a> [asg\_size](#input\_asg\_size) | The autoscaling groups desired/max/min capacity | `string` | `"2"` | no |
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
-| <a name="input_create_external_elb"></a> [create\_external\_elb](#input\_create\_external\_elb) | Create the external ELB | `bool` | `true` | no |
+| <a name="input_create_external_elb"></a> [create\_external\_elb](#input\_create\_external\_elb) | Create the external ELB | `bool` | `false` | no |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
@@ -75,6 +72,4 @@ draft-content-store node
 
 | Name | Description |
 |------|-------------|
-| <a name="output_draft-content-store_elb_address"></a> [draft-content-store\_elb\_address](#output\_draft-content-store\_elb\_address) | AWS' DNS name for the draft-content-store ELB |
-| <a name="output_external_service_dns_name"></a> [external\_service\_dns\_name](#output\_external\_service\_dns\_name) | DNS name to access the node service |
 | <a name="output_internal_service_dns_name"></a> [internal\_service\_dns\_name](#output\_internal\_service\_dns\_name) | DNS name to access the node service |

--- a/terraform/projects/app-draft-content-store/main.tf
+++ b/terraform/projects/app-draft-content-store/main.tf
@@ -63,7 +63,7 @@ variable "internal_domain_name" {
 
 variable "create_external_elb" {
   description = "Create the external ELB"
-  default     = true
+  default     = false
 }
 
 variable "instance_type" {
@@ -102,59 +102,6 @@ data "aws_acm_certificate" "elb_external_cert" {
 data "aws_acm_certificate" "elb_internal_cert" {
   domain   = "${var.elb_internal_certname}"
   statuses = ["ISSUED"]
-}
-
-resource "aws_elb" "draft-content-store_external_elb" {
-  count = "${var.create_external_elb}"
-
-  name            = "${var.stackname}-draft-content-store-ext"
-  subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_draft-content-store_external_elb_id}"]
-  internal        = "false"
-
-  access_logs {
-    bucket        = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-    bucket_prefix = "elb/${var.stackname}-draft-content-store-external-elb"
-    interval      = 60
-  }
-
-  listener {
-    instance_port     = "80"
-    instance_protocol = "http"
-    lb_port           = "443"
-    lb_protocol       = "https"
-
-    ssl_certificate_id = "${data.aws_acm_certificate.elb_external_cert.arn}"
-  }
-
-  health_check {
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-    timeout             = 3
-    target              = "HTTP:80/_healthcheck-live_draft-content-store"
-    interval            = 30
-  }
-
-  cross_zone_load_balancing   = true
-  idle_timeout                = 400
-  connection_draining         = true
-  connection_draining_timeout = 400
-
-  tags = "${map("Name", "${var.stackname}-draft-content-store", "Project", var.stackname, "aws_environment", var.aws_environment, "aws_migration", "draft_content_store")}"
-}
-
-resource "aws_route53_record" "external_service_record" {
-  count = "${var.create_external_elb}"
-
-  zone_id = "${data.aws_route53_zone.external.zone_id}"
-  name    = "draft-content-store.${var.external_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${aws_elb.draft-content-store_external_elb.dns_name}"
-    zone_id                = "${aws_elb.draft-content-store_external_elb.zone_id}"
-    evaluate_target_health = true
-  }
 }
 
 resource "aws_elb" "draft-content-store_internal_elb" {
@@ -247,31 +194,8 @@ locals {
   elb_httpcode_elb_5xx_threshold     = "${var.create_external_elb ? 50 : 0}"
 }
 
-module "alarms-elb-draft-content-store-external" {
-  source                         = "../../modules/aws/alarms/elb"
-  name_prefix                    = "${var.stackname}-draft-content-store-external"
-  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  elb_name                       = "${join("", aws_elb.draft-content-store_external_elb.*.name)}"
-  httpcode_backend_4xx_threshold = "0"
-  httpcode_backend_5xx_threshold = "${local.elb_httpcode_backend_5xx_threshold}"
-  httpcode_elb_4xx_threshold     = "0"
-  httpcode_elb_5xx_threshold     = "${local.elb_httpcode_elb_5xx_threshold}"
-  surgequeuelength_threshold     = "0"
-  healthyhostcount_threshold     = "0"
-}
-
 # Outputs
 # --------------------------------------------------------------
-
-output "draft-content-store_elb_address" {
-  value       = "${join("", aws_elb.draft-content-store_external_elb.*.dns_name)}"
-  description = "AWS' DNS name for the draft-content-store ELB"
-}
-
-output "external_service_dns_name" {
-  value       = "${join("", aws_route53_record.external_service_record.*.name)}"
-  description = "DNS name to access the node service"
-}
 
 output "internal_service_dns_name" {
   value       = "${aws_route53_record.internal_service_record.name}"

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -33,24 +33,16 @@ This project adds global resources for app components:
 | <a name="module_cache_public_lb"></a> [cache\_public\_lb](#module\_cache\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_cache_public_lb_rules"></a> [cache\_public\_lb\_rules](#module\_cache\_public\_lb\_rules) | ../../modules/aws/lb_listener_rules | n/a |
 | <a name="module_ckan_public_lb"></a> [ckan\_public\_lb](#module\_ckan\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_content-store_public_lb"></a> [content-store\_public\_lb](#module\_content-store\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_deploy_public_lb"></a> [deploy\_public\_lb](#module\_deploy\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_draft_cache_public_lb"></a> [draft\_cache\_public\_lb](#module\_draft\_cache\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_email_alert_api_public_lb"></a> [email\_alert\_api\_public\_lb](#module\_email\_alert\_api\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_feedback_public_lb"></a> [feedback\_public\_lb](#module\_feedback\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_graphite_public_lb"></a> [graphite\_public\_lb](#module\_graphite\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_licensify_backend_public_lb"></a> [licensify\_backend\_public\_lb](#module\_licensify\_backend\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_licensify_frontend_public_lb"></a> [licensify\_frontend\_public\_lb](#module\_licensify\_frontend\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_mapit_public_lb"></a> [mapit\_public\_lb](#module\_mapit\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_monitoring_public_lb"></a> [monitoring\_public\_lb](#module\_monitoring\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_prometheus_public_lb"></a> [prometheus\_public\_lb](#module\_prometheus\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_search_api_public_lb"></a> [search\_api\_public\_lb](#module\_search\_api\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_search_api_public_lb_rules"></a> [search\_api\_public\_lb\_rules](#module\_search\_api\_public\_lb\_rules) | ../../modules/aws/lb_listener_rules | n/a |
 | <a name="module_sidekiq_monitoring_public_lb"></a> [sidekiq\_monitoring\_public\_lb](#module\_sidekiq\_monitoring\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_static_public_lb"></a> [static\_public\_lb](#module\_static\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_support_api_public_lb"></a> [support\_api\_public\_lb](#module\_support\_api\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_whitehall_backend_public_lb"></a> [whitehall\_backend\_public\_lb](#module\_whitehall\_backend\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_whitehall_frontend_public_lb"></a> [whitehall\_frontend\_public\_lb](#module\_whitehall\_frontend\_public\_lb) | ../../modules/aws/lb | n/a |
 
 ## Resources
 
@@ -60,27 +52,17 @@ This project adds global resources for app components:
 | [aws_autoscaling_attachment.bouncer_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.cache_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.ckan_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.content-store_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.deploy_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.draft_cache_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.email_alert_api_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.frontend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.graphite_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.jumpbox_asg_attachment_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.licensify_backend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.licensify_frontend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.mapit-1_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.mapit-2_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.mapit-3_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.mapit-4_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.monitoring_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.prometheus_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.search_api_backend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.sidekiq_monitoring_backend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.static_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.support_api_backend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.whitehall_backend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.whitehall_frontend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_elb.jumpbox_public_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/elb) | resource |
 | [aws_iam_role.aws_waf_firehose](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role) | resource |
 | [aws_iam_role.aws_waf_log_trimmer](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role) | resource |
@@ -114,7 +96,6 @@ This project adds global resources for app components:
 | [aws_route53_record.ckan_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.ckan_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.ckan_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
-| [aws_route53_record.content-store_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.content_data_api_db_admin_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.content_data_api_postgresql_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.content_store_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
@@ -134,7 +115,6 @@ This project adds global resources for app components:
 | [aws_route53_record.elasticsearch6_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.email_alert_api_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.email_alert_api_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
-| [aws_route53_record.feedback_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.frontend_cache_name](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.frontend_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.frontend_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
@@ -150,7 +130,6 @@ This project adds global resources for app components:
 | [aws_route53_record.locations_api_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.mapit_cache_name](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.mapit_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
-| [aws_route53_record.mapit_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.mongo_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.monitoring_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.monitoring_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
@@ -160,18 +139,14 @@ This project adds global resources for app components:
 | [aws_route53_record.puppetmaster_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.rabbitmq_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.router_backend_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
-| [aws_route53_record.search_api_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.search_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.search_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.sidekiq_monitoring_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
-| [aws_route53_record.static_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
-| [aws_route53_record.support_api_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.transition_db_admin_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.transition_postgresql_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.whitehall_backend_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.whitehall_backend_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.whitehall_frontend_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
-| [aws_route53_record.whitehall_frontend_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_s3_bucket.aws_waf_logs](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/s3_bucket) | resource |
 | [aws_shield_protection.cache_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/shield_protection) | resource |
 | [aws_wafregional_regex_match_set.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_regex_match_set) | resource |
@@ -184,7 +159,6 @@ This project adds global resources for app components:
 | [aws_wafregional_web_acl_association.licensify_backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_web_acl_association) | resource |
 | [aws_wafregional_web_acl_association.licensify_frontend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_web_acl_association) | resource |
 | [aws_wafregional_web_acl_association.whitehall_backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_web_acl_association) | resource |
-| [aws_wafregional_web_acl_association.whitehall_frontend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/wafregional_web_acl_association) | resource |
 | [archive_file.aws_waf_log_trimmer](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_autoscaling_group.account](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_group) | data source |
 | [aws_autoscaling_group.backend](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/autoscaling_group) | data source |
@@ -278,7 +252,6 @@ This project adds global resources for app components:
 | <a name="input_email_alert_api_internal_service_names"></a> [email\_alert\_api\_internal\_service\_names](#input\_email\_alert\_api\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_email_alert_api_public_service_names"></a> [email\_alert\_api\_public\_service\_names](#input\_email\_alert\_api\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_enable_lb_app_healthchecks"></a> [enable\_lb\_app\_healthchecks](#input\_enable\_lb\_app\_healthchecks) | Use application specific target groups and healthchecks based on the list of services in the cname variable. | `string` | `false` | no |
-| <a name="input_feedback_public_service_names"></a> [feedback\_public\_service\_names](#input\_feedback\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_frontend_internal_service_cnames"></a> [frontend\_internal\_service\_cnames](#input\_frontend\_internal\_service\_cnames) | n/a | `list` | `[]` | no |
 | <a name="input_frontend_internal_service_names"></a> [frontend\_internal\_service\_names](#input\_frontend\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_graphite_internal_service_names"></a> [graphite\_internal\_service\_names](#input\_graphite\_internal\_service\_names) | n/a | `list` | `[]` | no |
@@ -293,7 +266,6 @@ This project adds global resources for app components:
 | <a name="input_locations_api_internal_service_names"></a> [locations\_api\_internal\_service\_names](#input\_locations\_api\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_locations_api_public_service_cnames"></a> [locations\_api\_public\_service\_cnames](#input\_locations\_api\_public\_service\_cnames) | n/a | `list` | `[]` | no |
 | <a name="input_mapit_internal_service_names"></a> [mapit\_internal\_service\_names](#input\_mapit\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_mapit_public_service_names"></a> [mapit\_public\_service\_names](#input\_mapit\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_mongo_internal_service_names"></a> [mongo\_internal\_service\_names](#input\_mongo\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_monitoring_internal_service_names"></a> [monitoring\_internal\_service\_names](#input\_monitoring\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_monitoring_internal_service_names_cname_dest"></a> [monitoring\_internal\_service\_names\_cname\_dest](#input\_monitoring\_internal\_service\_names\_cname\_dest) | This variable specifies the CNAME record destination to be associated with the service names defined in monitoring\_internal\_service\_names | `string` | `"alert"` | no |
@@ -316,8 +288,6 @@ This project adds global resources for app components:
 | <a name="input_search_internal_service_names"></a> [search\_internal\_service\_names](#input\_search\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_sidekiq_monitoring_public_service_names"></a> [sidekiq\_monitoring\_public\_service\_names](#input\_sidekiq\_monitoring\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
-| <a name="input_static_public_service_names"></a> [static\_public\_service\_names](#input\_static\_public\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_support_api_public_service_names"></a> [support\_api\_public\_service\_names](#input\_support\_api\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_transition_db_admin_internal_service_names"></a> [transition\_db\_admin\_internal\_service\_names](#input\_transition\_db\_admin\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_transition_postgresql_internal_service_names"></a> [transition\_postgresql\_internal\_service\_names](#input\_transition\_postgresql\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_waf_logs_hec_endpoint"></a> [waf\_logs\_hec\_endpoint](#input\_waf\_logs\_hec\_endpoint) | Splunk endpoint for shipping application firewall logs | `string` | n/a | yes |
@@ -327,7 +297,6 @@ This project adds global resources for app components:
 | <a name="input_whitehall_backend_public_service_cnames"></a> [whitehall\_backend\_public\_service\_cnames](#input\_whitehall\_backend\_public\_service\_cnames) | n/a | `list` | `[]` | no |
 | <a name="input_whitehall_backend_public_service_names"></a> [whitehall\_backend\_public\_service\_names](#input\_whitehall\_backend\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_whitehall_frontend_internal_service_names"></a> [whitehall\_frontend\_internal\_service\_names](#input\_whitehall\_frontend\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_whitehall_frontend_public_service_names"></a> [whitehall\_frontend\_public\_service\_names](#input\_whitehall\_frontend\_public\_service\_names) | n/a | `list` | `[]` | no |
 
 ## Outputs
 

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -171,11 +171,6 @@ variable "email_alert_api_public_service_names" {
   default = []
 }
 
-variable "feedback_public_service_names" {
-  type    = "list"
-  default = []
-}
-
 variable "graphite_public_service_names" {
   type    = "list"
   default = []
@@ -1323,44 +1318,6 @@ resource "aws_route53_record" "email_alert_api_internal_service_names" {
   ttl     = "300"
 }
 
-#
-# feedback
-#
-
-module "feedback_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-feedback-public"
-  internal                                   = true
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-feedback-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-
-  listener_action = {
-    "HTTPS:443" = "HTTP:80"
-  }
-
-  target_group_health_check_path = "/_healthcheck-ready_feedback"
-  subnets                        = ["${data.terraform_remote_state.infra_networking.private_subnet_ids}"]
-  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_feedback_elb_id}"]
-  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                   = "${map("Project", var.stackname, "aws_migration", "feedback", "aws_environment", var.aws_environment)}"
-}
-
-resource "aws_route53_record" "feedback_public_service_names" {
-  count   = "${length(var.feedback_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
-  name    = "${element(var.feedback_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.feedback_public_lb.lb_dns_name}"
-    zone_id                = "${module.feedback_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
 data "aws_autoscaling_groups" "frontend" {
   filter {
     name   = "key"
@@ -1371,12 +1328,6 @@ data "aws_autoscaling_groups" "frontend" {
     name   = "value"
     values = ["blue-frontend"]
   }
-}
-
-resource "aws_autoscaling_attachment" "frontend_asg_attachment_alb" {
-  count                  = "${length(data.aws_autoscaling_groups.frontend.names) > 0 ? 1 : 0}"
-  autoscaling_group_name = "${element(data.aws_autoscaling_groups.frontend.names, 0)}"
-  alb_target_group_arn   = "${element(module.feedback_public_lb.target_group_arns, 0)}"
 }
 
 #

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1054,40 +1054,6 @@ resource "aws_route53_record" "content_data_api_postgresql_internal_service_name
 
 # Content-store
 
-module "content-store_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-content-store-public"
-  internal                                   = false
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-content-store-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-
-  listener_action = {
-    "HTTPS:443" = "HTTP:80"
-  }
-
-  target_group_health_check_path = "/_healthcheck-ready_content-store"
-  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_content-store_external_elb_id}"]
-  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                   = "${map("Project", var.stackname, "aws_migration", "content-store", "aws_environment", var.aws_environment)}"
-}
-
-resource "aws_route53_record" "content-store_public_service_names" {
-  count   = "${length(var.content_store_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
-  name    = "${element(var.content_store_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.content-store_public_lb.lb_dns_name}"
-    zone_id                = "${module.content-store_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
 data "aws_autoscaling_groups" "content-store" {
   filter {
     name   = "key"
@@ -1098,12 +1064,6 @@ data "aws_autoscaling_groups" "content-store" {
     name   = "value"
     values = ["blue-content-store"]
   }
-}
-
-resource "aws_autoscaling_attachment" "content-store_asg_attachment_alb" {
-  count                  = "${length(data.aws_autoscaling_groups.content-store.names) > 0 ? 1 : 0}"
-  autoscaling_group_name = "${element(data.aws_autoscaling_groups.content-store.names, 0)}"
-  alb_target_group_arn   = "${element(module.content-store_public_lb.target_group_arns, 0)}"
 }
 
 resource "aws_route53_record" "content_store_internal_service_names" {

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -2080,48 +2080,6 @@ data "aws_autoscaling_groups" "static" {
   }
 }
 
-# support-api
-
-module "support_api_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-support-api-public"
-  internal                                   = false
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-support-api-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-
-  listener_action = {
-    "HTTPS:443" = "HTTP:80"
-  }
-
-  target_group_health_check_path = "/_healthcheck-ready_support-api"
-  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_support-api_external_elb_id}"]
-  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                   = "${map("Project", var.stackname, "aws_migration", "support-api", "aws_environment", var.aws_environment)}"
-}
-
-resource "aws_route53_record" "support_api_public_service_names" {
-  count   = "${length(var.support_api_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
-  name    = "${element(var.support_api_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.support_api_public_lb.lb_dns_name}"
-    zone_id                = "${module.support_api_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_autoscaling_attachment" "support_api_backend_asg_attachment_alb" {
-  count                  = "${data.aws_autoscaling_group.backend.name != "" ? 1 : 0}"
-  autoscaling_group_name = "${data.aws_autoscaling_group.backend.name}"
-  alb_target_group_arn   = "${element(module.support_api_public_lb.target_group_arns, 0)}"
-}
-
 #
 # sidekiq-monitoring
 #

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -2138,62 +2138,6 @@ resource "aws_route53_record" "search_internal_service_cnames" {
 }
 
 #
-# search-api
-#
-
-module "search_api_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-search-api-public"
-  internal                                   = false
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-search-api-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-
-  listener_action = {
-    "HTTPS:443" = "HTTP:80"
-  }
-
-  target_group_health_check_path = "/_healthcheck-ready_search-api"
-  subnets                        = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups                = ["${data.terraform_remote_state.infra_security_groups.sg_search-api_external_elb_id}"]
-  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                   = "${map("Project", var.stackname, "aws_migration", "search-api", "aws_environment", var.aws_environment)}"
-}
-
-resource "aws_route53_record" "search_api_public_service_names" {
-  count   = "${length(var.search_api_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
-  name    = "${element(var.search_api_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.search_api_public_lb.lb_dns_name}"
-    zone_id                = "${module.search_api_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-module "search_api_public_lb_rules" {
-  source                 = "../../modules/aws/lb_listener_rules"
-  name                   = "search-api"
-  autoscaling_group_name = "${data.aws_autoscaling_groups.search.names[0]}"
-  rules_host_domain      = "${var.aws_environment}.*"
-  vpc_id                 = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  listener_arn           = "${module.search_api_public_lb.load_balancer_ssl_listeners[0]}"
-  rules_host             = ["${compact(split(",", var.enable_lb_app_healthchecks ? join(",", var.search_api_public_service_names) : ""))}"]
-  priority_offset        = "1"
-  default_tags           = "${map("Project", var.stackname, "aws_migration", "search-api", "aws_environment", var.aws_environment)}"
-}
-
-resource "aws_autoscaling_attachment" "search_api_backend_asg_attachment_alb" {
-  count                  = "${length(data.aws_autoscaling_groups.search.names) > 0 ? 1 : 0}"
-  autoscaling_group_name = "${element(data.aws_autoscaling_groups.search.names, 0)}"
-  alb_target_group_arn   = "${element(module.search_api_public_lb.target_group_arns, 0)}"
-}
-
-#
 # Static
 #
 


### PR DESCRIPTION
During the migration from Carrenza to AWS some communication was needed between pat of the infrastructure in AWS and the part that was still running in Carrenza. Hence the need for public facing load balancers for services that would normally not require them.
Now that nothing is left running in Carrenza we can get rid of this vestigial infrastructure.
See also https://github.com/alphagov/govuk-aws-data/pull/1010