### PR TITLE
Add comment about uploadlicence domain

### DIFF
--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -1578,6 +1578,8 @@ module "alarms-elb-jumpbox-public" {
 #
 # Licensify
 #
+# uploadlicence.publishing.service.gov.uk uses the licensify-frontend public lb
+# and is still in use
 
 module "licensify_frontend_public_lb" {
   source                                     = "../../modules/aws/lb"


### PR DESCRIPTION
This feels like the best place to document that uploadlicence.publishing.service.gov.uk
is still in use. See [this incident review](https://docs.google.com/document/d/178xHfacEiYn64607tc7Ab-_F8EMOjAUlKPB7dJWg6nU/edit#) for more information.

Trello card: https://trello.com/c/u6p9k6It/2909-investigate-why-licensing-frontend-is-publicly-routable-and-hide-it-if-possible5
