### PR TITLE
Make AWS shield protection an opt-in feature

### DIFF
--- a/terraform/modules/aws/network/nat/README.md
+++ b/terraform/modules/aws/network/nat/README.md
@@ -31,6 +31,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_shield_protection_enabled"></a> [shield\_protection\_enabled](#input\_shield\_protection\_enabled) | Whether or not to enable AWS Shield. Terraform 0.11 doesn't have booleans, so representing as string. | `string` | `"true"` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of public subnet IDs where you want to create a NAT Gateway | `list` | n/a | yes |
 | <a name="input_subnet_ids_length"></a> [subnet\_ids\_length](#input\_subnet\_ids\_length) | Length of subnet\_ids variable | `string` | n/a | yes |
 

--- a/terraform/modules/aws/network/nat/main.tf
+++ b/terraform/modules/aws/network/nat/main.tf
@@ -5,6 +5,12 @@
 * subnets provided.
 */
 
+variable "shield_protection_enabled" {
+  type        = "string"
+  description = "Whether or not to enable AWS Shield. Terraform 0.11 doesn't have booleans, so representing as string."
+  default     = "true"
+}
+
 variable "subnet_ids" {
   type        = "list"
   description = "List of public subnet IDs where you want to create a NAT Gateway"
@@ -31,7 +37,7 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_shield_protection" "aws_eip" {
-  count        = "${length(aws_eip.nat.*.id)}"
+  count        = "${var.shield_protection_enabled ? length(aws_eip.nat.*.id) : 0}"
   name         = "${element(aws_eip.nat.*.id, count.index)}_shield"
   resource_arn = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${element(aws_eip.nat.*.id, count.index)}"
 }

--- a/terraform/projects/infra-networking/README.md
+++ b/terraform/projects/infra-networking/README.md
@@ -60,6 +60,7 @@ This module governs the creation of full network stacks.
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | <a name="input_remote_state_infra_monitoring_key_stack"></a> [remote\_state\_infra\_monitoring\_key\_stack](#input\_remote\_state\_infra\_monitoring\_key\_stack) | Override stackname path to infra\_monitoring remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override infra\_vpc remote state path | `string` | `""` | no |
+| <a name="input_shield_protection_enabled"></a> [shield\_protection\_enabled](#input\_shield\_protection\_enabled) | Whether or not to enable AWS Shield. Terraform 0.11 doesn't have booleans, so representing as string. | `string` | `"true"` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
 
 ## Outputs

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -26,6 +26,12 @@ variable "remote_state_infra_monitoring_key_stack" {
   default     = ""
 }
 
+variable "shield_protection_enabled" {
+  type        = "string"
+  description = "Whether or not to enable AWS Shield. Terraform 0.11 doesn't have booleans, so representing as string."
+  default     = "true"
+}
+
 variable "stackname" {
   type        = "string"
   description = "Stackname"
@@ -151,9 +157,10 @@ module "infra_public_subnet" {
 }
 
 module "infra_nat" {
-  source            = "../../modules/aws/network/nat"
-  subnet_ids        = "${matchkeys(values(module.infra_public_subnet.subnet_names_ids_map), keys(module.infra_public_subnet.subnet_names_ids_map), var.public_subnet_nat_gateway_enable)}"
-  subnet_ids_length = "${length(var.public_subnet_nat_gateway_enable)}"
+  shield_protection_enabled = "${var.shield_protection_enabled}"
+  source                    = "../../modules/aws/network/nat"
+  subnet_ids                = "${matchkeys(values(module.infra_public_subnet.subnet_names_ids_map), keys(module.infra_public_subnet.subnet_names_ids_map), var.public_subnet_nat_gateway_enable)}"
+  subnet_ids_length         = "${length(var.public_subnet_nat_gateway_enable)}"
 }
 
 # Intermediate variables in Terraform are not supported.


### PR DESCRIPTION
This isn't enabled in our Tools environment, and causes us to not be able to apply the infra-networking project. See
https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/3892/console