### PR TITLE
Swap cache public WAF to CloudWatch logging

### DIFF
--- a/terraform/projects/infra-public-wafs/README.md
+++ b/terraform/projects/infra-public-wafs/README.md
@@ -20,6 +20,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_log_group.public_cache_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_shield_protection.account_public_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.bouncer_public_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
@@ -57,7 +58,7 @@ No modules.
 | [aws_wafv2_web_acl_association.sidekiq_monitoring_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_association.whitehall_backend_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_logging_configuration.default_web_acl_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
-| [aws_wafv2_web_acl_logging_configuration.public_cache_web_acl_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
+| [aws_wafv2_web_acl_logging_configuration.public_cache_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [terraform_remote_state.infra_database_backups_bucket](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_monitoring](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_networking](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -84,6 +85,7 @@ No modules.
 | <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override path to infra\_vpc remote state | `string` | `""` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | `"govuk"` | no |
 | <a name="input_traffic_replay_ips"></a> [traffic\_replay\_ips](#input\_traffic\_replay\_ips) | An array of CIDR blocks that will replay traffic against an environment | `list(string)` | n/a | yes |
+| <a name="input_waf_log_retention_days"></a> [waf\_log\_retention\_days](#input\_waf\_log\_retention\_days) | The number of days CloudWatch will retain WAF logs for. | `string` | `"30"` | no |
 
 ## Outputs
 

--- a/terraform/projects/infra-public-wafs/variables.tf
+++ b/terraform/projects/infra-public-wafs/variables.tf
@@ -54,3 +54,9 @@ variable "traffic_replay_ips" {
   type        = list(string)
   description = "An array of CIDR blocks that will replay traffic against an environment"
 }
+
+variable "waf_log_retention_days" {
+  type        = string
+  description = "The number of days CloudWatch will retain WAF logs for."
+  default     = "30"
+}


### PR DESCRIPTION
We  currently use a kinesis firehose to send log entries to Splunk. There's a lambda that runs on each log entry to filter out things that aren't relevant.

Since the kinesis firehose was configured, AWS announced support for native [WAF log filtering](https://aws.amazon.com/about-aws/whats-new/2021/05/aws-waf-adds-support-for-log-filtering/).

If this works as expected, we should eventually be able to ditch [the kinesis/lambda set up](https://github.com/alphagov/govuk-aws/blob/main/terraform/projects/infra-public-services/waf.tf#L67-L101), which will be one less thing for us to worry about keeping up to date.

Logging to CloudWatch also gives us more ability to monitor what's happening on tools that we are more familiar with.

I expect we'll eventually ship the logs off to Splunk as well, but we can probably avoid doing that while we figure things out.

The intention for this is to log requests that trigger a COUNT or a BLOCK. Things that are allowed will be logged elsewhere in our infra, so should be easy enough to track down.

This is similar to the [existing lambda](https://github.com/alphagov/govuk-aws/blob/4e81ceee540e7f1a521a638a3a214b336289cad8/terraform/lambda/WAFLogTrimmer/lambda.js) which forwards on everything that isn't a the "Default Action". We do now though explicitly allow some traffic, and we probably don't need to log that as well.

When things are in CloudWatch we can [use the docs](https://aws.amazon.com/premiumsupport/knowledge-center/waf-analyze-logs-stored-cloudwatch-s3/) a bit more straightforwardly too. We'll tweak the retention period per
environment once we're sure the filtering is working as expected.

https://trello.com/c/NK1JYc96/2759-consolidate-waf-logging-on-cloudwatch