### PR TITLE
Create SSH user for govuk-repo-mirrorer and switch to script to production

### DIFF
--- a/terraform/projects/app-deploy/README.md
+++ b/terraform/projects/app-deploy/README.md
@@ -85,7 +85,7 @@ Deploy node
 | <a name="input_remote_state_infra_stack_dns_zones_key_stack"></a> [remote\_state\_infra\_stack\_dns\_zones\_key\_stack](#input\_remote\_state\_infra\_stack\_dns\_zones\_key\_stack) | Override stackname path to infra\_stack\_dns\_zones remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override infra\_vpc remote state path | `string` | `""` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
-| <a name="input_tools_govuk_codecommit_poweruser_role_arn"></a> [tools\_govuk\_codecommit\_poweruser\_role\_arn](#input\_tools\_govuk\_codecommit\_poweruser\_role\_arn) | ARN of the role that Integration Jenkins to assume the Tools govuk\_codecommit\_poweruser role | `string` | `""` | no |
+| <a name="input_tools_govuk_codecommit_poweruser_role_arn"></a> [tools\_govuk\_codecommit\_poweruser\_role\_arn](#input\_tools\_govuk\_codecommit\_poweruser\_role\_arn) | ARN of the role that Mirrorer Jenkins to assume the Tools govuk\_codecommit\_poweruser role | `string` | `""` | no |
 | <a name="input_user_data_snippets"></a> [user\_data\_snippets](#input\_user\_data\_snippets) | List of user-data snippets | `list` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/app-deploy/main.tf
+++ b/terraform/projects/app-deploy/main.tf
@@ -21,7 +21,7 @@ variable "aws_environment" {
 
 variable "tools_govuk_codecommit_poweruser_role_arn" {
   type        = "string"
-  description = "ARN of the role that Integration Jenkins to assume the Tools govuk_codecommit_poweruser role"
+  description = "ARN of the role that Mirrorer Jenkins to assume the Tools govuk_codecommit_poweruser role"
   default     = ""
 }
 
@@ -278,10 +278,10 @@ resource "aws_iam_policy" "deploy_iam_policy" {
   policy = "${file("${path.module}/additional_policy.json")}"
 }
 
-# Allow the Jenkins server in Integration to assume the govuk-codecommit-poweruser role
+# Allow the Jenkins server in Production to assume the govuk-codecommit-poweruser role
 # in the Tools account to mirror GitHub repos in AWS CodeCommit
 resource "aws_iam_policy" "allow_assume_tools_codecommit_poweruser_policy" {
-  count       = "${var.aws_environment == "integration" ? 1 : 0}"
+  count       = "${var.aws_environment == "production" ? 1 : 0}"
   name        = "govuk-${var.aws_environment}-tools-codecommit-poweruser-policy"
   description = "Allows assuming the role of 'govuk-codecommit-poweruser' in the Tools environment"
 
@@ -289,7 +289,7 @@ resource "aws_iam_policy" "allow_assume_tools_codecommit_poweruser_policy" {
 }
 
 data "aws_iam_policy_document" "allow_assume_tools_codecommit_poweruser_policy_document" {
-  count = "${var.aws_environment == "integration" ? 1 : 0}"
+  count = "${var.aws_environment == "production" ? 1 : 0}"
 
   statement {
     actions = [
@@ -318,7 +318,7 @@ resource "aws_iam_role_policy_attachment" "allow_reads_from_artefact_bucket" {
 }
 
 resource "aws_iam_role_policy_attachment" "allow_assume_role_concourse_code_commit" {
-  count      = "${var.aws_environment == "integration" ? 1 : 0}"
+  count      = "${var.aws_environment == "production" ? 1 : 0}"
   role       = "${module.deploy.instance_iam_role_name}"
   policy_arn = "${aws_iam_policy.allow_assume_tools_codecommit_poweruser_policy.arn}"
 }

--- a/terraform/projects/infra-govuk-repo-mirror/README.md
+++ b/terraform/projects/infra-govuk-repo-mirror/README.md
@@ -2,7 +2,7 @@
 
 Configures:
 1. an IAM role to allow the `mirror_github_repositories` Jenkins job
-   in Integration to mirror the GOV.UK GitHub repositories to AWS CodeCommit in
+   in Production to mirror the GOV.UK GitHub repositories to AWS CodeCommit in
    Tools
 2. an IAM user with SSH authorized keys from Jenkins in Integration, Staging and
    Production to access to AWS CodeCommit in Tools to deploy applications
@@ -31,9 +31,12 @@ No modules.
 | [aws_iam_policy.govuk_codecommit_user_gitpush_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.govuk_codecommit_poweruser](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.govuk_codecommit_poweruser_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_user.govuk_codecommit_mirrorer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.govuk_codecommit_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user_policy_attachment.govuk_codecommit_mirrorer_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.govuk_codecommit_user_readonly_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.govuk_codecommit_user_tag_resources_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [aws_iam_user_ssh_key.govuk_codecommit_mirrorer_ssh_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_ssh_key) | resource |
 | [aws_iam_user_ssh_key.govuk_codecommit_user_jenkins_ssh_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_ssh_key) | resource |
 | [aws_iam_policy_document.allow_codecommit_gitpush_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -43,8 +46,9 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
+| <a name="input_govuk_codecommit_mirrorer_ssh_key"></a> [govuk\_codecommit\_mirrorer\_ssh\_key](#input\_govuk\_codecommit\_mirrorer\_ssh\_key) | SSH key of the IAM user used by the GOV.UK repo mirroring script to access Tools AWS CodeCommit | `string` | n/a | yes |
 | <a name="input_govuk_environments_ssh_key"></a> [govuk\_environments\_ssh\_key](#input\_govuk\_environments\_ssh\_key) | Map of govuk-environment:ssh\_key used to define a GOV.UK environment Jenkins access to AWS CodeCommit | `list(object({ environment = string, ssh_key = string }))` | n/a | yes |
-| <a name="input_integration_jenkins_role_arn"></a> [integration\_jenkins\_role\_arn](#input\_integration\_jenkins\_role\_arn) | ARN of the role that Jenkins uses to assume the govuk\_codecommit\_poweruser role | `string` | n/a | yes |
+| <a name="input_mirrorer_jenkins_role_arn"></a> [mirrorer\_jenkins\_role\_arn](#input\_mirrorer\_jenkins\_role\_arn) | ARN of the role that Mirrorer Jenkins uses to assume the govuk\_codecommit\_poweruser role | `string` | n/a | yes |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
 
 ## Outputs


### PR DESCRIPTION
1. create in Tools a SSH user that the govuk-repo-mirrorer script will
   use
2. change IAM permissions so that the govuk-repo-mirrorer script can
   run in production only because integration has too wide access

Trello: https://trello.com/c/QlPzhn6A/2814-move-code-repository-mirroring-off-of-concourse