### PR TITLE
Allocate EIPs for future use by GOV.UK Licensing

### DIFF
--- a/terraform/projects/infra-vpc/README.md
+++ b/terraform/projects/infra-vpc/README.md
@@ -28,6 +28,7 @@ and resources to export these logs to S3
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_group.log](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_eip.licensify_reservation](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/eip) | resource |
 | [aws_flow_log.vpc_flow_log](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/flow_log) | resource |
 | [aws_iam_policy.vpc_flow_logs_policy](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_policy) | resource |
 | [aws_iam_role.vpc_flow_logs_role](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role) | resource |
@@ -38,6 +39,7 @@ and resources to export these logs to S3
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_cloudwatch_log_retention"></a> [cloudwatch\_log\_retention](#input\_cloudwatch\_log\_retention) | Number of days to retain Cloudwatch logs for | `string` | n/a | yes |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |


### PR DESCRIPTION
We've been trying for a long time to get Civica to update their ACLs to allow our AWS environments to make API calls to their infrastructure, on behalf of GOV.UK Licensing's local authority users.

We're starting to see some promising signs that they might finally do this, and we want to make sure that we've got a reasonably future proof set of IP addresses to give them.

Currently, API calls to Civica go through a VPN that runs to UK Cloud.

We'd like to remove this, and have API calls go through the NAT Gateways in our production and staging VPCs. There are three NAT gateways in both environments, so we have 6 IP addresses which need to be allowlisted.

In the future, there's a high chance we'll want to move Licensing into its own VPC (or possibly its own AWS account). If this happens, we'll end up with another set of IP addresses, and we'd have to do the whole dance with Civica again.

To avoid this, this commit allocates 3 EIPs in our production VPC and 3 EIPs in our staging VPC. These will initially not be assigned to anything, but we will ask Civica to add them to their allow lists. When we eventually move Licensing, we'll be able to ask AWS support to move these EIPs to the appropriate VPC / AWS account.

NOTE: I already created one of these EIPs in production, while I was testing. Unfortunately I can't remove it again, because of the DenyEipRelease IAM policy. Instead, I've imported it into the terraform state as `aws_eip.licensify_reservation[0]`. This means that the terraform plan for this PR should only attempt to add two EIPs in production (because one is already there), but three in staging. Apologies for testing directly in production.