### PR TITLE
Allow Jenkins to assume the govuk-codecommit-poweruser role

### DIFF
--- a/terraform/projects/app-deploy/README.md
+++ b/terraform/projects/app-deploy/README.md
@@ -31,7 +31,9 @@ Deploy node
 | [aws_ebs_volume.deploy](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/ebs_volume) | resource |
 | [aws_elb.deploy_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/elb) | resource |
 | [aws_elb.deploy_internal_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/elb) | resource |
+| [aws_iam_policy.allow_assume_tools_codecommit_poweruser_policy](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.deploy_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_policy) | resource |
+| [aws_iam_role_policy_attachment.allow_assume_role_concourse_code_commit](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.allow_reads_from_artefact_bucket](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.allow_writes_from_artefact_bucket](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.deploy_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
@@ -42,6 +44,7 @@ Deploy node
 | [null_resource.user_data](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_acm_certificate.elb_external_cert](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/acm_certificate) | data source |
 | [aws_acm_certificate.elb_internal_cert](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/acm_certificate) | data source |
+| [aws_iam_policy_document.allow_assume_tools_codecommit_poweruser_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.external](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/route53_zone) | data source |
 | [aws_route53_zone.internal](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/route53_zone) | data source |
 | [terraform_remote_state.app_related_links](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -82,6 +85,7 @@ Deploy node
 | <a name="input_remote_state_infra_stack_dns_zones_key_stack"></a> [remote\_state\_infra\_stack\_dns\_zones\_key\_stack](#input\_remote\_state\_infra\_stack\_dns\_zones\_key\_stack) | Override stackname path to infra\_stack\_dns\_zones remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override infra\_vpc remote state path | `string` | `""` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
+| <a name="input_tools_govuk_codecommit_poweruser_role_arn"></a> [tools\_govuk\_codecommit\_poweruser\_role\_arn](#input\_tools\_govuk\_codecommit\_poweruser\_role\_arn) | ARN of the role that Integration Jenkins to assume the Tools govuk\_codecommit\_poweruser role | `string` | `""` | no |
 | <a name="input_user_data_snippets"></a> [user\_data\_snippets](#input\_user\_data\_snippets) | List of user-data snippets | `list` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/app-deploy/user_data_snippets.tf
+++ b/terraform/projects/app-deploy/user_data_snippets.tf
@@ -6,7 +6,7 @@
 #
 # To concatenate the snippets, use:
 # ${join("\n", null_resource.user_data.*.triggers.snippet)}
-# 
+#
 
 variable "user_data_snippets" {
   type        = "list"

--- a/terraform/projects/infra-govuk-repo-mirror/README.md
+++ b/terraform/projects/infra-govuk-repo-mirror/README.md
@@ -1,8 +1,11 @@
 ## Module: govuk-repo-mirror
 
-Configures a user and role to allow the govuk-repo-mirror Concourse pipeline
-to push to AWS CodeCommit (the user is used by the Jenkins
-Deploy\_App job and the role is used by the Concourse mirroring job)
+Configures:
+1. an IAM role to allow the `mirror_github_repositories` Jenkins job
+   in Integration to mirror the GOV.UK GitHub repositories to AWS CodeCommit in
+   Tools
+2. an IAM user with SSH authorized keys from Jenkins in Integration, Staging and
+   Production to access to AWS CodeCommit in Tools to deploy applications
 
 ## Requirements
 
@@ -26,8 +29,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_role.govuk_concourse_codecommit_role](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.govuk_concourse_codecommit_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role.govuk_codecommit_poweruser](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.govuk_codecommit_poweruser_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_user.govuk_codecommit_user](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_user) | resource |
 | [aws_iam_user.govuk_concourse_codecommit_user](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy_attachment.govuk_codecommit_user_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_user_policy_attachment) | resource |
@@ -49,7 +52,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
-| <a name="input_concourse_role_arn"></a> [concourse\_role\_arn](#input\_concourse\_role\_arn) | The role ARN of the role that Concourse uses to assume the govuk\_concourse\_codecommit\_role role | `string` | n/a | yes |
+| <a name="input_integration_jenkins_role_arn"></a> [integration\_jenkins\_role\_arn](#input\_integration\_jenkins\_role\_arn) | ARN of the role that Jenkins uses to assume the govuk\_codecommit\_poweruser role | `string` | n/a | yes |
 | <a name="input_jenkins_carrenza_production_ssh_public_key"></a> [jenkins\_carrenza\_production\_ssh\_public\_key](#input\_jenkins\_carrenza\_production\_ssh\_public\_key) | The SSH public key of the Jenkins instance in the Carrenza production environment | `string` | n/a | yes |
 | <a name="input_jenkins_carrenza_staging_ssh_public_key"></a> [jenkins\_carrenza\_staging\_ssh\_public\_key](#input\_jenkins\_carrenza\_staging\_ssh\_public\_key) | The SSH public key of the Jenkins instance in the Carrenza staging environment | `string` | n/a | yes |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |


### PR DESCRIPTION
Depends on https://github.com/alphagov/govuk-aws-data/pull/1022

These are the minimum changes required to move the repository
mirroring pipeline out of Concourse and into Jenkins. Whilst we
could go down the route of creating a brand new user and role
for Jenkins, the existing pipeline is quite tightly coupled to
the Concourse user/role and existing SSH keys, so is best left
as-is:
https://docs.publishing.service.gov.uk/manual/github-unavailable.html

We can look at removing outdated config and renaming away from
'Concourse' later once the new pipeline is working.

Trello: https://trello.com/c/QlPzhn6A/2814-move-code-repository-mirroring-off-of-concourse