### PR TITLE
Stop using old alphagov.co.uk domain

### DIFF
--- a/terraform/userdata/00-base
+++ b/terraform/userdata/00-base
@@ -34,7 +34,7 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: install Gov.UK package signing key an
 curl --silent --show-error --fail \
   https://apt.publishing.service.gov.uk/EC5FE1A937E3ACBB.asc | apt-key add -
 
-echo "deb [arch=amd64] http://apt.production.alphagov.co.uk/awscli $DISTRIB_CODENAME main" \
+echo "deb [arch=amd64] https://apt.publishing.service.gov.uk/awscli/ $DISTRIB_CODENAME main" \
   >> /etc/apt/sources.list.d/awscli.list
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] base: ensure the packages are up to date ..."


### PR DESCRIPTION
https://trello.com/c/CkRb8XcT/3003-audit-usage-of-alphagovcouk-domain-2