### PR TITLE
Allow monitoring to access the mirror bucket

### DIFF
--- a/terraform/projects/infra-mirror-bucket/README.md
+++ b/terraform/projects/infra-mirror-bucket/README.md
@@ -70,6 +70,7 @@ No modules.
 | [terraform_remote_state.app_mirrorer](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_monitoring](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_networking](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.infra_vpc](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs
 
@@ -94,6 +95,7 @@ No modules.
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | <a name="input_remote_state_infra_monitoring_key_stack"></a> [remote\_state\_infra\_monitoring\_key\_stack](#input\_remote\_state\_infra\_monitoring\_key\_stack) | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_networking_key_stack"></a> [remote\_state\_infra\_networking\_key\_stack](#input\_remote\_state\_infra\_networking\_key\_stack) | Override infra\_networking remote state path | `string` | `""` | no |
+| <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override infra\_vpc remote state path | `string` | `""` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -104,6 +104,12 @@ variable "lifecycle_government_uploads" {
   default     = "8"
 }
 
+variable "remote_state_infra_vpc_key_stack" {
+  type        = "string"
+  description = "Override infra_vpc remote state path"
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -153,6 +159,16 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
+    region = "${var.aws_replica_region}"
+  }
+}
+
+data "terraform_remote_state" "infra_vpc" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
     region = "${var.aws_replica_region}"
   }
 }

--- a/terraform/projects/infra-mirror-bucket/mirror-read-policy.tf
+++ b/terraform/projects/infra-mirror-bucket/mirror-read-policy.tf
@@ -227,6 +227,27 @@ data "aws_iam_policy_document" "s3_mirror_replica_read_policy_doc" {
   }
 
   statement {
+    sid     = "S3NATGatewayReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-replica.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk-mirror-replica.id}/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceVpce"
+      values   = ["${data.terraform_remote_state.infra_vpc.s3_gateway_id}"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+
+  statement {
     sid    = "CrossAccountAccess"
     effect = "Allow"
 


### PR DESCRIPTION
[Smokey is currently failing](https://alert.production.govuk.digital/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-13-5-163.eu-west-1.compute.internal&service=Smokey+loop+for+mirror) because the monitoring machine is attempting to use the [new S3 gateway](https://github.com/alphagov/govuk-aws/pull/1605) to retrieve pages from the replica mirror and failing.

Looking at the policies on the bucket, we have locked them down to Fastly, office and AWS NAT ip addresses, none of which are used in this case.