### PR TITLE
Remove public load balancer for licensify-frontend

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -38,7 +38,6 @@ This project adds global resources for app components:
 | <a name="module_email_alert_api_public_lb"></a> [email\_alert\_api\_public\_lb](#module\_email\_alert\_api\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_graphite_public_lb"></a> [graphite\_public\_lb](#module\_graphite\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_licensify_backend_public_lb"></a> [licensify\_backend\_public\_lb](#module\_licensify\_backend\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_licensify_frontend_public_lb"></a> [licensify\_frontend\_public\_lb](#module\_licensify\_frontend\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_monitoring_public_lb"></a> [monitoring\_public\_lb](#module\_monitoring\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_prometheus_public_lb"></a> [prometheus\_public\_lb](#module\_prometheus\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_sidekiq_monitoring_public_lb"></a> [sidekiq\_monitoring\_public\_lb](#module\_sidekiq\_monitoring\_public\_lb) | ../../modules/aws/lb | n/a |
@@ -58,7 +57,6 @@ This project adds global resources for app components:
 | [aws_autoscaling_attachment.graphite_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.jumpbox_asg_attachment_elb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.licensify_backend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.licensify_frontend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.monitoring_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.prometheus_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.sidekiq_monitoring_backend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/autoscaling_attachment) | resource |
@@ -70,7 +68,6 @@ This project adds global resources for app components:
 | [aws_kinesis_firehose_delivery_stream.splunk](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/kinesis_firehose_delivery_stream) | resource |
 | [aws_lambda_function.aws_waf_log_trimmer](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/lambda_function) | resource |
 | [aws_lb_listener.licensify_backend_http_80](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/lb_listener) | resource |
-| [aws_lb_listener.licensify_frontend_public_http_80](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/lb_listener) | resource |
 | [aws_lb_listener_rule.backend_alb_blocked_host_headers](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/lb_listener_rule) | resource |
 | [aws_route53_record.account_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.account_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/route53_record) | resource |
@@ -124,8 +121,6 @@ This project adds global resources for app components:
 | [aws_route53_record.licensify_backend_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.licensify_frontend_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.licensify_frontend_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/route53_record) | resource |
-| [aws_route53_record.licensify_frontend_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/route53_record) | resource |
-| [aws_route53_record.licensify_frontend_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.locations_api_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.locations_api_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.mapit_cache_name](https://registry.terraform.io/providers/hashicorp/aws/2.69.0/docs/resources/route53_record) | resource |
@@ -304,7 +299,6 @@ This project adds global resources for app components:
 | <a name="output_graphite_public_lb_id"></a> [graphite\_public\_lb\_id](#output\_graphite\_public\_lb\_id) | The ID of the graphite\_public load balancer |
 | <a name="output_kinesis_firehose_splunk_arn"></a> [kinesis\_firehose\_splunk\_arn](#output\_kinesis\_firehose\_splunk\_arn) | The ARN of the splunk endpoint of the kinesis firehose stream |
 | <a name="output_licensify_backend_public_lb_id"></a> [licensify\_backend\_public\_lb\_id](#output\_licensify\_backend\_public\_lb\_id) | The ID of the licensify\_backend\_public load balancer |
-| <a name="output_licensify_frontend_public_lb_id"></a> [licensify\_frontend\_public\_lb\_id](#output\_licensify\_frontend\_public\_lb\_id) | The ID of the licensify\_frontend\_public\_lb load balancer |
 | <a name="output_monitoring_public_lb_id"></a> [monitoring\_public\_lb\_id](#output\_monitoring\_public\_lb\_id) | The ID of the monitoring\_public load balancer |
 | <a name="output_prometheus_public_lb_id"></a> [prometheus\_public\_lb\_id](#output\_prometheus\_public\_lb\_id) | The ID of the prometheus\_public load balancer |
 | <a name="output_sidekiq_monitoring_public_lb_id"></a> [sidekiq\_monitoring\_public\_lb\_id](#output\_sidekiq\_monitoring\_public\_lb\_id) | The ID of the sidekiq\_monitoring\_public\_lb load balancer |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1579,70 +1579,6 @@ module "alarms-elb-jumpbox-public" {
 # Licensify
 #
 
-module "licensify_frontend_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-licensify-frontend-public"
-  internal                                   = false
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-licensify-frontend-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-  target_group_health_check_path             = "/api/licences"
-
-  listener_action = {
-    "HTTPS:443" = "HTTP:80"
-  }
-
-  subnets         = ["${data.terraform_remote_state.infra_networking.public_subnet_ids}"]
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.sg_licensify-frontend_external_elb_id}"]
-  alarm_actions   = ["${data.terraform_remote_state.infra_monitoring.sns_topic_cloudwatch_alarms_arn}"]
-
-  default_tags = {
-    Project         = "${var.stackname}"
-    aws_migration   = "licensify-frontend"
-    aws_environment = "${var.aws_environment}"
-  }
-}
-
-resource "aws_lb_listener" "licensify_frontend_public_http_80" {
-  load_balancer_arn = "${module.licensify_frontend_public_lb.lb_id}"
-  port              = "80"
-  protocol          = "HTTP"
-
-  default_action {
-    type = "redirect"
-
-    redirect {
-      port        = "443"
-      protocol    = "HTTPS"
-      status_code = "HTTP_301"
-    }
-  }
-}
-
-resource "aws_route53_record" "licensify_frontend_public_service_names" {
-  count   = "${length(var.licensify_frontend_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
-  name    = "${element(var.licensify_frontend_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.licensify_frontend_public_lb.lb_dns_name}"
-    zone_id                = "${module.licensify_frontend_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_route53_record" "licensify_frontend_public_service_cnames" {
-  count   = "${length(var.licensify_frontend_public_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.external_root_zone_id}"
-  name    = "${element(var.licensify_frontend_public_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.licensify_frontend_public_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.external_root_domain_name}"]
-  ttl     = "300"
-}
-
 data "aws_autoscaling_groups" "licensify_frontend" {
   filter {
     name   = "key"
@@ -1653,12 +1589,6 @@ data "aws_autoscaling_groups" "licensify_frontend" {
     name   = "value"
     values = ["blue-licensify-frontend"]
   }
-}
-
-resource "aws_autoscaling_attachment" "licensify_frontend_asg_attachment_alb" {
-  count                  = "${length(data.aws_autoscaling_groups.licensify_frontend.names) > 0 ? 1 : 0}"
-  autoscaling_group_name = "${element(data.aws_autoscaling_groups.licensify_frontend.names, 0)}"
-  alb_target_group_arn   = "${element(module.licensify_frontend_public_lb.target_group_arns, 0)}"
 }
 
 resource "aws_route53_record" "licensify_frontend_internal_service_names" {
@@ -2254,11 +2184,6 @@ output "graphite_public_lb_id" {
 output "prometheus_public_lb_id" {
   value       = "${module.prometheus_public_lb.lb_id}"
   description = "The ID of the prometheus_public load balancer"
-}
-
-output "licensify_frontend_public_lb_id" {
-  value       = "${module.licensify_frontend_public_lb.lb_id}"
-  description = "The ID of the licensify_frontend_public_lb load balancer"
 }
 
 output "licensify_backend_public_lb_id" {


### PR DESCRIPTION
This was missed previously during the Carrenza cleanup.

[The Terraform plan](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/3203/console) has been run for `integration`:

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  - aws_autoscaling_attachment.licensify_frontend_asg_attachment_alb

  - aws_lb_listener.licensify_frontend_public_http_80

  - aws_route53_record.licensify_frontend_public_service_cnames

  - aws_route53_record.licensify_frontend_public_service_names

  - aws_route53_record.rate_limit_redis_internal_service_names

  - module.licensify_frontend_public_lb.aws_cloudwatch_metric_alarm.elb_httpcode_elb_5xx_count

  - module.licensify_frontend_public_lb.aws_cloudwatch_metric_alarm.elb_httpcode_target_5xx_count

  - module.licensify_frontend_public_lb.aws_lb.lb

  - module.licensify_frontend_public_lb.aws_lb_listener.listener

  - module.licensify_frontend_public_lb.aws_lb_target_group.tg_default


Plan: 0 to add, 0 to change, 10 to destroy.
```

Trello card: https://trello.com/c/u6p9k6It/2909-investigate-why-licensing-frontend-is-publicly-routable-and-hide-it-if-possible5