### PR TITLE
Use a bigger instance for data-science-data

### DIFF
--- a/terraform/projects/app-data-science-data/main.tf
+++ b/terraform/projects/app-data-science-data/main.tf
@@ -189,7 +189,7 @@ resource "aws_launch_template" "data-science-data_launch_template" {
   name     = "data-science-data_launch-template"
   image_id = "${data.aws_ami.ubuntu_bionic.id}"
 
-  instance_type = "r4.4xlarge"
+  instance_type = "r4.8xlarge"
 
   vpc_security_group_ids = ["${data.terraform_remote_state.infra_security_groups.sg_data-science-data_id}"]
 


### PR DESCRIPTION
We've run out of memory to run the pipeline, so this changes
the instance to 8xlarge. We might go back once we've simplified
the pipeline as planned. On the other hand the instance runs for
about 10h a week, so it's not astronomical, and faster too