### PR TITLE
Remove original Cyber logging filter

### DIFF
--- a/terraform/projects/infra-cyber-cloudwatch-to-splunk/README.md
+++ b/terraform/projects/infra-cyber-cloudwatch-to-splunk/README.md
@@ -19,7 +19,6 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_log_subscription_filter.log_subscription](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter) | resource |
 | [aws_cloudwatch_log_subscription_filter.log_subscription_v2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter) | resource |
 
 ## Inputs
@@ -27,7 +26,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
-| <a name="input_splunk_destination_arn"></a> [splunk\_destination\_arn](#input\_splunk\_destination\_arn) | The ARN of Cyber Security's centralised security logging service (https://github.com/alphagov/centralised-security-logging-service) | `string` | n/a | yes |
 | <a name="input_splunk_destination_v2_arn"></a> [splunk\_destination\_v2\_arn](#input\_splunk\_destination\_v2\_arn) | The ARN of v2 of Cyber Security's centralised security logging service (https://github.com/alphagov/centralised-security-logging-service) | `string` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/infra-cyber-cloudwatch-to-splunk/main.tf
+++ b/terraform/projects/infra-cyber-cloudwatch-to-splunk/main.tf
@@ -5,11 +5,6 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
-variable "splunk_destination_arn" {
-  type        = string
-  description = "The ARN of Cyber Security's centralised security logging service (https://github.com/alphagov/centralised-security-logging-service)"
-}
-
 variable "splunk_destination_v2_arn" {
   type        = string
   description = "The ARN of v2 of Cyber Security's centralised security logging service (https://github.com/alphagov/centralised-security-logging-service)"
@@ -29,13 +24,6 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
-}
-
-resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
-  name            = "log_subscription"
-  log_group_name  = "auth-log"
-  filter_pattern  = ""
-  destination_arn = var.splunk_destination_arn
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "log_subscription_v2" {


### PR DESCRIPTION
We've migrated to the new one, so this can be removed.

Corresponds with https://github.com/alphagov/govuk-aws-data/pull/1098

https://trello.com/c/IJQFMwki/2984-update-cyber-splunk-endpoint