### PR TITLE
Remove legacy roles

### DIFF
--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -24,16 +24,11 @@ Infrastructure security settings:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_gds_role_admin"></a> [gds\_role\_admin](#module\_gds\_role\_admin) | ../../modules/aws/iam/gds_user_role | n/a |
-| <a name="module_gds_role_poweruser"></a> [gds\_role\_poweruser](#module\_gds\_role\_poweruser) | ../../modules/aws/iam/gds_user_role | n/a |
-| <a name="module_gds_role_user"></a> [gds\_role\_user](#module\_gds\_role\_user) | ../../modules/aws/iam/gds_user_role | n/a |
-| <a name="module_role_admin"></a> [role\_admin](#module\_role\_admin) | ../../modules/aws/iam/role_user | n/a |
+| <a name="module_gds_admin_roles"></a> [gds\_admin\_roles](#module\_gds\_admin\_roles) | ../../modules/aws/iam/gds_user_role | n/a |
+| <a name="module_gds_poweruser_roles"></a> [gds\_poweruser\_roles](#module\_gds\_poweruser\_roles) | ../../modules/aws/iam/gds_user_role | n/a |
+| <a name="module_gds_readonly_roles"></a> [gds\_readonly\_roles](#module\_gds\_readonly\_roles) | ../../modules/aws/iam/gds_user_role | n/a |
 | <a name="module_role_dataengineeruser"></a> [role\_dataengineeruser](#module\_role\_dataengineeruser) | ../../modules/aws/iam/role_user | n/a |
 | <a name="module_role_datascienceuser"></a> [role\_datascienceuser](#module\_role\_datascienceuser) | ../../modules/aws/iam/role_user | n/a |
-| <a name="module_role_internal_admin"></a> [role\_internal\_admin](#module\_role\_internal\_admin) | ../../modules/aws/iam/role_user | n/a |
-| <a name="module_role_platformhealth_poweruser"></a> [role\_platformhealth\_poweruser](#module\_role\_platformhealth\_poweruser) | ../../modules/aws/iam/role_user | n/a |
-| <a name="module_role_poweruser"></a> [role\_poweruser](#module\_role\_poweruser) | ../../modules/aws/iam/role_user | n/a |
-| <a name="module_role_user"></a> [role\_user](#module\_role\_user) | ../../modules/aws/iam/role_user | n/a |
 
 ## Resources
 
@@ -73,22 +68,17 @@ Infrastructure security settings:
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
+| <a name="input_gds_admin_role_policy_arns"></a> [gds\_admin\_role\_policy\_arns](#input\_gds\_admin\_role\_policy\_arns) | List of ARNs of policies to attach to the GDS GOV.UK Admin role | `list(any)` | `[]` | no |
+| <a name="input_gds_admin_role_user_arns"></a> [gds\_admin\_role\_user\_arns](#input\_gds\_admin\_role\_user\_arns) | List of ARNs of external users that can assume the GDS GOV.UK Admin role | `list(any)` | `[]` | no |
+| <a name="input_gds_poweruser_role_policy_arns"></a> [gds\_poweruser\_role\_policy\_arns](#input\_gds\_poweruser\_role\_policy\_arns) | List of ARNs of policies to attach to the GDS GOV.UK Poweruser role | `list(any)` | `[]` | no |
+| <a name="input_gds_readonly_role_policy_arns"></a> [gds\_readonly\_role\_policy\_arns](#input\_gds\_readonly\_role\_policy\_arns) | List of ARNs of policies to attach to the GDS GOV.UK Readonly role | `list(any)` | `[]` | no |
+| <a name="input_gds_readonly_role_user_arns"></a> [gds\_readonly\_role\_user\_arns](#input\_gds\_readonly\_role\_user\_arns) | List of ARNs of external users that can assume the GDS GOV.UK Readonly role | `list(any)` | `[]` | no |
 | <a name="input_office_ips"></a> [office\_ips](#input\_office\_ips) | An array of CIDR blocks that will be allowed offsite access. | `list(any)` | n/a | yes |
-| <a name="input_role_admin_policy_arns"></a> [role\_admin\_policy\_arns](#input\_role\_admin\_policy\_arns) | List of ARNs of policies to attach to the role | `list(any)` | `[]` | no |
-| <a name="input_role_admin_user_arns"></a> [role\_admin\_user\_arns](#input\_role\_admin\_user\_arns) | List of ARNs of external users that can assume the role | `list(any)` | `[]` | no |
 | <a name="input_role_dataengineeruser_policy_arns"></a> [role\_dataengineeruser\_policy\_arns](#input\_role\_dataengineeruser\_policy\_arns) | List of ARNs of policies to attach to the role | `list(any)` | `[]` | no |
 | <a name="input_role_dataengineeruser_user_arns"></a> [role\_dataengineeruser\_user\_arns](#input\_role\_dataengineeruser\_user\_arns) | List of ARNs of external users that can assume the role | `list(any)` | `[]` | no |
 | <a name="input_role_datascienceuser_policy_arns"></a> [role\_datascienceuser\_policy\_arns](#input\_role\_datascienceuser\_policy\_arns) | List of ARNs of policies to attach to the role | `list(any)` | `[]` | no |
 | <a name="input_role_datascienceuser_user_arns"></a> [role\_datascienceuser\_user\_arns](#input\_role\_datascienceuser\_user\_arns) | List of ARNs of external users that can assume the role | `list(any)` | `[]` | no |
-| <a name="input_role_internal_admin_policy_arns"></a> [role\_internal\_admin\_policy\_arns](#input\_role\_internal\_admin\_policy\_arns) | List of ARNs of policies to attach to the role | `list(any)` | `[]` | no |
-| <a name="input_role_internal_admin_user_arns"></a> [role\_internal\_admin\_user\_arns](#input\_role\_internal\_admin\_user\_arns) | List of ARNs of external users that can assume the role | `list(any)` | `[]` | no |
-| <a name="input_role_platformhealth_poweruser_policy_arns"></a> [role\_platformhealth\_poweruser\_policy\_arns](#input\_role\_platformhealth\_poweruser\_policy\_arns) | List of ARNs of policies to attach to the role | `list(any)` | `[]` | no |
-| <a name="input_role_platformhealth_poweruser_user_arns"></a> [role\_platformhealth\_poweruser\_user\_arns](#input\_role\_platformhealth\_poweruser\_user\_arns) | List of ARNs of external users that can assume the role | `list(any)` | `[]` | no |
-| <a name="input_role_poweruser_policy_arns"></a> [role\_poweruser\_policy\_arns](#input\_role\_poweruser\_policy\_arns) | List of ARNs of policies to attach to the role | `list(any)` | `[]` | no |
-| <a name="input_role_poweruser_user_arns"></a> [role\_poweruser\_user\_arns](#input\_role\_poweruser\_user\_arns) | List of ARNs of external users that can assume the role | `list(any)` | `[]` | no |
 | <a name="input_role_step_function_role_policy_arns"></a> [role\_step\_function\_role\_policy\_arns](#input\_role\_step\_function\_role\_policy\_arns) | List of ARNs of policies to attach to the role | `list(any)` | `[]` | no |
-| <a name="input_role_user_policy_arns"></a> [role\_user\_policy\_arns](#input\_role\_user\_policy\_arns) | List of ARNs of policies to attach to the role | `list(any)` | `[]` | no |
-| <a name="input_role_user_user_arns"></a> [role\_user\_user\_arns](#input\_role\_user\_user\_arns) | List of ARNs of external users that can assume the role | `list(any)` | `[]` | no |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The public part of an SSH keypair | `string` | `null` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | `""` | no |
 

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -26,51 +26,33 @@ variable "stackname" {
   default     = ""
 }
 
-variable "role_admin_user_arns" {
+variable "gds_admin_role_user_arns" {
   type        = list(any)
-  description = "List of ARNs of external users that can assume the role"
+  description = "List of ARNs of external users that can assume the GDS GOV.UK Admin role"
   default     = []
 }
 
-variable "role_admin_policy_arns" {
+variable "gds_admin_role_policy_arns" {
   type        = list(any)
-  description = "List of ARNs of policies to attach to the role"
+  description = "List of ARNs of policies to attach to the GDS GOV.UK Admin role"
   default     = []
 }
 
-variable "role_internal_admin_user_arns" {
+variable "gds_poweruser_role_policy_arns" {
   type        = list(any)
-  description = "List of ARNs of external users that can assume the role"
+  description = "List of ARNs of policies to attach to the GDS GOV.UK Poweruser role"
   default     = []
 }
 
-variable "role_internal_admin_policy_arns" {
+variable "gds_readonly_role_user_arns" {
   type        = list(any)
-  description = "List of ARNs of policies to attach to the role"
+  description = "List of ARNs of external users that can assume the GDS GOV.UK Readonly role"
   default     = []
 }
 
-variable "role_platformhealth_poweruser_user_arns" {
+variable "gds_readonly_role_policy_arns" {
   type        = list(any)
-  description = "List of ARNs of external users that can assume the role"
-  default     = []
-}
-
-variable "role_platformhealth_poweruser_policy_arns" {
-  type        = list(any)
-  description = "List of ARNs of policies to attach to the role"
-  default     = []
-}
-
-variable "role_poweruser_user_arns" {
-  type        = list(any)
-  description = "List of ARNs of external users that can assume the role"
-  default     = []
-}
-
-variable "role_poweruser_policy_arns" {
-  type        = list(any)
-  description = "List of ARNs of policies to attach to the role"
+  description = "List of ARNs of policies to attach to the GDS GOV.UK Readonly role"
   default     = []
 }
 
@@ -99,18 +81,6 @@ variable "role_dataengineeruser_policy_arns" {
 }
 
 variable "role_step_function_role_policy_arns" {
-  type        = list(any)
-  description = "List of ARNs of policies to attach to the role"
-  default     = []
-}
-
-variable "role_user_user_arns" {
-  type        = list(any)
-  description = "List of ARNs of external users that can assume the role"
-  default     = []
-}
-
-variable "role_user_policy_arns" {
   type        = list(any)
   description = "List of ARNs of policies to attach to the role"
   default     = []
@@ -148,48 +118,28 @@ provider "aws" {
 
 data "aws_caller_identity" "current" {}
 
-module "role_admin" {
-  source           = "../../modules/aws/iam/role_user"
-  role_name        = "govuk-administrators"
-  role_user_arns   = var.role_admin_user_arns
-  role_policy_arns = var.role_admin_policy_arns
-}
-
-module "gds_role_admin" {
+module "gds_admin_roles" {
   source           = "../../modules/aws/iam/gds_user_role"
   role_suffix      = "admin"
-  role_user_arns   = toset(concat(var.role_admin_user_arns, var.role_internal_admin_user_arns, var.role_platformhealth_poweruser_user_arns, var.role_poweruser_user_arns))
-  role_policy_arns = var.role_admin_policy_arns
+  role_user_arns   = toset(var.gds_admin_role_user_arns)
+  role_policy_arns = var.gds_admin_role_policy_arns
   office_ips       = var.office_ips
 }
 
-module "role_internal_admin" {
-  source           = "../../modules/aws/iam/role_user"
-  role_name        = "govuk-internal-administrators"
-  role_user_arns   = var.role_internal_admin_user_arns
-  role_policy_arns = var.role_internal_admin_policy_arns
-}
-
-module "role_platformhealth_poweruser" {
-  source           = "../../modules/aws/iam/role_user"
-  role_name        = "govuk-platformhealth-powerusers"
-  role_user_arns   = var.role_platformhealth_poweruser_user_arns
-  role_policy_arns = var.role_platformhealth_poweruser_policy_arns
-}
-
-module "gds_role_poweruser" {
+module "gds_poweruser_roles" {
   source           = "../../modules/aws/iam/gds_user_role"
   role_suffix      = "poweruser"
-  role_user_arns   = toset(concat(var.role_admin_user_arns, var.role_internal_admin_user_arns, var.role_platformhealth_poweruser_user_arns, var.role_poweruser_user_arns))
-  role_policy_arns = var.role_poweruser_policy_arns
+  role_user_arns   = toset(var.gds_admin_role_user_arns)
+  role_policy_arns = var.gds_poweruser_role_policy_arns
   office_ips       = var.office_ips
 }
 
-module "role_poweruser" {
-  source           = "../../modules/aws/iam/role_user"
-  role_name        = "govuk-powerusers"
-  role_user_arns   = var.role_poweruser_user_arns
-  role_policy_arns = var.role_poweruser_policy_arns
+module "gds_readonly_roles" {
+  source           = "../../modules/aws/iam/gds_user_role"
+  role_suffix      = "user"
+  role_user_arns   = toset(concat(var.gds_admin_role_user_arns, var.gds_readonly_role_user_arns))
+  role_policy_arns = var.gds_readonly_role_policy_arns
+  office_ips       = var.office_ips
 }
 
 module "role_datascienceuser" {
@@ -281,21 +231,6 @@ resource "aws_iam_policy" "event_bridge" {
 resource "aws_iam_role_policy_attachment" "event_bridge" {
   role       = aws_iam_role.event_bridge.name
   policy_arn = aws_iam_policy.event_bridge.arn
-}
-
-module "role_user" {
-  source           = "../../modules/aws/iam/role_user"
-  role_name        = "govuk-users"
-  role_user_arns   = var.role_user_user_arns
-  role_policy_arns = var.role_user_policy_arns
-}
-
-module "gds_role_user" {
-  source           = "../../modules/aws/iam/gds_user_role"
-  role_suffix      = "user"
-  role_user_arns   = toset(concat(var.role_admin_user_arns, var.role_internal_admin_user_arns, var.role_platformhealth_poweruser_user_arns, var.role_poweruser_user_arns, var.role_user_user_arns))
-  role_policy_arns = var.role_user_policy_arns
-  office_ips       = var.office_ips
 }
 
 resource "aws_iam_account_password_policy" "tighten_passwords" {
@@ -500,7 +435,7 @@ data "aws_iam_policy_document" "kms_sops_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [module.role_admin.role_arn, module.role_internal_admin.role_arn]
+      identifiers = [for role, arn in module.gds_admin_roles.roles_and_arns : arn]
     }
   }
 
@@ -519,7 +454,7 @@ data "aws_iam_policy_document" "kms_sops_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [module.role_admin.role_arn, module.role_internal_admin.role_arn]
+      identifiers = [for role, arn in module.gds_admin_roles.roles_and_arns : arn]
     }
   }
 
@@ -536,7 +471,7 @@ data "aws_iam_policy_document" "kms_sops_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [module.role_admin.role_arn, module.role_internal_admin.role_arn]
+      identifiers = [for role, arn in module.gds_admin_roles.roles_and_arns : arn]
     }
   }
 }
@@ -565,17 +500,17 @@ resource "aws_kms_key" "shared_documentdb" {
 # --------------------------------------------------------------
 
 output "admin_roles_and_arns" {
-  value       = module.gds_role_admin.roles_and_arns
+  value       = module.gds_admin_roles.roles_and_arns
   description = "Map of '$username-admin' to role ARN, for the *-admin roles. e.g. {'joe.bloggs-admin': 'arn:aws:iam::123467890123:role/joe.bloggs-admin'}"
 }
 
 output "poweruser_roles_and_arns" {
-  value       = module.gds_role_poweruser.roles_and_arns
+  value       = module.gds_poweruser_roles.roles_and_arns
   description = "Map of '$username-poweruser' to role ARN, for the *-poweruser roles. e.g. {'joe.bloggs-poweruser': 'arn:aws:iam::123467890123:role/joe.bloggs-poweruser'}"
 }
 
 output "user_roles_and_arns" {
-  value       = module.gds_role_user.roles_and_arns
+  value       = module.gds_readonly_roles.roles_and_arns
   description = "Map of '$username-user' to role ARN, for the *-user roles. e.g. {'joe.bloggs-user': 'arn:aws:iam::123467890123:role/joe.bloggs-user'}"
 }
 


### PR DESCRIPTION
In #1412, a role is created for each user per GOV.UK privilege
category. This was done as a workaround to the size limit of a
role in ARN where we can't create a single role per GOV.UK
privilege category and add in all the users of that category in.

As a temporary measure, we left the legacy roles there but now
we hit again that limit so it's time to remove these legary
roles. Developers had time to switch to their new roles now.