### PR TITLE
Double the size of the knowledge graph disk

### DIFF
--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -450,7 +450,7 @@ resource "aws_launch_template" "knowledge-graph-dev_launch_template" {
     device_name = "/dev/sda1"
 
     ebs {
-      volume_size = 32
+      volume_size = 64
     }
   }
 


### PR DESCRIPTION
Much more data is being loaded into the graph, causing the disk to run out of space.

To enable https://github.com/alphagov/govuk-knowledge-graph/pull/409