### PR TITLE
Allow external partner IPs to send traffic to us

### DIFF
--- a/terraform/projects/infra-public-wafs/README.md
+++ b/terraform/projects/infra-public-wafs/README.md
@@ -36,6 +36,7 @@ No modules.
 | [aws_shield_protection.prometheus_public_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.sidekiq_monitoring_public_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.whitehall_backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
+| [aws_wafv2_ip_set.external_partner_ips](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set) | resource |
 | [aws_wafv2_ip_set.govuk_requesting_ips](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set) | resource |
 | [aws_wafv2_ip_set.nat_gateway_ips](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set) | resource |
 | [aws_wafv2_regex_pattern_set.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_regex_pattern_set) | resource |
@@ -71,6 +72,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allow_external_ips"></a> [allow\_external\_ips](#input\_allow\_external\_ips) | An array of CIDR blocks that are our partners using to send traffic to us | `list(string)` | n/a | yes |
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_cache_public_base_rate_limit"></a> [cache\_public\_base\_rate\_limit](#input\_cache\_public\_base\_rate\_limit) | Number of requests to allow in a 5 minute period before rate limiting is applied. | `number` | n/a | yes |

--- a/terraform/projects/infra-public-wafs/cache_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/cache_public_rule.tf
@@ -93,7 +93,7 @@ resource "aws_wafv2_web_acl" "cache_public" {
     }
   }
 
-rule {
+  rule {
     name     = "allow-external-partners"
     priority = 4
 

--- a/terraform/projects/infra-public-wafs/cache_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/cache_public_rule.tf
@@ -93,6 +93,33 @@ resource "aws_wafv2_web_acl" "cache_public" {
     }
   }
 
+rule {
+    name     = "allow-external-partners"
+    priority = 4
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.external_partner_ips.arn
+
+        ip_set_forwarded_ip_config {
+          fallback_behavior = "NO_MATCH"
+          header_name       = "true-client-ip"
+          position          = "FIRST"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "external-partner-cache-requests"
+      sampled_requests_enabled   = true
+    }
+  }
+
   # set a base rate limit per IP looking back over the last 5 minutes
   # this is checked every 30s
   rule {
@@ -151,6 +178,14 @@ resource "aws_wafv2_ip_set" "govuk_requesting_ips" {
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
   addresses          = concat(var.traffic_replay_ips, local.nat_gateway_ips)
+}
+
+resource "aws_wafv2_ip_set" "external_partner_ips" {
+  name               = "external_partner_ips"
+  description        = "The IP addresses are used by our partners."
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = var.allow_external_ips
 }
 
 resource "aws_cloudwatch_log_group" "public_cache_waf" {

--- a/terraform/projects/infra-public-wafs/variables.tf
+++ b/terraform/projects/infra-public-wafs/variables.tf
@@ -55,6 +55,11 @@ variable "traffic_replay_ips" {
   description = "An array of CIDR blocks that will replay traffic against an environment"
 }
 
+variable "allow_external_ips" {
+  type        = list(string)
+  description = "An array of CIDR blocks that are our partners using to send traffic to us"
+}
+
 variable "waf_log_retention_days" {
   type        = string
   description = "The number of days CloudWatch will retain WAF logs for."


### PR DESCRIPTION
The National Archives requires to crawl our content. We accept this, therefore, we need to allow their IPs to get through the cache-public-waf.

Trello: https://trello.com/c/3tnQrCBV/3036-add-national-archives-ip-addresses-to-allow-list