### PR TITLE
Add a log subscription filter

### DIFF
--- a/terraform/projects/infra-cyber-cloudwatch-to-splunk/README.md
+++ b/terraform/projects/infra-cyber-cloudwatch-to-splunk/README.md
@@ -20,6 +20,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_subscription_filter.log_subscription](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter) | resource |
+| [aws_cloudwatch_log_subscription_filter.log_subscription_v2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter) | resource |
 
 ## Inputs
 
@@ -27,6 +28,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_splunk_destination_arn"></a> [splunk\_destination\_arn](#input\_splunk\_destination\_arn) | The ARN of Cyber Security's centralised security logging service (https://github.com/alphagov/centralised-security-logging-service) | `string` | n/a | yes |
+| <a name="input_splunk_destination_v2_arn"></a> [splunk\_destination\_v2\_arn](#input\_splunk\_destination\_v2\_arn) | The ARN of v2 of Cyber Security's centralised security logging service (https://github.com/alphagov/centralised-security-logging-service) | `string` | n/a | yes |
 
 ## Outputs
 

--- a/terraform/projects/infra-cyber-cloudwatch-to-splunk/main.tf
+++ b/terraform/projects/infra-cyber-cloudwatch-to-splunk/main.tf
@@ -10,6 +10,11 @@ variable "splunk_destination_arn" {
   description = "The ARN of Cyber Security's centralised security logging service (https://github.com/alphagov/centralised-security-logging-service)"
 }
 
+variable "splunk_destination_v2_arn" {
+  type        = string
+  description = "The ARN of v2 of Cyber Security's centralised security logging service (https://github.com/alphagov/centralised-security-logging-service)"
+}
+
 terraform {
   backend "s3" {}
   required_version = "~> 1.1"
@@ -31,4 +36,11 @@ resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
   log_group_name  = "auth-log"
   filter_pattern  = ""
   destination_arn = var.splunk_destination_arn
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "log_subscription_v2" {
+  name            = "log_subscription_python"
+  log_group_name  = "auth-log"
+  filter_pattern  = ""
+  destination_arn = var.splunk_destination_v2_arn
 }


### PR DESCRIPTION
Cyber are migrating their ingestion lambda because of the deprecation (by AWS) of something their old one relied on.

Here we add another filter pointing at their new lambda. The two will run in parallel for a short time while we confirm that everything's working and to ensure that we don't drop any logs.

https://trello.com/c/IJQFMwki/2984-update-cyber-splunk-endpoint