### PR TITLE
Output office IPs

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -607,6 +607,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_office_ips"></a> [office\_ips](#output\_office\_ips) | n/a |
 | <a name="output_sg_accessibility-reports_id"></a> [sg\_accessibility-reports\_id](#output\_sg\_accessibility-reports\_id) | n/a |
 | <a name="output_sg_account_elb_external_id"></a> [sg\_account\_elb\_external\_id](#output\_sg\_account\_elb\_external\_id) | n/a |
 | <a name="output_sg_account_elb_internal_id"></a> [sg\_account\_elb\_internal\_id](#output\_sg\_account\_elb\_internal\_id) | n/a |

--- a/terraform/projects/infra-security-groups/outputs.tf
+++ b/terraform/projects/infra-security-groups/outputs.tf
@@ -533,3 +533,7 @@ output "sg_data-science-data_id" {
 output "sg_accessibility-reports_id" {
   value = "${aws_security_group.accessibility-reports.id}"
 }
+
+output "office_ips" {
+  value = "${var.office_ips}"
+}


### PR DESCRIPTION
The outputted office IPs will then be used in govuk-infrastructure for the GOV.UK EKS Platform.