### PR TITLE
Give data scientists full access to S3 and EC2

### DIFF
--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -326,6 +326,8 @@ data "aws_iam_policy_document" "data-science-access-sagemaker" {
       "sagemaker:StartNotebookInstance",
       "sagemaker:StopNotebookInstance",
       "sagemaker:UpdateNotebookInstance",
+      "s3:*",
+      "ec2:*"
     ]
 
     effect    = "Allow"


### PR DESCRIPTION
Data scientists already have `AmazonSageMakerFullAccess` and `AmazonS3FullAccess` (among others) via the [managed policies listed here](https://github.com/alphagov/govuk-aws-data/blob/d79d71f2ea5199b523389e07be157e5260cfcc8f/data/infra-security/integration/common.tfvars#L80-L88).

It is difficult/impossible to give Data Scientists more access via that repo, because we hit a limit `Error: error reading IAM Role Managed Policy Attachment (govuk-datascienceusers:arn:aws:iam::210287912431:policy/govuk-pass-step-function-role): couldn't find resource`.  AWS allows at most 10 managed policies to be attached to a role, unless it is configured to allow 20, but that's the maximum.

A workaround is to use custom policies that include the same actions.  This PR uses an existing custom policy for data scientists, which already includes a subset of SageMaker actions, and adds all S3 and EC2 actions.  The only new actions it introduces are the EC2 ones.  These can later be reduced, by using the [IAM Access Analyzer](https://dwmkerr.com/building-least-privilege-permissions-aws/) to find out what actions we have actually taken.