### PR TITLE
Use cheaper and faster gp3 block storage for mirrorer.

### DIFF
--- a/terraform/projects/app-mirrorer/main.tf
+++ b/terraform/projects/app-mirrorer/main.tf
@@ -81,7 +81,7 @@ resource "aws_ebs_volume" "mirrorer" {
   availability_zone = "${lookup(data.terraform_remote_state.infra_networking.private_subnet_names_azs_map, var.mirrorer_subnet)}"
   encrypted         = "${var.ebs_encrypted}"
   size              = "${var.mirrorer_ebs_size}"
-  type              = "gp2"
+  type              = "gp3"
 
   tags {
     Name            = "${var.stackname}-mirrorer"


### PR DESCRIPTION
The mirror job overrunning because it's so slow, so let's update to the current generation of block storage and see if that helps.

Tested: manually updated in staging and [ran the mirrorer job](https://docs.publishing.service.gov.uk/manual/alerts/mirror-sync.html#troubleshooting).