### PR TITLE
Add new Owner ID where specified in projects rather than centrally.

### DIFF
--- a/terraform/projects/app-accessibility-reports/main.tf
+++ b/terraform/projects/app-accessibility-reports/main.tf
@@ -45,7 +45,7 @@ data "aws_ami" "ubuntu_bionic" {
   most_recent = true
 
   # canonical
-  owners = ["099720109477"]
+  owners = ["099720109477", "696911096973"]
 
   filter {
     name   = "name"

--- a/terraform/projects/app-data-science-data/main.tf
+++ b/terraform/projects/app-data-science-data/main.tf
@@ -45,7 +45,7 @@ data "aws_ami" "ubuntu_bionic" {
   most_recent = true
 
   # canonical
-  owners = ["099720109477"]
+  owners = ["099720109477", "696911096973"]
 
   filter {
     name   = "name"

--- a/terraform/projects/app-govuk-rds/db_admin.tf
+++ b/terraform/projects/app-govuk-rds/db_admin.tf
@@ -12,7 +12,7 @@ data "aws_ami" "node_ami_ubuntu" {
   }
 
   # this is the ID of the Amazon owner of the AMI we use
-  owners = ["099720109477"]
+  owners = ["099720109477", "696911096973"]
 }
 
 data "aws_iam_policy_document" "assume_node_role" {

--- a/terraform/projects/app-knowledge-graph/main.tf
+++ b/terraform/projects/app-knowledge-graph/main.tf
@@ -258,7 +258,7 @@ data "template_file" "knowledge-graph_userdata" {
 # The AWS image to use to host the knowledge graph
 # Ubuntu Server 22.04 LTS (HVM), SSD Volume Type
 data "aws_ami" "ubuntu_server_22" {
-  owners = ["099720109477"]
+  owners = ["099720109477", "696911096973"]
 
   filter {
     name   = "image-id"

--- a/terraform/projects/app-related-links/main.tf
+++ b/terraform/projects/app-related-links/main.tf
@@ -73,7 +73,7 @@ data "aws_ami" "ubuntu_bionic" {
   most_recent = true
 
   # canonical
-  owners = ["099720109477"]
+  owners = ["099720109477", "696911096973"]
 
   filter {
     name   = "name"

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -441,7 +441,7 @@ data "aws_ami" "ubuntu_focal" {
   most_recent = true
 
   # canonical
-  owners = ["099720109477"]
+  owners = ["099720109477", "696911096973"]
 
   filter {
     name   = "name"


### PR DESCRIPTION
The AMI Owner ID that was needed to fix the central node_group module (here: https://github.com/alphagov/govuk-aws/pull/1626)  is also needed in 6 other places where AMI Owner IDs have been specified explicitly.

 