### PR TITLE
Sort out WAF baseline on public LBs

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -163,19 +163,15 @@ This project adds global resources for app components:
 | [aws_shield_protection.prometheus_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.sidekiq_monitoring_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.whitehall_backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/shield_protection) | resource |
-| [aws_wafregional_regex_match_set.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_regex_match_set) | resource |
-| [aws_wafregional_regex_pattern_set.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_regex_pattern_set) | resource |
-| [aws_wafregional_rule.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_rule) | resource |
-| [aws_wafregional_web_acl.default](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_web_acl) | resource |
-| [aws_wafregional_web_acl_association.account_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_web_acl_association) | resource |
-| [aws_wafregional_web_acl_association.backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_web_acl_association) | resource |
-| [aws_wafregional_web_acl_association.licensify_backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_web_acl_association) | resource |
-| [aws_wafregional_web_acl_association.licensify_frontend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_web_acl_association) | resource |
-| [aws_wafregional_web_acl_association.whitehall_backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_web_acl_association) | resource |
 | [aws_wafv2_regex_pattern_set.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_regex_pattern_set) | resource |
 | [aws_wafv2_rule_group.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_rule_group) | resource |
 | [aws_wafv2_web_acl.default](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl) | resource |
+| [aws_wafv2_web_acl_association.account_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_association.backend_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_association.cache_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_association.licensify_backend_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_association.licensify_frontend_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_association.whitehall_backend_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_logging_configuration.public_cache_web_acl_logging](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [archive_file.aws_waf_log_trimmer](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_autoscaling_group.account](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/data-sources/autoscaling_group) | data source |
@@ -318,6 +314,4 @@ This project adds global resources for app components:
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_default_waf_acl"></a> [default\_waf\_acl](#output\_default\_waf\_acl) | GOV.UK default regional WAF ACL |
+No outputs.

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -168,9 +168,18 @@ This project adds global resources for app components:
 | [aws_wafv2_web_acl.default](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl) | resource |
 | [aws_wafv2_web_acl_association.account_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_association.backend_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_association.bouncer_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_association.cache_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_association.ckan_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_association.deploy_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_association.draft_cache_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_association.email_alert_api_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_association.graphite_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_association.licensify_backend_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_association.licensify_frontend_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_association.monitoring_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_association.prometheus_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_association.sidekiq_monitoring_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_association.whitehall_backend_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_logging_configuration.public_cache_web_acl_logging](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [archive_file.aws_waf_log_trimmer](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |

--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -169,10 +169,14 @@ This project adds global resources for app components:
 | [aws_wafregional_web_acl.default](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_web_acl) | resource |
 | [aws_wafregional_web_acl_association.account_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_web_acl_association) | resource |
 | [aws_wafregional_web_acl_association.backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_web_acl_association) | resource |
-| [aws_wafregional_web_acl_association.cache_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_web_acl_association) | resource |
 | [aws_wafregional_web_acl_association.licensify_backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_web_acl_association) | resource |
 | [aws_wafregional_web_acl_association.licensify_frontend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_web_acl_association) | resource |
 | [aws_wafregional_web_acl_association.whitehall_backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafregional_web_acl_association) | resource |
+| [aws_wafv2_regex_pattern_set.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_regex_pattern_set) | resource |
+| [aws_wafv2_rule_group.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_rule_group) | resource |
+| [aws_wafv2_web_acl.default](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl) | resource |
+| [aws_wafv2_web_acl_association.cache_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_logging_configuration.public_cache_web_acl_logging](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [archive_file.aws_waf_log_trimmer](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_autoscaling_group.account](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/data-sources/autoscaling_group) | data source |
 | [aws_autoscaling_group.backend](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/data-sources/autoscaling_group) | data source |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -787,6 +787,11 @@ resource "aws_shield_protection" "bouncer_public_lb" {
   resource_arn = "${module.bouncer_public_lb.lb_id}"
 }
 
+resource "aws_wafv2_web_acl_association" "bouncer_public_web_acl" {
+  resource_arn = "${module.bouncer_public_lb.lb_id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
+}
+
 resource "aws_route53_record" "bouncer_public_service_names" {
   count   = "${length(var.bouncer_public_service_names)}"
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
@@ -963,6 +968,11 @@ resource "aws_shield_protection" "ckan_public_lb" {
   resource_arn = "${module.ckan_public_lb.lb_id}"
 }
 
+resource "aws_wafv2_web_acl_association" "ckan_public_web_acl" {
+  resource_arn = "${module.ckan_public_lb.lb_id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
+}
+
 resource "aws_route53_record" "ckan_public_service_names" {
   count   = "${length(var.ckan_public_service_names)}"
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
@@ -1104,6 +1114,11 @@ resource "aws_shield_protection" "deploy_public_lb" {
   resource_arn = "${module.deploy_public_lb.lb_id}"
 }
 
+resource "aws_wafv2_web_acl_association" "deploy_public_web_acl" {
+  resource_arn = "${module.deploy_public_lb.lb_id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
+}
+
 resource "aws_route53_record" "deploy_public_service_names" {
   count   = "${length(var.deploy_public_service_names)}"
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
@@ -1179,6 +1194,11 @@ module "draft_cache_public_lb" {
 resource "aws_shield_protection" "draft_cache_public_lb" {
   name         = "${var.stackname}-draft-cache-public-lb_shield"
   resource_arn = "${module.draft_cache_public_lb.lb_id}"
+}
+
+resource "aws_wafv2_web_acl_association" "draft_cache_public_web_acl" {
+  resource_arn = "${module.draft_cache_public_lb.lb_id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
 }
 
 resource "aws_route53_record" "draft_cache_public_service_names" {
@@ -1313,6 +1333,11 @@ resource "aws_shield_protection" "email_alert_api_public_lb" {
   resource_arn = "${module.email_alert_api_public_lb.lb_id}"
 }
 
+resource "aws_wafv2_web_acl_association" "email_alert_api_public_web_acl" {
+  resource_arn = "${module.email_alert_api_public_lb.lb_id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
+}
+
 resource "aws_route53_record" "email_alert_api_public_service_names" {
   count   = "${length(var.email_alert_api_public_service_names)}"
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
@@ -1420,6 +1445,11 @@ resource "aws_shield_protection" "graphite_public_lb" {
   resource_arn = "${module.graphite_public_lb.lb_id}"
 }
 
+resource "aws_wafv2_web_acl_association" "graphite_public_web_acl" {
+  resource_arn = "${module.graphite_public_lb.lb_id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
+}
+
 #
 # Prometheus
 #
@@ -1456,6 +1486,11 @@ module "prometheus_public_lb" {
 resource "aws_shield_protection" "prometheus_public_lb" {
   name         = "${var.stackname}-prometheus-public-lb_shield"
   resource_arn = "${module.prometheus_public_lb.lb_id}"
+}
+
+resource "aws_wafv2_web_acl_association" "prometheus_public_web_acl" {
+  resource_arn = "${module.prometheus_public_lb.lb_id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
 }
 
 resource "aws_route53_record" "prometheus_public_service_names" {
@@ -1806,7 +1841,6 @@ resource "aws_wafv2_web_acl_association" "licensify_backend_public_web_acl" {
   web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
 }
 
-
 resource "aws_route53_record" "licensify_backend_public_service_names" {
   count   = "${length(var.licensify_backend_public_service_names)}"
   zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
@@ -1943,6 +1977,11 @@ module "monitoring_public_lb" {
 resource "aws_shield_protection" "monitoring_public_lb" {
   name         = "${var.stackname}-monitoring-public-lb_shield"
   resource_arn = "${module.monitoring_public_lb.lb_id}"
+}
+
+resource "aws_wafv2_web_acl_association" "monitoring_public_web_acl" {
+  resource_arn = "${module.monitoring_public_lb.lb_id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
 }
 
 resource "aws_route53_record" "monitoring_public_service_names" {
@@ -2115,6 +2154,11 @@ module "sidekiq_monitoring_public_lb" {
 resource "aws_shield_protection" "sidekiq_monitoring_public_lb" {
   name         = "${var.stackname}-sidekiq-monitoring-public-lb_shield"
   resource_arn = "${module.sidekiq_monitoring_public_lb.lb_id}"
+}
+
+resource "aws_wafv2_web_acl_association" "sidekiq_monitoring_public_web_acl" {
+  resource_arn = "${module.sidekiq_monitoring_public_lb.lb_id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
 }
 
 resource "aws_route53_record" "sidekiq_monitoring_public_service_names" {

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -531,9 +531,9 @@ resource "aws_shield_protection" "account_public_lb" {
   resource_arn = "${module.account_public_lb.lb_id}"
 }
 
-resource "aws_wafregional_web_acl_association" "account_public_lb" {
+resource "aws_wafv2_web_acl_association" "account_public_web_acl" {
   resource_arn = "${module.account_public_lb.lb_id}"
-  web_acl_id   = "${aws_wafregional_web_acl.default.id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
 }
 
 module "account_public_lb_rules" {
@@ -658,9 +658,9 @@ resource "aws_shield_protection" "backend_public_lb" {
   resource_arn = "${module.backend_public_lb.lb_id}"
 }
 
-resource "aws_wafregional_web_acl_association" "backend_public_lb" {
+resource "aws_wafv2_web_acl_association" "backend_public_web_acl" {
   resource_arn = "${module.backend_public_lb.lb_id}"
-  web_acl_id   = "${aws_wafregional_web_acl.default.id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
 }
 
 resource "aws_lb_listener_rule" "backend_alb_blocked_host_headers" {
@@ -1686,9 +1686,9 @@ resource "aws_shield_protection" "licensify_frontend_public_lb" {
   resource_arn = "${module.licensify_frontend_public_lb.lb_id}"
 }
 
-resource "aws_wafregional_web_acl_association" "licensify_frontend_public_lb" {
+resource "aws_wafv2_web_acl_association" "licensify_frontend_web_acl" {
   resource_arn = "${module.licensify_frontend_public_lb.lb_id}"
-  web_acl_id   = "${aws_wafregional_web_acl.default.id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
 }
 
 resource "aws_route53_record" "licensify_frontend_public_service_names" {
@@ -1801,10 +1801,11 @@ resource "aws_shield_protection" "licensify_backend_public_lb" {
   resource_arn = "${module.licensify_backend_public_lb.lb_id}"
 }
 
-resource "aws_wafregional_web_acl_association" "licensify_backend_public_lb" {
+resource "aws_wafv2_web_acl_association" "licensify_backend_public_web_acl" {
   resource_arn = "${module.licensify_backend_public_lb.lb_id}"
-  web_acl_id   = "${aws_wafregional_web_acl.default.id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
 }
+
 
 resource "aws_route53_record" "licensify_backend_public_service_names" {
   count   = "${length(var.licensify_backend_public_service_names)}"
@@ -2196,9 +2197,9 @@ resource "aws_shield_protection" "whitehall_backend_public_lb" {
   resource_arn = "${module.whitehall_backend_public_lb.lb_id}"
 }
 
-resource "aws_wafregional_web_acl_association" "whitehall_backend_public_lb" {
+resource "aws_wafv2_web_acl_association" "whitehall_backend_public_web_acl" {
   resource_arn = "${module.whitehall_backend_public_lb.lb_id}"
-  web_acl_id   = "${aws_wafregional_web_acl.default.id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
 }
 
 resource "aws_route53_record" "whitehall_backend_public_service_names" {

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -847,9 +847,9 @@ module "cache_public_lb" {
   default_tags                               = "${map("Project", var.stackname, "aws_migration", "cache", "aws_environment", var.aws_environment)}"
 }
 
-resource "aws_wafregional_web_acl_association" "cache_public_web_acl" {
+resource "aws_wafv2_web_acl_association" "cache_public_web_acl" {
   resource_arn = "${module.cache_public_lb.lb_id}"
-  web_acl_id   = "${aws_wafregional_web_acl.default.id}"
+  web_acl_arn  = "${aws_wafv2_web_acl.default.arn}"
 }
 
 resource "aws_shield_protection" "cache_public_lb" {

--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -24,6 +24,47 @@ resource "aws_wafregional_web_acl" "default" {
   ]
 }
 
+resource "aws_wafv2_web_acl" "default" {
+  name  = "x-always-block_web_acl"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "x-always-block_web_acl_rule"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      rule_group_reference_statement {
+        arn = "${aws_wafv2_rule_group.x_always_block.arn}"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "x-always-block-rule-group"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "x-always-block-web-acl"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "public_cache_web_acl_logging" {
+  log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.splunk.arn}"]
+  resource_arn            = "${aws_wafv2_web_acl.default.arn}"
+}
+
 resource "aws_s3_bucket" "aws_waf_logs" {
   acl    = "private"
   bucket = "govuk-${var.aws_environment}-aws-waf-logs"

--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -1,29 +1,3 @@
-resource "aws_wafregional_web_acl" "default" {
-  name        = "CachePublicWebACL"
-  metric_name = "CachePublicWebACL"
-
-  default_action {
-    type = "ALLOW"
-  }
-
-  rule {
-    action {
-      type = "BLOCK"
-    }
-
-    priority = 2
-    rule_id  = "${aws_wafregional_rule.x_always_block.id}"
-  }
-
-  logging_configuration {
-    log_destination = "${aws_kinesis_firehose_delivery_stream.splunk.arn}"
-  }
-
-  depends_on = [
-    "aws_wafregional_rule.x_always_block",
-  ]
-}
-
 resource "aws_wafv2_web_acl" "default" {
   name  = "x-always-block_web_acl"
   scope = "REGIONAL"
@@ -213,9 +187,4 @@ resource "aws_kinesis_firehose_delivery_stream" "splunk" {
       }
     }
   }
-}
-
-output "default_waf_acl" {
-  value       = "${aws_wafregional_web_acl.default.id}"
-  description = "GOV.UK default regional WAF ACL"
 }

--- a/terraform/projects/infra-public-services/waf_test_rule.tf
+++ b/terraform/projects/infra-public-services/waf_test_rule.tf
@@ -2,36 +2,6 @@
 # we use it as a simple sanity check / acceptance test from smokey to ensure that
 # the waf is enabled and processing requests
 #
-resource "aws_wafregional_regex_pattern_set" "x_always_block" {
-  name                  = "XAlwaysBlock"
-  regex_pattern_strings = ["true"]
-}
-
-resource "aws_wafregional_regex_match_set" "x_always_block" {
-  name = "XAlwaysBlock"
-
-  regex_match_tuple {
-    field_to_match {
-      data = "X-Always-Block"
-      type = "HEADER"
-    }
-
-    regex_pattern_set_id = "${aws_wafregional_regex_pattern_set.x_always_block.id}"
-    text_transformation  = "NONE"
-  }
-}
-
-resource "aws_wafregional_rule" "x_always_block" {
-  name        = "XAlwaysBlock"
-  metric_name = "XAlwaysBlock"
-
-  predicate {
-    data_id = "${aws_wafregional_regex_match_set.x_always_block.id}"
-    negated = false
-    type    = "RegexMatch"
-  }
-}
-
 resource "aws_wafv2_regex_pattern_set" "x_always_block" {
   name        = "x-always-block_pattern"
   description = "Matches the text we expect in the header"

--- a/terraform/projects/infra-public-services/waf_test_rule.tf
+++ b/terraform/projects/infra-public-services/waf_test_rule.tf
@@ -31,3 +31,60 @@ resource "aws_wafregional_rule" "x_always_block" {
     type    = "RegexMatch"
   }
 }
+
+resource "aws_wafv2_regex_pattern_set" "x_always_block" {
+  name        = "x-always-block_pattern"
+  description = "Matches the text we expect in the header"
+  scope       = "REGIONAL"
+
+  regular_expression {
+    regex_string = "true"
+  }
+}
+
+resource "aws_wafv2_rule_group" "x_always_block" {
+  name  = "x-always-block_rule_group"
+  scope = "REGIONAL"
+
+  # regex_pattern_set = 25
+  # leaving a bit of head room as this number is immutable
+  capacity = 50
+
+  rule {
+    name     = "x-always-block_rule"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      regex_pattern_set_reference_statement {
+        arn = "${aws_wafv2_regex_pattern_set.x_always_block.arn}"
+
+        field_to_match {
+          single_header {
+            name = "x-always-block"
+          }
+        }
+
+        text_transformation {
+          priority = 1
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "x-always-block-rule"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "x-always-block-rule-group"
+    sampled_requests_enabled   = false
+  }
+}


### PR DESCRIPTION
This PR has three sections:

- converting the existing "classic" WAF to WAFv2 and applying it to the public cache LB as an example
- converting the other LBs that use the existing WAF to use the new WAF (and removing the old one)
- adding the new WAF to the public LBs that did not have anything applied

This is a stepping stone to make it easier to configure specific WAF configurations to each LB that needs it. The next step is to configure separate WebACLs for each LB that needs different configuration.

There is further context in each commit.

https://trello.com/c/IvZrVCL3/2869-setting-rate-limits-within-aws-waf