### PR TITLE
Bump waf logs lambda to supported node version

### DIFF
--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -96,7 +96,7 @@ resource "aws_lambda_function" "aws_waf_log_trimmer" {
   source_code_hash = "${data.archive_file.aws_waf_log_trimmer.output_base64sha256}"
   role             = "${aws_iam_role.aws_waf_log_trimmer.arn}"
   handler          = "lambda.handler"
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs12.x"
   timeout          = 190
 }
 


### PR DESCRIPTION
nodejs10.x is no longer supported.

Node 12 is a supported runtime, however [it's the last on the block](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html). 14 and 16 are newer, so we should aim to bump up to those soon.

In the interest of making small changes though, and because we're not amazingly familiar with upgrading lambdas, we'll stick with just getting to a supported version.

I've reviewed [node's changes between 10 and 12, and they all look reasonable.](https://nodejs.org/tr/blog/uncategorized/10-lts-to-12-lts/)

[The lambda itself](https://github.com/alphagov/govuk-aws/blob/main/terraform/lambda/WAFLogTrimmer/lambda.js) is quite simple which makes this process easier to evaluate.

https://trello.com/c/GMYN51xo/2988-bump-waf-logs-lambda-nodejs-version