### PR TITLE
Staging and integration can read production transition backups

### DIFF
--- a/terraform/projects/app-transition-db-admin/README.md
+++ b/terraform/projects/app-transition-db-admin/README.md
@@ -31,6 +31,7 @@ DB admin boxes for Transition's RDS instance
 |------|------|
 | [aws_elb.transition-db-admin_elb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/elb) | resource |
 | [aws_iam_role_policy_attachment.read_integration_transition-db-admin_database_backups_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.read_production_transition-db-admin_database_backups_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.read_staging_transition-db-admin_database_backups_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.write_transition-db-admin_database_backups_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_route53_record.transition_db_admin_service_record](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |

--- a/terraform/projects/app-transition-db-admin/main.tf
+++ b/terraform/projects/app-transition-db-admin/main.tf
@@ -155,6 +155,13 @@ resource "aws_iam_role_policy_attachment" "write_transition-db-admin_database_ba
   policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.transition_dbadmin_write_database_backups_bucket_policy_arn}"
 }
 
+# Non-production environments should be able to read the database backups from production to pull data for syncing.
+resource "aws_iam_role_policy_attachment" "read_production_transition-db-admin_database_backups_iam_role_policy_attachment" {
+  count      = "${var.aws_environment != "production" ? 1 : 0}"
+  role       = "${module.transition-db-admin.instance_iam_role_name}"
+  policy_arn = "${data.terraform_remote_state.infra_database_backups_bucket.production_transition_dbadmin_read_database_backups_bucket_policy_arn}"
+}
+
 resource "aws_iam_role_policy_attachment" "read_integration_transition-db-admin_database_backups_iam_role_policy_attachment" {
   count      = "${var.aws_environment == "integration" ? 1 : 0}"
   role       = "${module.transition-db-admin.instance_iam_role_name}"


### PR DESCRIPTION
This grants access for the staging and integration DB admin machines to
read the production transition database backups. It is required for
their overnight env-sync tasks [1] [2].

The lack of this is preventing integration from syncing databases
overnight. Oddly it is working in staging where there seems to be an IAM
role policy added that isn't managed by Terraform.

[1]: https://github.com/alphagov/govuk-puppet/blob/950d713e663b081af763bff46d7db5c4cc4821db/hieradata_aws/class/integration/transition_db_admin.yaml#L2-L13
[2]: https://github.com/alphagov/govuk-puppet/blob/950d713e663b081af763bff46d7db5c4cc4821db/hieradata_aws/class/staging/transition_db_admin.yaml#L2-L13