### PR TITLE
Fix shield advanced on EIP

### DIFF
--- a/terraform/modules/aws/network/nat/README.md
+++ b/terraform/modules/aws/network/nat/README.md
@@ -24,6 +24,8 @@ No modules.
 | [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_nat_gateway.nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
 | [aws_shield_protection.aws_eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/terraform/modules/aws/network/nat/main.tf
+++ b/terraform/modules/aws/network/nat/main.tf
@@ -26,9 +26,14 @@ resource "aws_eip" "nat" {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_shield_protection" "aws_eip" {
-  name         = "${var.stackname}-aws-eip_shield"
-  resource_arn = "${module.aws_eip.lb_id}"
+  count        = "${length(aws_eip.nat.*.id)}"
+  name         = "${element(aws_eip.nat.*.id, count.index)}_shield"
+  resource_arn = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${element(aws_eip.nat.*.id, count.index)}"
 }
 
 resource "aws_nat_gateway" "nat" {


### PR DESCRIPTION
The current terraform doesn't work at all. I think it was included by mistake in a previous PR.

This adds the EIPs to the resources covered by AWS shield advanced.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection

[Plan of the change adding 3 AWS shield resources](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/3097/console)