### PR TITLE
Set detailed exit status for terrform plans

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -49,8 +49,9 @@ git clone --single-branch --branch "$GOVUK_AWS_DATA_BRANCH" git@github.com:alpha
 
 case $COMMAND in
   'apply') EXTRA='-auto-approve';;
-  'plan (destroy)') COMMAND='plan'; EXTRA='-destroy';;
+  'plan (destroy)') COMMAND='plan'; EXTRA='-detailed-exitcode -destroy';;
   'destroy') EXTRA='-force';;
+  'plan') EXTRA='-detailed-exitcode';;
 esac
 
 tools/build-terraform-project.sh -d './govuk-aws-data/data' \


### PR DESCRIPTION
Before there was a regex in Jenkins which interpreted `Plan ..`
as unstable builds. This is incorrect with newer versions of
Terraform which displays this line when doing applies with changes.

We now make terraform plan with detailed-exitcode so that it exits
with 2 when there are changes in the plan and Jenkins will mark the
build as unstable.