### PR TITLE
Allow Google Cloud Platform to read a bucket

### DIFF
--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -42,12 +42,15 @@ Infrastructure security settings:
 | [aws_iam_policy.data-science-access-sagemaker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.deny-eip-release](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.event_bridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.google-s3-mirror](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.pass_step_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.shield-response-team-access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.event_bridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.google-s3-mirror](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.role_step_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.shield-response-team-access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.event_bridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.google-s3-mirror-access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.role_step_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.shield-response-team-access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_key_pair.govuk-infra-key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
@@ -61,6 +64,7 @@ Infrastructure security settings:
 | [aws_iam_policy_document.data-science-access-glue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.data-science-access-sagemaker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.deny-eip-release](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.google_s3_mirror](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_sops_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.pass_step_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.shield-response-team-access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |


### PR DESCRIPTION
This allows a particular GCP project to read the bucket govuk-integration-database-backups, so that other GCP projects can securely and easily access GOV.UK's data.  The approach has been [discussed](https://docs.google.com/document/d/1Nw7xqXZQn6PIjkB_XsXuAFa2iyN9s6Booi9HxtpyGCE).

The GCP project uses the "Storage Transfer" service to sync a GCP bucket with the AWS bucket.  The service uses a default service account (i.e. one that Google manages).  This pull request allows that service account, identified by its "subject ID", given here as `accounts.google.com:sub`, to assume an IAM role that has permission to read the contents of the AWS bucket.  No keys are required.  See [Google's documentation of this arrangement](https://cloud.google.com/storage-transfer/docs/source-amazon-s3#federated_identity).

The corresponding [GCP config](https://github.com/alphagov/govuk-s3-mirror/blob/main/terraform/transfer.tf).  Currently it only syncs some of the objects in the bucket, because those are the ones currently being used by other projects in GCP.  See [Google's documentation of this arrangement](https://cloud.google.com/storage-transfer/docs/create-transfers#amazon-s3).  See also [Terraform's example configuration](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_transfer_job#example-usage).

There is a [precedent](https://github.com/alphagov/govuk-aws/blob/main/terraform/projects/infra-google-mirror-bucket/main.tf), which backs up the buckets govuk-production-mirror and govuk-staging-mirror.  It uses a key, which requires manual maintenance. 
