### PR TITLE
Use 2 dollar signs to instantiate local variable

### DIFF
--- a/terraform/projects/app-knowledge-graph/userdata.tpl
+++ b/terraform/projects/app-knowledge-graph/userdata.tpl
@@ -45,4 +45,4 @@ cd govuk-knowledge-graph
 chmod +x ./provision_knowledge_graph
 
 # Run provisioning script
-./provision_knowledge_graph -i ${instance_id} -d ${data_infrastructure_bucket_name} -r ${related_links_bucket_name} 2>&1
+./provision_knowledge_graph -i $${instance_id} -d ${data_infrastructure_bucket_name} -r ${related_links_bucket_name} 2>&1


### PR DESCRIPTION
instance_id is a local variable defined above, and as such
needs to be instantiated using two dollar signs, as opposed
to pre-set variables that need only one.