### PR TITLE
Create a second instance of the knowledge graph

### DIFF
--- a/terraform/projects/app-knowledge-graph/README.md
+++ b/terraform/projects/app-knowledge-graph/README.md
@@ -47,7 +47,7 @@ No modules.
 | [aws_iam_role_policy_attachment.read_write_data_infrastructure_bucket_role_attachment](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_launch_template.knowledge-graph-dev_launch_template](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/launch_template) | resource |
 | [aws_launch_template.knowledge-graph_launch_template](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/launch_template) | resource |
-| [aws_route53_record.knowledge_graph_lab_service_record_external](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/route53_record) | resource |
+| [aws_route53_record.knowledge_graph_dev_service_record_external](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.knowledge_graph_service_record_external](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/route53_record) | resource |
 | [aws_s3_bucket.data_infrastructure_bucket](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/s3_bucket) | resource |
 | [aws_acm_certificate.elb_external_cert](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/data-sources/acm_certificate) | data source |

--- a/terraform/projects/app-knowledge-graph/README.md
+++ b/terraform/projects/app-knowledge-graph/README.md
@@ -27,9 +27,13 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_autoscaling_group.knowledge-graph-dev_asg](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/autoscaling_group) | resource |
 | [aws_autoscaling_group.knowledge-graph_asg](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/autoscaling_group) | resource |
+| [aws_autoscaling_schedule.knowledge-graph-dev_schedule-spin-down](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/autoscaling_schedule) | resource |
+| [aws_autoscaling_schedule.knowledge-graph-dev_schedule-spin-up](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/autoscaling_schedule) | resource |
 | [aws_autoscaling_schedule.knowledge-graph_schedule-spin-down](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/autoscaling_schedule) | resource |
 | [aws_autoscaling_schedule.knowledge-graph_schedule-spin-up](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/autoscaling_schedule) | resource |
+| [aws_elb.knowledge-graph-dev_elb_external](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/elb) | resource |
 | [aws_elb.knowledge-graph_elb_external](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/elb) | resource |
 | [aws_iam_instance_profile.knowledge-graph_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_policy.knowledge-graph_read_ssm_policy](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/iam_policy) | resource |
@@ -41,7 +45,9 @@ No modules.
 | [aws_iam_role_policy_attachment.knowledge-graph_read_ssm_role_attachment](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.knowledge-graph_register_instance_with_elb_role_attachment](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.read_write_data_infrastructure_bucket_role_attachment](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_launch_template.knowledge-graph-dev_launch_template](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/launch_template) | resource |
 | [aws_launch_template.knowledge-graph_launch_template](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/launch_template) | resource |
+| [aws_route53_record.knowledge_graph_lab_service_record_external](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.knowledge_graph_service_record_external](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/route53_record) | resource |
 | [aws_s3_bucket.data_infrastructure_bucket](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/resources/s3_bucket) | resource |
 | [aws_acm_certificate.elb_external_cert](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/data-sources/acm_certificate) | data source |
@@ -52,6 +58,7 @@ No modules.
 | [aws_iam_policy_document.read_write_data_infrastructure_bucket_policy_document](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.external](https://registry.terraform.io/providers/hashicorp/aws/1.40.0/docs/data-sources/route53_zone) | data source |
 | [template_file.ec2_assume_policy_template](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+| [template_file.knowledge-graph-dev_userdata](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 | [template_file.knowledge-graph_userdata](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 | [terraform_remote_state.app_related_links](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_database_backups_bucket](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |

--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -338,7 +338,7 @@ resource "aws_route53_record" "knowledge_graph_service_record_external" {
 }
 
 resource "aws_elb" "knowledge-graph_elb_external" {
-  name                = "${var.stackname}-knowledge-graph-elb_external"
+  name                = "${var.stackname}-knowledge-graph-elb-ex"
   internal            = false
   connection_draining = true
 
@@ -487,7 +487,7 @@ resource "aws_route53_record" "knowledge_graph_lab_service_record_external" {
 }
 
 resource "aws_elb" "knowledge-graph-dev_elb_external" {
-  name                = "${var.stackname}-knowledge-graph-dev-elb_external"
+  name                = "${var.stackname}-knowledge-graph-dev-elb-ex"
   internal            = false
   connection_draining = true
 

--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -474,7 +474,7 @@ resource "aws_autoscaling_schedule" "knowledge-graph-dev_schedule-spin-down" {
   desired_capacity       = 0
 }
 
-resource "aws_route53_record" "knowledge_graph_lab_service_record_external" {
+resource "aws_route53_record" "knowledge_graph_dev_service_record_external" {
   zone_id = "${data.aws_route53_zone.external.zone_id}"
   name    = "knowledge-graph-dev.${var.external_domain_name}"
   type    = "A"

--- a/terraform/projects/app-knowledge-graph/userdata-dev.tpl
+++ b/terraform/projects/app-knowledge-graph/userdata-dev.tpl
@@ -1,0 +1,66 @@
+#!/bin/bash
+sudo apt-get update -y
+sudo apt-get install -y htop jq zip unzip
+
+#### Install aws cli
+# From https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+echo "Installing AWS CLI"
+echo "- uninstalling old version"
+sudo apt-get remove -y aws # First uninstall the version already installed in this AMI
+which -a aws && echo "aws binary found after uninstalling. Something's wrong."
+echo "- downloaded new version"
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip -q awscliv2.zip
+echo "- installing new version"
+sudo ./aws/install
+if [ "$(which aws)" == "/usr/local/bin/aws" ]; then
+    echo "aws found at /usr/local/bin/aws. All good."
+else
+    echo "No aws found at /usr/local/bin/aws. Something's wrong."
+fi
+
+# Allow SSH access
+echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1v8UTV0pOjSjZXnvQaWH/m5sOluCQGxeLU8NAbMa20lcazUDhEnQqjQ8SFvfMC06Zu8LWRMMPj3bIdS9I9G7ETWIq4Q8NdHEuOpgBJTcKsiL76hBVyQGWD682xfl4WhAHygsyN6qRGJg8YvkC5sAhYd7nu/9sfI8erc1S7mFt2zzT/4N4ULlI2vHgWGhePPJOfRz7cGi1nxe/WzlYNURVfR0YQfYsxI4vRwjSM0xDelTwKDbb5D1PgcTYx3c2bnrMcQ4FSA7iAyvJJnLSRCcxaCF8XjokR8gBg7Dp9tims0Amjee4J/S1v4ty3Pi8Hm590ZrmuvyVC8KEajCmUnD4JvUAPM7hZYKtLbUsHtR5rF43Ot9gadGV1FF8xEmcMvI0NuqiSuTRV/GPjHxPh+5U5uxrNqODUeTiLHH6m2+Cb55ud5aJJGkbg6nCM2LsWuTN3vbaIwlCxheEdZtp0HLi1XSo6WRiUPKuUpO4a/EX8h9zP+Nd1yeT/9xcyMMFAeieufV3PUjr/7TtG4KpgqzL0C9blWLaYUu9fa7/xT9jJg3yJIFvtidEXtiYvf56tfIr6wWxPkNNYIS5SEarCwI6AoMgMG0geicgzwmPBczovX62IN3lUDskLT0LGo8eliadEeaYCnQ1E3NS2rYwluTdPDYpqIYPH1Vb6MwGajmQBw== kelvin.gan@digital.cabinet-office.gov.uk" >> /home/ubuntu/.ssh/authorized_keys
+echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDvuBdxXkJ2Htbt47fm/CV7+uQLOu//OJ7tJv4mlyM0nChhvvI56ZjfYRCdcZNH+eFXzUDUDh1/HK9J8tA2J/ZTg/OqS+UMylQPdc4+LxPHDenhZjvCigf0Uf4ISJdprTCPJj11I/wc7bq1m6C3HGwK5DWAmSIOh7rqLDhuDIZIKdlx3nz8DEAmUFutcA//3sCfHSd8n3B6Rvpzhw5wqqJhG1nS7upJir3lew+XHt+anu6J17iGHTKKuSlZ9ZgXP7poQPizIjIK7sAkI6S45gLcKtJpbMd5pt8Ze80GcH5qoycylz93kUhy8jQJUAR97eDxh7odaFOX0y+Am2EcDJ33PsjDu9QCqJOQu0NiXWLobRIyqtDo08cdDg7yBYgAg5GuPAska/lCG9SFI1gYe7DNRB3LLvBZ4zKwhbiaQ2wdS4K0o4P1OAXdHq2Jp2XcG0jFERdI677v3uUcVEAuQ7GLVHoVKLpdj6+6IbWnh6j5WxVBLaXY2wLMC+dU60M2F1F19ixDEHNb2TUU7f5WIQuJH0N1u+lM3cDjba5cRQuMXDzlaHEwl8XjmHRGC1nwCdTtiNNAbmRe9sX8myXtbnYG0MgUcLkzd0YjVNQXv5jmmvvrRR80Zj2etTQmLQcOKwFkMScQCT9PJenj8RCm+DeCyT+TpRigxmD/6ztr8lHFzw== max.froumentin@digital.cabinet-office.gov.uk" >> /home/ubuntu/.ssh/authorized_keys
+echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC77d30YoXpAluaF5hYEPiMQvs7FCa4i2HZoAzKnpKVABYtKioAqrQ5zWg6oB77WBidKU1+0igNIlAzR/zVo9ld8YwDjex78hSql9jsVBdITKuArU7K4WdjcMIhmZwNyNZzMpgQN3PFgETOj2JIF/bGebTmAGHx7W1/nSwWz/BZO665O2cYG1eCr6XCB4Cl9aao77V5INQzSDkP51yBMBPWXXFRcTI7X8nyyim68Fs7VSh8rLHUSqgprvAq+1Lae10Lb050c+J7Gxg8GDjKwWD9WAET6JYcjLYbIpeLSROZfwF6uob8CLF8ojoNTyTJk7vX/o/tIGIWlED6/W0l1WUjnGcuArgd14v6cHekWA9dWWZGVIp+SkiGi2qsu2eO+Q8du92QH1aneKGyJewRWf3f4XB86W/p4DpRmAYnrhlEis3i0rbBxdwNGNHyF4blsPG5iy3b5tcs3y/zlyxcldWpZUeois2Z4SLTEY3YXts96JyHI0Gd0Efn0ekuNSm/1KR5zUrakgSDixayP9g4HH5kxsOiq1Q3E1Pc7ouinjcv88/ogzUw5XDjfWB62sEW9Zw7Ec7cTHLY8IK7Wrd1Wkaj0Gyuq7d+LTEcT5SwzYIls/z8CxwDfEKGm3G6EjNFTttbrVDaEGeEDAgeEYlt3gOEQvIvlj6etoG9xLwVgpvAgQ== duncan.garmonsway@digital.cabinet-office.gov.uk" >> /home/ubuntu/.ssh/authorized_keys
+
+# Register instance with load balancer
+instance_id="$(curl http://169.254.169.254/latest/meta-data/instance-id)"
+aws elb register-instances-with-load-balancer --load-balancer-name "${elb_name}" --instances $instance_id --region eu-west-1
+
+sudo locale-gen en_GB.UTF-8
+
+# Create data dir
+sudo mkdir /var/data
+sudo chown -R ubuntu:ubuntu /var/data
+sudo chmod g+s /var/data
+cd /var/data
+
+
+################################################################################
+# Get Knowledge graph repository to launch the data pipeline
+
+
+# This is a private repo so we need a github ssh key for cloning
+aws ssm get-parameter --name govuk_knowledge_graph_github_deploy_key --query "Parameter.Value" --region eu-west-1 --with-decryption | jq -r '.' > kg_id_rsa
+chmod 600 kg_id_rsa
+
+# Add Github deploy key to ssh agent
+eval "$(ssh-agent -s)"
+ssh-add /var/data/kg_id_rsa
+
+# Accept Github SSH fingerprint
+ssh -T git@github.com -o StrictHostKeyChecking=no
+
+# Download knowledge graph repo
+mkdir /var/data/github
+cd /var/data/github
+git clone git@github.com:alphagov/govuk-knowledge-graph.git
+
+# Set correct permissions for provisioning script
+cd govuk-knowledge-graph
+git checkout sandbox
+chmod +x ./provision_knowledge_graph_dev
+
+# Run provisioning script
+./provision_knowledge_graph_lab -i $${instance_id} -d ${data_infrastructure_bucket_name} -r ${related_links_bucket_name} 2>&1

--- a/terraform/projects/app-knowledge-graph/userdata-dev.tpl
+++ b/terraform/projects/app-knowledge-graph/userdata-dev.tpl
@@ -59,8 +59,8 @@ git clone git@github.com:alphagov/govuk-knowledge-graph.git
 
 # Set correct permissions for provisioning script
 cd govuk-knowledge-graph
-git checkout sandbox
-chmod +x ./provision_knowledge_graph_dev
+git checkout dev
+chmod +x ./provision_knowledge_graph
 
 # Run provisioning script
-./provision_knowledge_graph_lab -i $${instance_id} -d ${data_infrastructure_bucket_name} -r ${related_links_bucket_name} 2>&1
+./provision_knowledge_graph -i $${instance_id} -d ${data_infrastructure_bucket_name} -r ${related_links_bucket_name} 2>&1

--- a/terraform/projects/app-knowledge-graph/userdata.tpl
+++ b/terraform/projects/app-knowledge-graph/userdata.tpl
@@ -6,7 +6,7 @@ sudo apt-get install -y htop jq zip unzip
 # From https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
 echo "Installing AWS CLI"
 echo "- uninstalling old version"
-sudo apt-get remove -y aws # First uninstall the version already installed in this AMI
+sudo apt-get remove -y awscli # First uninstall the version already installed in this AMI
 which -a aws && echo "aws binary found after uninstalling. Something's wrong."
 echo "- downloaded new version"
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"


### PR DESCRIPTION
For testing purposes as the live one now has a substantial
number of users, so it's more awkward if we break it as we
test changes.