### PR TITLE
Output the IDs of infra-public resources

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -325,4 +325,21 @@ This project adds global resources for app components:
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_account_public_lb_id"></a> [account\_public\_lb\_id](#output\_account\_public\_lb\_id) | The ID of the account\_public load balancer |
+| <a name="output_backend_public_lb_id"></a> [backend\_public\_lb\_id](#output\_backend\_public\_lb\_id) | The ID of the backend\_public load balancer |
+| <a name="output_bouncer_public_lb_id"></a> [bouncer\_public\_lb\_id](#output\_bouncer\_public\_lb\_id) | The ID of the bouncer\_public load balancer |
+| <a name="output_cache_public_lb_id"></a> [cache\_public\_lb\_id](#output\_cache\_public\_lb\_id) | The ID of the cache\_public load balancer |
+| <a name="output_ckan_public_lb_id"></a> [ckan\_public\_lb\_id](#output\_ckan\_public\_lb\_id) | The ID of the ckan\_public load balancer |
+| <a name="output_deploy_public_lb_id"></a> [deploy\_public\_lb\_id](#output\_deploy\_public\_lb\_id) | The ID of the deploy\_public load balancer |
+| <a name="output_draft_cache_public_lb_id"></a> [draft\_cache\_public\_lb\_id](#output\_draft\_cache\_public\_lb\_id) | The ID of the draft\_cache\_public load balancer |
+| <a name="output_email_alert_api_public_lb_id"></a> [email\_alert\_api\_public\_lb\_id](#output\_email\_alert\_api\_public\_lb\_id) | The ID of the email\_alert\_api\_public load balancer |
+| <a name="output_graphite_public_lb_id"></a> [graphite\_public\_lb\_id](#output\_graphite\_public\_lb\_id) | The ID of the graphite\_public load balancer |
+| <a name="output_kinesis_firehose_splunk_arn"></a> [kinesis\_firehose\_splunk\_arn](#output\_kinesis\_firehose\_splunk\_arn) | The ARN of the splunk endpoint of the kinesis firehose stream |
+| <a name="output_licensify_backend_public_lb_id"></a> [licensify\_backend\_public\_lb\_id](#output\_licensify\_backend\_public\_lb\_id) | The ID of the licensify\_backend\_public load balancer |
+| <a name="output_licensify_frontend_public_lb_id"></a> [licensify\_frontend\_public\_lb\_id](#output\_licensify\_frontend\_public\_lb\_id) | The ID of the licensify\_frontend\_public\_lb load balancer |
+| <a name="output_monitoring_public_lb_id"></a> [monitoring\_public\_lb\_id](#output\_monitoring\_public\_lb\_id) | The ID of the monitoring\_public load balancer |
+| <a name="output_prometheus_public_lb_id"></a> [prometheus\_public\_lb\_id](#output\_prometheus\_public\_lb\_id) | The ID of the prometheus\_public load balancer |
+| <a name="output_sidekiq_monitoring_public_lb_id"></a> [sidekiq\_monitoring\_public\_lb\_id](#output\_sidekiq\_monitoring\_public\_lb\_id) | The ID of the sidekiq\_monitoring\_public\_lb load balancer |
+| <a name="output_whitehall_backend_public_lb_id"></a> [whitehall\_backend\_public\_lb\_id](#output\_whitehall\_backend\_public\_lb\_id) | The ID of the whitehall\_backend\_public load balancer |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -2347,3 +2347,86 @@ resource "aws_route53_record" "draft_content_store_public_service_names" {
   records = ["${element(var.draft_content_store_public_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"]
   ttl     = "300"
 }
+
+# Outputs
+# ---------------------
+
+output "kinesis_firehose_splunk_arn" {
+  value       = "${aws_kinesis_firehose_delivery_stream.splunk.arn}"
+  description = "The ARN of the splunk endpoint of the kinesis firehose stream"
+}
+
+output "account_public_lb_id" {
+  value       = "${module.account_public_lb.lb_id}"
+  description = "The ID of the account_public load balancer"
+}
+
+output "backend_public_lb_id" {
+  value       = "${module.backend_public_lb.lb_id}"
+  description = "The ID of the backend_public load balancer"
+}
+
+output "bouncer_public_lb_id" {
+  value       = "${module.bouncer_public_lb.lb_id}"
+  description = "The ID of the bouncer_public load balancer"
+}
+
+output "cache_public_lb_id" {
+  value       = "${module.cache_public_lb.lb_id}"
+  description = "The ID of the cache_public load balancer"
+}
+
+output "ckan_public_lb_id" {
+  value       = "${module.ckan_public_lb.lb_id}"
+  description = "The ID of the ckan_public load balancer"
+}
+
+output "deploy_public_lb_id" {
+  value       = "${module.deploy_public_lb.lb_id}"
+  description = "The ID of the deploy_public load balancer"
+}
+
+output "draft_cache_public_lb_id" {
+  value       = "${module.draft_cache_public_lb.lb_id}"
+  description = "The ID of the draft_cache_public load balancer"
+}
+
+output "email_alert_api_public_lb_id" {
+  value       = "${module.email_alert_api_public_lb.lb_id}"
+  description = "The ID of the email_alert_api_public load balancer"
+}
+
+output "graphite_public_lb_id" {
+  value       = "${module.graphite_public_lb.lb_id}"
+  description = "The ID of the graphite_public load balancer"
+}
+
+output "prometheus_public_lb_id" {
+  value       = "${module.prometheus_public_lb.lb_id}"
+  description = "The ID of the prometheus_public load balancer"
+}
+
+output "licensify_frontend_public_lb_id" {
+  value       = "${module.licensify_frontend_public_lb.lb_id}"
+  description = "The ID of the licensify_frontend_public_lb load balancer"
+}
+
+output "licensify_backend_public_lb_id" {
+  value       = "${module.licensify_backend_public_lb.lb_id}"
+  description = "The ID of the licensify_backend_public load balancer"
+}
+
+output "monitoring_public_lb_id" {
+  value       = "${module.monitoring_public_lb.lb_id}"
+  description = "The ID of the monitoring_public load balancer"
+}
+
+output "sidekiq_monitoring_public_lb_id" {
+  value       = "${module.sidekiq_monitoring_public_lb.lb_id}"
+  description = "The ID of the sidekiq_monitoring_public_lb load balancer"
+}
+
+output "whitehall_backend_public_lb_id" {
+  value       = "${module.whitehall_backend_public_lb.lb_id}"
+  description = "The ID of the whitehall_backend_public load balancer"
+}


### PR DESCRIPTION
These IDs will be referenced from a separate project which will configure the web acls for the public load balancers. The resources we're outputting are:

- IDs of public load balancers
- the ID of the existing kinesis data firehose

The load balancer IDs will be used in the new project to attach the new web ACLs to the public load balancers.

The kinesis data firehose is used to [send the logs generated by the new WAFs to S3.](https://aws.amazon.com/premiumsupport/knowledge-center/waf-configure-comprehensive-logging/).
This happens at present with the default web ACL, but the plan is to move that configuration out of the extremely large infra-public-services project into something a bit more easily manageable. 

We'll reuse this kinesis data firehose instance for the moment, until we need to do something different.