### PR TITLE
Add our own owner id to the list that images are filtered by.

### DIFF
--- a/terraform/modules/aws/node_group/main.tf
+++ b/terraform/modules/aws/node_group/main.tf
@@ -207,7 +207,7 @@ data "aws_ami" "node_ami_ubuntu" {
     values = ["hvm"]
   }
 
-  owners = ["099720109477", "898082745236"]
+  owners = ["099720109477", "898082745236", "696911096973"]
 }
 
 resource "aws_iam_role" "node_iam_role" {


### PR DESCRIPTION
The Canonical AMI we previously depended on is not available
anymore, we've made a copy that we own so that we can continue to
use it. In order to make it findable we add our own owner id to
the search filter.