### PR TITLE
Allow traffic replay to bypass rate limiting

### DIFF
--- a/terraform/projects/infra-public-wafs/README.md
+++ b/terraform/projects/infra-public-wafs/README.md
@@ -35,6 +35,7 @@ No modules.
 | [aws_shield_protection.prometheus_public_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.sidekiq_monitoring_public_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.whitehall_backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
+| [aws_wafv2_ip_set.govuk_requesting_ips](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set) | resource |
 | [aws_wafv2_ip_set.nat_gateway_ips](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set) | resource |
 | [aws_wafv2_regex_pattern_set.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_regex_pattern_set) | resource |
 | [aws_wafv2_rule_group.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_rule_group) | resource |
@@ -82,6 +83,7 @@ No modules.
 | <a name="input_remote_state_infra_security_groups_key_stack"></a> [remote\_state\_infra\_security\_groups\_key\_stack](#input\_remote\_state\_infra\_security\_groups\_key\_stack) | Override path to infra\_security\_groups remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override path to infra\_vpc remote state | `string` | `""` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | `"govuk"` | no |
+| <a name="input_traffic_replay_ips"></a> [traffic\_replay\_ips](#input\_traffic\_replay\_ips) | An array of CIDR blocks that will replay traffic against an environment | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/terraform/projects/infra-public-wafs/cache_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/cache_public_rule.tf
@@ -24,9 +24,9 @@ resource "aws_wafv2_web_acl" "cache_public" {
     }
 
     visibility_config {
-      cloudwatch_metrics_enabled = false
+      cloudwatch_metrics_enabled = true
       metric_name                = "x-always-block-rule-group"
-      sampled_requests_enabled   = false
+      sampled_requests_enabled   = true
     }
   }
 
@@ -53,9 +53,9 @@ resource "aws_wafv2_web_acl" "cache_public" {
     }
 
     visibility_config {
-      cloudwatch_metrics_enabled = false
+      cloudwatch_metrics_enabled = true
       metric_name                = "govuk-infra-cache-requests"
-      sampled_requests_enabled   = false
+      sampled_requests_enabled   = true
     }
   }
 
@@ -87,9 +87,9 @@ resource "aws_wafv2_web_acl" "cache_public" {
     }
 
     visibility_config {
-      cloudwatch_metrics_enabled = false
+      cloudwatch_metrics_enabled = true
       metric_name                = "fastly-healthcheck-requests"
-      sampled_requests_enabled   = false
+      sampled_requests_enabled   = true
     }
   }
 

--- a/terraform/projects/infra-public-wafs/cache_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/cache_public_rule.tf
@@ -42,7 +42,7 @@ resource "aws_wafv2_web_acl" "cache_public" {
 
     statement {
       ip_set_reference_statement {
-        arn = aws_wafv2_ip_set.nat_gateway_ips.arn
+        arn = aws_wafv2_ip_set.govuk_requesting_ips.arn
 
         ip_set_forwarded_ip_config {
           fallback_behavior = "NO_MATCH"
@@ -131,12 +131,26 @@ resource "aws_wafv2_web_acl" "cache_public" {
   }
 }
 
+# Can be deleted once the new set has been associated with the rule and applied
 resource "aws_wafv2_ip_set" "nat_gateway_ips" {
   name               = "nat_gateway_ips"
   description        = "The IP addresses used by our infra to talk to the public internet."
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
   addresses          = formatlist("%s/32", data.terraform_remote_state.infra_networking.outputs.nat_gateway_elastic_ips_list)
+}
+
+locals {
+  # formatting into a CIDR block as expected by the aws_wafv2_ip_set below
+  nat_gateway_ips = formatlist("%s/32", data.terraform_remote_state.infra_networking.outputs.nat_gateway_elastic_ips_list)
+}
+
+resource "aws_wafv2_ip_set" "govuk_requesting_ips" {
+  name               = "govuk_requesting_ips"
+  description        = "The IP addresses used by our infra to make requests that hit the cache LB."
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = concat(var.traffic_replay_ips, local.nat_gateway_ips)
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "public_cache_web_acl_logging" {

--- a/terraform/projects/infra-public-wafs/variables.tf
+++ b/terraform/projects/infra-public-wafs/variables.tf
@@ -49,3 +49,8 @@ variable "cache_public_base_rate_limit" {
   type        = number
   description = "Number of requests to allow in a 5 minute period before rate limiting is applied."
 }
+
+variable "traffic_replay_ips" {
+  type        = list(string)
+  description = "An array of CIDR blocks that will replay traffic against an environment"
+}


### PR DESCRIPTION
In integration and staging, production traffic is replayed to some extent. The rate limiting works using the IP address of the request originator, which in the case of traffic replay is limited to a couple of addresses on our side.

This will not affect production, as traffic is not replayed there.

As before, the IP address is provided in a CIDR block format. This is specified already in the [common config](https://github.com/alphagov/govuk-aws-data/blob/main/data/common/staging/common.tfvars#L72)

Temporarily leaving the old IP set in, as it doesn't appear to delete cleanly if all done at once.

Also re-adding metrics for the rules that bypass the rate limiting, as this makes troubleshooting easier

https://trello.com/c/IvZrVCL3/2869-setting-rate-limits-within-aws-waf