### PR TITLE
Move from Concourse to Jenkins for govuk-repo-mirror job

### DIFF
--- a/terraform/projects/infra-govuk-repo-mirror/README.md
+++ b/terraform/projects/infra-govuk-repo-mirror/README.md
@@ -1,8 +1,8 @@
 ## Module: govuk-repo-mirror
 
-Configures a user and role to allow the govuk-repo-mirror Concourse pipeline
-to push to AWS CodeCommit (the user is used by the Jenkins
-Deploy\_App job and the role is used by the Concourse mirroring job)
+Configures a user and role to allow the "Mirror GitHub repositories"
+Jenkins job to push to AWS CodeCommit. See
+See https://deploy.integration.publishing.service.gov.uk/job/Mirror_Github_Repositories/
 
 ## Requirements
 
@@ -26,16 +26,11 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_role.govuk_concourse_codecommit_role](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.govuk_concourse_codecommit_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role.govuk_jenkins_codecommit_role](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.govuk_jenkins_codecommit_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_user.govuk_codecommit_user](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_user) | resource |
-| [aws_iam_user.govuk_concourse_codecommit_user](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy_attachment.govuk_codecommit_user_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_user_policy_attachment) | resource |
-| [aws_iam_user_policy_attachment.govuk_concourse_codecommit_user_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_user_policy_attachment) | resource |
-| [aws_iam_user_ssh_key.govuk_codecommit_user_jenkins_production_ssh_key](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_user_ssh_key) | resource |
-| [aws_iam_user_ssh_key.govuk_codecommit_user_jenkins_staging_ssh_key](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_user_ssh_key) | resource |
-| [aws_iam_user_ssh_key.govuk_concourse_codecommit_production_user_ssh_key](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_user_ssh_key) | resource |
-| [aws_iam_user_ssh_key.govuk_concourse_codecommit_staging_user_ssh_key](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_user_ssh_key) | resource |
+| [aws_iam_user_ssh_key.govuk_repo_mirror_user_ssh_public_key](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_user_ssh_key) | resource |
 | [terraform_remote_state.infra_monitoring](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_networking](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_root_dns_zones](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -49,9 +44,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
-| <a name="input_concourse_role_arn"></a> [concourse\_role\_arn](#input\_concourse\_role\_arn) | The role ARN of the role that Concourse uses to assume the govuk\_concourse\_codecommit\_role role | `string` | n/a | yes |
-| <a name="input_jenkins_carrenza_production_ssh_public_key"></a> [jenkins\_carrenza\_production\_ssh\_public\_key](#input\_jenkins\_carrenza\_production\_ssh\_public\_key) | The SSH public key of the Jenkins instance in the Carrenza production environment | `string` | n/a | yes |
-| <a name="input_jenkins_carrenza_staging_ssh_public_key"></a> [jenkins\_carrenza\_staging\_ssh\_public\_key](#input\_jenkins\_carrenza\_staging\_ssh\_public\_key) | The SSH public key of the Jenkins instance in the Carrenza staging environment | `string` | n/a | yes |
+| <a name="input_govuk_repo_mirror_user_ssh_public_key"></a> [govuk\_repo\_mirror\_user\_ssh\_public\_key](#input\_govuk\_repo\_mirror\_user\_ssh\_public\_key) | The SSH public key of the govuk-repo-mirror-user user in AWS | `string` | n/a | yes |
+| <a name="input_jenkins_role_arn"></a> [jenkins\_role\_arn](#input\_jenkins\_role\_arn) | The role ARN of the role that Jenkins uses to assume the govuk\_jenkins\_codecommit\_role role | `string` | n/a | yes |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | <a name="input_remote_state_infra_monitoring_key_stack"></a> [remote\_state\_infra\_monitoring\_key\_stack](#input\_remote\_state\_infra\_monitoring\_key\_stack) | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_networking_key_stack"></a> [remote\_state\_infra\_networking\_key\_stack](#input\_remote\_state\_infra\_networking\_key\_stack) | Override infra\_networking remote state path | `string` | `""` | no |

--- a/terraform/projects/infra-govuk-repo-mirror/integration.govuk.backend
+++ b/terraform/projects/infra-govuk-repo-mirror/integration.govuk.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-integration"
+key     = "govuk/infra-govuk-repo-mirror.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/projects/infra-govuk-repo-mirror/main.tf
+++ b/terraform/projects/infra-govuk-repo-mirror/main.tf
@@ -1,9 +1,9 @@
 /**
 * ## Module: govuk-repo-mirror
 *
-* Configures a user and role to allow the govuk-repo-mirror Concourse pipeline
-* to push to AWS CodeCommit (the user is used by the Jenkins
-* Deploy_App job and the role is used by the Concourse mirroring job)
+* Configures a user and role to allow the "Mirror GitHub repositories"
+* Jenkins job to push to AWS CodeCommit. See
+* See https://deploy.integration.publishing.service.gov.uk/job/Mirror_Github_Repositories/
 */
 variable "aws_region" {
   type        = "string"
@@ -21,19 +21,14 @@ variable "stackname" {
   description = "Stackname"
 }
 
-variable "jenkins_carrenza_staging_ssh_public_key" {
+variable "govuk_repo_mirror_user_ssh_public_key" {
   type        = "string"
-  description = "The SSH public key of the Jenkins instance in the Carrenza staging environment"
+  description = "The SSH public key of the govuk-repo-mirror-user user in AWS"
 }
 
-variable "jenkins_carrenza_production_ssh_public_key" {
+variable "jenkins_role_arn" {
   type        = "string"
-  description = "The SSH public key of the Jenkins instance in the Carrenza production environment"
-}
-
-variable "concourse_role_arn" {
-  type        = "string"
-  description = "The role ARN of the role that Concourse uses to assume the govuk_concourse_codecommit_role role"
+  description = "The role ARN of the role that Jenkins uses to assume the govuk_jenkins_codecommit_role role"
 }
 
 terraform {
@@ -47,7 +42,7 @@ provider "aws" {
 }
 
 resource "aws_iam_user" "govuk_codecommit_user" {
-  name = "govuk-${var.aws_environment}-govuk-code-commit-user"
+  name = "govuk-repo-mirror-user"
 }
 
 resource "aws_iam_user_policy_attachment" "govuk_codecommit_user_policy_attachment" {
@@ -55,41 +50,14 @@ resource "aws_iam_user_policy_attachment" "govuk_codecommit_user_policy_attachme
   policy_arn = "arn:aws:iam::aws:policy/AWSCodeCommitPowerUser"
 }
 
-resource "aws_iam_user_ssh_key" "govuk_codecommit_user_jenkins_staging_ssh_key" {
+resource "aws_iam_user_ssh_key" "govuk_repo_mirror_user_ssh_public_key" {
   username   = "${aws_iam_user.govuk_codecommit_user.name}"
   encoding   = "SSH"
-  public_key = "${var.jenkins_carrenza_staging_ssh_public_key}"
+  public_key = "${var.govuk_repo_mirror_user_ssh_public_key}"
 }
 
-resource "aws_iam_user_ssh_key" "govuk_codecommit_user_jenkins_production_ssh_key" {
-  username   = "${aws_iam_user.govuk_codecommit_user.name}"
-  encoding   = "SSH"
-  public_key = "${var.jenkins_carrenza_production_ssh_public_key}"
-}
-
-resource "aws_iam_user" "govuk_concourse_codecommit_user" {
-  name = "govuk-concourse-codecommit-user"
-}
-
-resource "aws_iam_user_policy_attachment" "govuk_concourse_codecommit_user_policy_attachment" {
-  user       = "${aws_iam_user.govuk_concourse_codecommit_user.name}"
-  policy_arn = "arn:aws:iam::aws:policy/AWSCodeCommitPowerUser"
-}
-
-resource "aws_iam_user_ssh_key" "govuk_concourse_codecommit_staging_user_ssh_key" {
-  username   = "${aws_iam_user.govuk_concourse_codecommit_user.name}"
-  encoding   = "SSH"
-  public_key = "${var.jenkins_carrenza_staging_ssh_public_key}"
-}
-
-resource "aws_iam_user_ssh_key" "govuk_concourse_codecommit_production_user_ssh_key" {
-  username   = "${aws_iam_user.govuk_concourse_codecommit_user.name}"
-  encoding   = "SSH"
-  public_key = "${var.jenkins_carrenza_production_ssh_public_key}"
-}
-
-resource "aws_iam_role" "govuk_concourse_codecommit_role" {
-  name = "govuk-concourse-codecommit-role"
+resource "aws_iam_role" "govuk_jenkins_codecommit_role" {
+  name = "govuk-repo-mirror-role"
   path = "/"
 
   assume_role_policy = <<EOF
@@ -99,7 +67,7 @@ resource "aws_iam_role" "govuk_concourse_codecommit_role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "AWS": "${var.concourse_role_arn}"
+        "AWS": "${var.jenkins_role_arn}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -109,7 +77,7 @@ resource "aws_iam_role" "govuk_concourse_codecommit_role" {
 EOF
 }
 
-resource "aws_iam_role_policy_attachment" "govuk_concourse_codecommit_role_policy_attachment" {
-  role       = "${aws_iam_role.govuk_concourse_codecommit_role.name}"
+resource "aws_iam_role_policy_attachment" "govuk_jenkins_codecommit_role_policy_attachment" {
+  role       = "${aws_iam_role.govuk_jenkins_codecommit_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/AWSCodeCommitPowerUser"
 }

--- a/terraform/projects/infra-govuk-repo-mirror/tools.govuk.backend
+++ b/terraform/projects/infra-govuk-repo-mirror/tools.govuk.backend
@@ -1,4 +1,0 @@
-bucket  = "govuk-terraform-steppingstone-tools"
-key     = "govuk/infra-govuk-repo-mirror.tfstate"
-encrypt = true
-region  = "eu-west-2"


### PR DESCRIPTION
Concourse is no longer supported, so we're moving the repo mirroring job to Jenkins. We can reuse much of the Terraform though.

The previous Terraform was overcomplicated, handling Carrenza environments and creating multiple users. We only need one user and one role, and we only need to grant `AWSCodeCommitPowerUser` permission to the role.

There was some discussion (with Roch) as to whether this should continue to exist in the `tools` AWS environment, which was introduced [about 2.5 years ago](https://github.com/alphagov/govuk-aws/commit/608cefb10b6a58fadd42aa4df588d8d2efb224a0) as a place for 'meta' production services. But the `tools` environment is not documented anywhere and thus doesn't give much reassurance that we can restore code from CodeCommit in an emergency. There is also a school of thought that such things are deemed essential, thus should live in the production environment. But we're also inconsistent on this - for example, the 'deploy terraform' job is essential but exists in Integration.

In the absence of a clear policy of environments, integration seems as good a place as any to house this job.

Depends on https://github.com/alphagov/govuk-aws-data/pull/1021.

Trello: https://trello.com/c/QlPzhn6A/2814-move-code-repository-mirroring-off-of-concourse