### PR TITLE
Allow authenticating-proxy to talk to RDS for Postgres

### DIFF
--- a/terraform/projects/app-draft-cache/README.md
+++ b/terraform/projects/app-draft-cache/README.md
@@ -37,11 +37,13 @@ Draft Cache servers
 | [aws_route53_record.draft-cache_publicapi_service_record](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.draft-cache_service_record](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
 | [aws_route53_record.draft-router-api_internal_record](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/route53_record) | resource |
+| [aws_security_group_rule.authenticating-proxy-rds_ingress_draft_cache_postgres](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [null_resource.user_data](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_acm_certificate.elb_external_cert](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/acm_certificate) | data source |
 | [aws_acm_certificate.elb_internal_cert](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/acm_certificate) | data source |
 | [aws_route53_zone.external](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/route53_zone) | data source |
 | [aws_route53_zone.internal](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/route53_zone) | data source |
+| [aws_security_group.authenticating-proxy-rds](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/data-sources/security_group) | data source |
 | [terraform_remote_state.infra_monitoring](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_networking](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_root_dns_zones](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |

--- a/terraform/projects/app-draft-cache/main.tf
+++ b/terraform/projects/app-draft-cache/main.tf
@@ -311,6 +311,20 @@ module "alarms-elb-draft-cache-external" {
   healthyhostcount_threshold     = "0"
 }
 
+data "aws_security_group" "authenticating-proxy-rds" {
+  name = "${var.stackname}_authenticating-proxy_rds_access"
+}
+
+resource "aws_security_group_rule" "authenticating-proxy-rds_ingress_draft_cache_postgres" {
+  type      = "ingress"
+  from_port = 5432
+  to_port   = 5432
+  protocol  = "tcp"
+
+  security_group_id        = "${data.aws_security_group.authenticating-proxy-rds.0.id}"
+  source_security_group_id = "${data.terraform_remote_state.infra_security_groups.sg_draft-cache_id}"
+}
+
 # Outputs
 # --------------------------------------------------------------
 


### PR DESCRIPTION
Adds security rules to allow AP to talk to RDS, needed for the Postgres switch.

NB: This adds elements, it does not remove any existing elements (ie it is safe to deploy even if we have to roll back, because the existing infrastructure for MongoDB is untouched)

Authenticating Proxy PR:
https://github.com/alphagov/authenticating-proxy/pull/350

Related PRs:
https://github.com/alphagov/govuk-aws-data/pull/1092
https://github.com/alphagov/govuk-puppet/pull/11967
https://github.com/alphagov/govuk-secrets/pull/1370

## Why
https://trello.com/c/lSpntlfk/81-mongo-26-has-reached-end-of-life