### PR TITLE
app-knowledge-graph: also log stderr

### DIFF
--- a/terraform/projects/app-knowledge-graph/userdata.tpl
+++ b/terraform/projects/app-knowledge-graph/userdata.tpl
@@ -45,4 +45,4 @@ cd govuk-knowledge-graph
 chmod +x ./provision_knowledge_graph
 
 # Run provisioning script
-./provision_knowledge_graph -i ${instance_id} -d ${data_infrastructure_bucket_name} -r ${related_links_bucket_name}
+./provision_knowledge_graph -i ${instance_id} -d ${data_infrastructure_bucket_name} -r ${related_links_bucket_name} 2>&1


### PR DESCRIPTION
So that we get the error messages when the provision_knowledge_graph
script outputs errors to stderr