### PR TITLE
Setup the Trusty ESM repo to be used during provisioning

### DIFF
--- a/terraform/projects/app-account/README.md
+++ b/terraform/projects/app-account/README.md
@@ -50,6 +50,7 @@ account node
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.xlarge"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-account/user_data_snippets.tf
+++ b/terraform/projects/app-account/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-apt/README.md
+++ b/terraform/projects/app-apt/README.md
@@ -57,6 +57,7 @@ Apt node
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_public_secondary_certname"></a> [elb\_public\_secondary\_certname](#input\_elb\_public\_secondary\_certname) | The ACM secondary cert domain name to find the ARN of | `string` | `""` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-apt/user_data_snippets.tf
+++ b/terraform/projects/app-apt/user_data_snippets.tf
@@ -6,11 +6,15 @@
 #
 # To concatenate the snippets, use:
 # ${join("\n", null_resource.user_data.*.triggers.snippet)}
-#
+# 
 
 variable "user_data_snippets" {
   type        = "list"
   description = "List of user-data snippets"
+}
+
+variable "esm_trusty_token" {
+  type = "string"
 }
 
 # Resources
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-asset-master/README.md
+++ b/terraform/projects/app-asset-master/README.md
@@ -47,6 +47,7 @@ Asset Master node.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.large"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-asset-master/user_data_snippets.tf
+++ b/terraform/projects/app-asset-master/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-backend/README.md
+++ b/terraform/projects/app-backend/README.md
@@ -76,6 +76,7 @@ Backend node
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.2xlarge"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-backend/user_data_snippets.tf
+++ b/terraform/projects/app-backend/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-bouncer/README.md
+++ b/terraform/projects/app-bouncer/README.md
@@ -50,6 +50,7 @@ Bouncer node
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"t3.large"` | no |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |

--- a/terraform/projects/app-bouncer/user_data_snippets.tf
+++ b/terraform/projects/app-bouncer/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-cache/README.md
+++ b/terraform/projects/app-cache/README.md
@@ -58,6 +58,7 @@ Cache application servers
 | <a name="input_create_external_elb"></a> [create\_external\_elb](#input\_create\_external\_elb) | Create the external ELB | `bool` | `true` | no |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-cache/user_data_snippets.tf
+++ b/terraform/projects/app-cache/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-calculators-frontend/README.md
+++ b/terraform/projects/app-calculators-frontend/README.md
@@ -53,6 +53,7 @@ Calculators Frontend application servers
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_enable_alb"></a> [enable\_alb](#input\_enable\_alb) | Use application specific target groups and healthchecks based on the list of services in the cname variable. | `string` | `false` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"c5.xlarge"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-calculators-frontend/user_data_snippets.tf
+++ b/terraform/projects/app-calculators-frontend/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-ci-agents/README.md
+++ b/terraform/projects/app-ci-agents/README.md
@@ -113,6 +113,7 @@ CI agents
 | <a name="input_ebs_encrypted"></a> [ebs\_encrypted](#input\_ebs\_encrypted) | whether or not the EBS volume is encrypted | `string` | `"true"` | no |
 | <a name="input_ebs_volume_type"></a> [ebs\_volume\_type](#input\_ebs\_volume\_type) | Volume type to use for data and Docker EBS volumes; see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html | `string` | `"gp3"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.2xlarge"` | no |
 | <a name="input_internal_app_service_records"></a> [internal\_app\_service\_records](#input\_internal\_app\_service\_records) | List of application service names that get traffic via this loadbalancer | `list` | `[]` | no |

--- a/terraform/projects/app-ci-agents/user_data_snippets.tf
+++ b/terraform/projects/app-ci-agents/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-ci-master/README.md
+++ b/terraform/projects/app-ci-master/README.md
@@ -66,6 +66,7 @@ CI Master Node
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of, will be attached to internal classic ELB | `string` | n/a | yes |
 | <a name="input_elb_public_certname"></a> [elb\_public\_certname](#input\_elb\_public\_certname) | The ACM cert domain name to find the ARN of, will be attached to external ALB | `string` | n/a | yes |
 | <a name="input_elb_public_secondary_certname"></a> [elb\_public\_secondary\_certname](#input\_elb\_public\_secondary\_certname) | The ACM secondary cert domain name to find the ARN of, will be attached to external ALB | `string` | `""` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-ci-master/user_data_snippets.tf
+++ b/terraform/projects/app-ci-master/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-ckan/README.md
+++ b/terraform/projects/app-ckan/README.md
@@ -61,6 +61,7 @@ CKAN node
 | <a name="input_ebs_encrypted"></a> [ebs\_encrypted](#input\_ebs\_encrypted) | Whether or not the EBS volume is encrypted | `string` | n/a | yes |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.xlarge"` | no |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |

--- a/terraform/projects/app-ckan/user_data_snippets.tf
+++ b/terraform/projects/app-ckan/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-content-data-api-db-admin/README.md
+++ b/terraform/projects/app-content-data-api-db-admin/README.md
@@ -46,6 +46,7 @@ DB admin boxes for the Content Data API RDS instance
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"t2.medium"` | no |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | <a name="input_remote_state_infra_database_backups_bucket_key_stack"></a> [remote\_state\_infra\_database\_backups\_bucket\_key\_stack](#input\_remote\_state\_infra\_database\_backups\_bucket\_key\_stack) | Override stackname path to infra\_database\_backups\_bucket remote state | `string` | `""` | no |

--- a/terraform/projects/app-content-data-api-db-admin/user_data_snippets.tf
+++ b/terraform/projects/app-content-data-api-db-admin/user_data_snippets.tf
@@ -6,11 +6,15 @@
 #
 # To concatenate the snippets, use:
 # ${join("\n", null_resource.user_data.*.triggers.snippet)}
-#
+# 
 
 variable "user_data_snippets" {
   type        = "list"
   description = "List of user-data snippets"
+}
+
+variable "esm_trusty_token" {
+  type = "string"
 }
 
 # Resources
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-content-store/README.md
+++ b/terraform/projects/app-content-store/README.md
@@ -52,6 +52,7 @@ content-store node
 | <a name="input_create_external_elb"></a> [create\_external\_elb](#input\_create\_external\_elb) | Create the external ELB | `bool` | `false` | no |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-content-store/user_data_snippets.tf
+++ b/terraform/projects/app-content-store/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-data-science/README.md
+++ b/terraform/projects/app-data-science/README.md
@@ -49,6 +49,7 @@ Run resource intensive scripts for data science purposes.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-2"` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"c5.4xlarge"` | no |
 | <a name="input_machine_learning_instance_type"></a> [machine\_learning\_instance\_type](#input\_machine\_learning\_instance\_type) | Instance type used for EC2 resources | `string` | `"p3.8xlarge"` | no |

--- a/terraform/projects/app-data-science/user_data_snippets.tf
+++ b/terraform/projects/app-data-science/user_data_snippets.tf
@@ -6,11 +6,15 @@
 #
 # To concatenate the snippets, use:
 # ${join("\n", null_resource.user_data.*.triggers.snippet)}
-#
+# 
 
 variable "user_data_snippets" {
   type        = "list"
   description = "List of user-data snippets"
+}
+
+variable "esm_trusty_token" {
+  type = "string"
 }
 
 # Resources
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-db-admin/README.md
+++ b/terraform/projects/app-db-admin/README.md
@@ -66,6 +66,7 @@ These nodes connect to RDS instances and administer them.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"t2.medium"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-db-admin/user_data_snippets.tf
+++ b/terraform/projects/app-db-admin/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-deploy/README.md
+++ b/terraform/projects/app-deploy/README.md
@@ -68,6 +68,7 @@ Deploy node
 | <a name="input_ebs_encrypted"></a> [ebs\_encrypted](#input\_ebs\_encrypted) | Whether or not the EBS volume is encrypted | `string` | n/a | yes |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-deploy/user_data_snippets.tf
+++ b/terraform/projects/app-deploy/user_data_snippets.tf
@@ -6,11 +6,15 @@
 #
 # To concatenate the snippets, use:
 # ${join("\n", null_resource.user_data.*.triggers.snippet)}
-#
+# 
 
 variable "user_data_snippets" {
   type        = "list"
   description = "List of user-data snippets"
+}
+
+variable "esm_trusty_token" {
+  type = "string"
 }
 
 # Resources
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-docker-management/README.md
+++ b/terraform/projects/app-docker-management/README.md
@@ -45,6 +45,7 @@ Docker management node, used to run run adhoc containers.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"t2.medium"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-docker-management/user_data_snippets.tf
+++ b/terraform/projects/app-docker-management/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-draft-cache/README.md
+++ b/terraform/projects/app-draft-cache/README.md
@@ -60,6 +60,7 @@ Draft Cache servers
 | <a name="input_create_external_elb"></a> [create\_external\_elb](#input\_create\_external\_elb) | Create the external ELB | `bool` | `true` | no |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-draft-cache/user_data_snippets.tf
+++ b/terraform/projects/app-draft-cache/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-draft-content-store/README.md
+++ b/terraform/projects/app-draft-content-store/README.md
@@ -52,6 +52,7 @@ draft-content-store node
 | <a name="input_create_external_elb"></a> [create\_external\_elb](#input\_create\_external\_elb) | Create the external ELB | `bool` | `false` | no |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-draft-content-store/user_data_snippets.tf
+++ b/terraform/projects/app-draft-content-store/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-draft-frontend/README.md
+++ b/terraform/projects/app-draft-frontend/README.md
@@ -53,6 +53,7 @@ Draft Frontend application servers
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_enable_alb"></a> [enable\_alb](#input\_enable\_alb) | Use application specific target groups and healthchecks based on the list of services in the cname variable. | `string` | `false` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.large"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-draft-frontend/user_data_snippets.tf
+++ b/terraform/projects/app-draft-frontend/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-email-alert-api/README.md
+++ b/terraform/projects/app-email-alert-api/README.md
@@ -50,6 +50,7 @@ email-alert-api node
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.xlarge"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-email-alert-api/user_data_snippets.tf
+++ b/terraform/projects/app-email-alert-api/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-frontend/README.md
+++ b/terraform/projects/app-frontend/README.md
@@ -57,6 +57,7 @@ Frontend application servers
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_enable_alb"></a> [enable\_alb](#input\_enable\_alb) | Use application specific target groups and healthchecks based on the list of services in the cname variable. | `string` | `false` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.xlarge"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-frontend/user_data_snippets.tf
+++ b/terraform/projects/app-frontend/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-gatling/README.md
+++ b/terraform/projects/app-gatling/README.md
@@ -52,6 +52,7 @@ Gatling node
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_ebs_encrypted"></a> [ebs\_encrypted](#input\_ebs\_encrypted) | Whether or not the EBS volume is encrypted | `string` | n/a | yes |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-gatling/user_data_snippets.tf
+++ b/terraform/projects/app-gatling/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-graphite/README.md
+++ b/terraform/projects/app-graphite/README.md
@@ -64,6 +64,7 @@ Graphite node
 | <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | EBS Volume size in GB | `string` | `"250"` | no |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_graphite_1_subnet"></a> [graphite\_1\_subnet](#input\_graphite\_1\_subnet) | Name of the subnet to place the Graphite instance 1 and EBS volume | `string` | n/a | yes |

--- a/terraform/projects/app-graphite/user_data_snippets.tf
+++ b/terraform/projects/app-graphite/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-jumpbox/README.md
+++ b/terraform/projects/app-jumpbox/README.md
@@ -46,6 +46,7 @@ Jumpbox node
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_create_external_elb"></a> [create\_external\_elb](#input\_create\_external\_elb) | Create the external ELB | `bool` | `true` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-jumpbox/user_data_snippets.tf
+++ b/terraform/projects/app-jumpbox/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-licensify-backend/README.md
+++ b/terraform/projects/app-licensify-backend/README.md
@@ -48,6 +48,7 @@ Licensify Backend nodes
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The domain name of the ACM cert to use for the internal LB | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.large"` | no |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |

--- a/terraform/projects/app-licensify-backend/user_data_snippets.tf
+++ b/terraform/projects/app-licensify-backend/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-licensify-frontend/README.md
+++ b/terraform/projects/app-licensify-frontend/README.md
@@ -50,6 +50,7 @@ Licensify Frontend nodes
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-licensify-frontend/user_data_snippets.tf
+++ b/terraform/projects/app-licensify-frontend/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-locations-api/README.md
+++ b/terraform/projects/app-locations-api/README.md
@@ -52,6 +52,7 @@ Locations API nodes
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-locations-api/user_data_snippets.tf
+++ b/terraform/projects/app-locations-api/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-mapit/README.md
+++ b/terraform/projects/app-mapit/README.md
@@ -65,6 +65,7 @@ Mapit node
 | <a name="input_ebs_device_volume_size"></a> [ebs\_device\_volume\_size](#input\_ebs\_device\_volume\_size) | Size of additional ebs volume in GB | `string` | `"20"` | no |
 | <a name="input_ebs_encrypted"></a> [ebs\_encrypted](#input\_ebs\_encrypted) | Whether or not the EBS volume is encrypted | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"c5.2xlarge"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-mapit/user_data_snippets.tf
+++ b/terraform/projects/app-mapit/user_data_snippets.tf
@@ -6,11 +6,15 @@
 #
 # To concatenate the snippets, use:
 # ${join("\n", null_resource.user_data.*.triggers.snippet)}
-#
+# 
 
 variable "user_data_snippets" {
   type        = "list"
   description = "List of user-data snippets"
+}
+
+variable "esm_trusty_token" {
+  type = "string"
 }
 
 # Resources
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-mirrorer/README.md
+++ b/terraform/projects/app-mirrorer/README.md
@@ -47,6 +47,7 @@ Mirrorer node
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_ebs_encrypted"></a> [ebs\_encrypted](#input\_ebs\_encrypted) | Whether or not the EBS volume is encrypted | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.large"` | no |
 | <a name="input_mirrorer_ebs_size"></a> [mirrorer\_ebs\_size](#input\_mirrorer\_ebs\_size) | Size of addtiional EBS volume in GB | `string` | `"100"` | no |

--- a/terraform/projects/app-mirrorer/user_data_snippets.tf
+++ b/terraform/projects/app-mirrorer/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-mongo/README.md
+++ b/terraform/projects/app-mongo/README.md
@@ -75,6 +75,7 @@ Mongo hosts
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_ebs_encrypted"></a> [ebs\_encrypted](#input\_ebs\_encrypted) | Whether or not the EBS volume is encrypted | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.large"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-mongo/user_data_snippets.tf
+++ b/terraform/projects/app-mongo/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-monitoring/README.md
+++ b/terraform/projects/app-monitoring/README.md
@@ -60,6 +60,7 @@ Monitoring node
 | <a name="input_ebs_encrypted"></a> [ebs\_encrypted](#input\_ebs\_encrypted) | Whether or not the EBS volume is encrypted | `string` | n/a | yes |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-monitoring/user_data_snippets.tf
+++ b/terraform/projects/app-monitoring/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-publishing-api/README.md
+++ b/terraform/projects/app-publishing-api/README.md
@@ -59,6 +59,7 @@ publishing-api node
 | <a name="input_create_external_elb"></a> [create\_external\_elb](#input\_create\_external\_elb) | Create the external ELB | `bool` | `true` | no |
 | <a name="input_elb_external_certname"></a> [elb\_external\_certname](#input\_elb\_external\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain_name"></a> [external\_domain\_name](#input\_external\_domain\_name) | The domain name of the external DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_external_zone_name"></a> [external\_zone\_name](#input\_external\_zone\_name) | The name of the Route53 zone that contains external records | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |

--- a/terraform/projects/app-publishing-api/user_data_snippets.tf
+++ b/terraform/projects/app-publishing-api/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-puppetmaster/README.md
+++ b/terraform/projects/app-puppetmaster/README.md
@@ -57,6 +57,7 @@ Puppetmaster node
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_enable_bootstrap"></a> [enable\_bootstrap](#input\_enable\_bootstrap) | Whether to create the ELB which allows a user to SSH to the Puppetmaster from the office | `string` | `false` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.xlarge"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name. | `string` | n/a | yes |

--- a/terraform/projects/app-puppetmaster/user_data_snippets.tf
+++ b/terraform/projects/app-puppetmaster/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-rabbitmq/README.md
+++ b/terraform/projects/app-rabbitmq/README.md
@@ -50,6 +50,7 @@ Rabbitmq cluster
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_federation"></a> [federation](#input\_federation) | Whether we do RabbitMQ federation or not | `string` | `"false"` | no |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"t2.medium"` | no |

--- a/terraform/projects/app-rabbitmq/user_data_snippets.tf
+++ b/terraform/projects/app-rabbitmq/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-router-backend/README.md
+++ b/terraform/projects/app-router-backend/README.md
@@ -62,6 +62,7 @@ Router backend hosts both Mongo and router-api
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"t2.medium"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-router-backend/user_data_snippets.tf
+++ b/terraform/projects/app-router-backend/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-search/README.md
+++ b/terraform/projects/app-search/README.md
@@ -79,6 +79,7 @@ Search application servers
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"c5.xlarge"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-search/user_data_snippets.tf
+++ b/terraform/projects/app-search/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-transition-db-admin/README.md
+++ b/terraform/projects/app-transition-db-admin/README.md
@@ -50,6 +50,7 @@ DB admin boxes for Transition's RDS instance
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"t2.medium"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |
 | <a name="input_internal_zone_name"></a> [internal\_zone\_name](#input\_internal\_zone\_name) | The name of the Route53 zone that contains internal records | `string` | n/a | yes |

--- a/terraform/projects/app-transition-db-admin/user_data_snippets.tf
+++ b/terraform/projects/app-transition-db-admin/user_data_snippets.tf
@@ -6,11 +6,15 @@
 #
 # To concatenate the snippets, use:
 # ${join("\n", null_resource.user_data.*.triggers.snippet)}
-#
+# 
 
 variable "user_data_snippets" {
   type        = "list"
   description = "List of user-data snippets"
+}
+
+variable "esm_trusty_token" {
+  type = "string"
 }
 
 # Resources
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-whitehall-backend/README.md
+++ b/terraform/projects/app-whitehall-backend/README.md
@@ -56,6 +56,7 @@ Whitehall Backend nodes
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.large"` | no |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |

--- a/terraform/projects/app-whitehall-backend/user_data_snippets.tf
+++ b/terraform/projects/app-whitehall-backend/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/projects/app-whitehall-frontend/README.md
+++ b/terraform/projects/app-whitehall-frontend/README.md
@@ -50,6 +50,7 @@ Whitehall Frontend nodes
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_elb_internal_certname"></a> [elb\_internal\_certname](#input\_elb\_internal\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
+| <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |
 | <a name="input_instance_ami_filter_name"></a> [instance\_ami\_filter\_name](#input\_instance\_ami\_filter\_name) | Name to use to find AMI images | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for EC2 resources | `string` | `"m5.large"` | no |
 | <a name="input_internal_domain_name"></a> [internal\_domain\_name](#input\_internal\_domain\_name) | The domain name of the internal DNS records, it could be different from the zone name | `string` | n/a | yes |

--- a/terraform/projects/app-whitehall-frontend/user_data_snippets.tf
+++ b/terraform/projects/app-whitehall-frontend/user_data_snippets.tf
@@ -13,6 +13,10 @@ variable "user_data_snippets" {
   description = "List of user-data snippets"
 }
 
+variable "esm_trusty_token" {
+  type = "string"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -20,6 +24,6 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }

--- a/terraform/userdata/00-base
+++ b/terraform/userdata/00-base
@@ -44,6 +44,16 @@ apt-get -y upgrade
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: install AWS cli ..."
 apt-get install -y awscli jq
 
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: install ubuntu-advantage-tools ..."
+apt-get install -y ubuntu-advantage-tools
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] setup the esm repo ..."
+ubuntu-advantage attach ESM_TRUSTY_TOKEN
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: ensure the packages are up to date ..."
+apt-get update -qq
+apt-get -y upgrade
+
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: install LVM ..."
 apt-get install -y lvm2
 

--- a/tools/build-terraform-project.sh
+++ b/tools/build-terraform-project.sh
@@ -65,6 +65,7 @@ DATA_DIR="../../../${DATA_DIR}"
 COMMON_DATA_DIR="${DATA_DIR}/common/${ENVIRONMENT}"
 
 COMMON_DATA="${COMMON_DATA_DIR}/common.tfvars"
+SECRET_COMMON_DATA="${COMMON_DATA_DIR}/common.secret.tfvars"
 STACK_COMMON_DATA="${COMMON_DATA_DIR}/${STACKNAME}.tfvars"
 
 PROJECT_DATA_DIR="${DATA_DIR}/${PROJECT}/${ENVIRONMENT}"
@@ -144,6 +145,7 @@ function init() {
 TO_RUN="init && terraform $CMD"
 # Append which ever tfvar files exist
 for TFVAR_FILE in "$COMMON_DATA" \
+                  "$SECRET_COMMON_DATA" \
                   "$STACK_COMMON_DATA" \
                   "$COMMON_PROJECT_DATA" \
                   "$SECRET_COMMON_PROJECT_DATA" \
@@ -152,6 +154,7 @@ for TFVAR_FILE in "$COMMON_DATA" \
 do
   if [[ -f $TFVAR_FILE ]] &&
      {
+      [[ "$TFVAR_FILE" == "$SECRET_COMMON_DATA" ]] ||
       [[ "$TFVAR_FILE" == "$SECRET_PROJECT_DATA" ]] ||
       [[ "$TFVAR_FILE" == "$SECRET_COMMON_PROJECT_DATA" ]]
      } ; then

--- a/tools/generate-user-data-boiler-plate.sh
+++ b/tools/generate-user-data-boiler-plate.sh
@@ -32,7 +32,7 @@ resource "null_resource" "user_data" {
   count = "${length(var.user_data_snippets)}"
 
   triggers {
-    snippet = "${file("../../userdata/${element(var.user_data_snippets, count.index)}")}"
+    snippet = "${replace(file("../../userdata/${element(var.user_data_snippets, count.index)}"),"ESM_TRUSTY_TOKEN","${var.esm_trusty_token}")}"
   }
 }
 EOT


### PR DESCRIPTION
We modify the way the user-data script is generated to include the setup of the ESM repo so that we can apply the latest supported update for Trusty as early as the provisioning phase.
To avoid letting the secret token used in the setup in clear in the code, we use an intermediary beacon text that is then replaced by the actual secret.