### PR TITLE
replace -force with -auto-approve for terraform v1.0+

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -50,7 +50,7 @@ git clone --single-branch --branch "$GOVUK_AWS_DATA_BRANCH" git@github.com:alpha
 case $COMMAND in
   'apply') EXTRA='-auto-approve';;
   'plan (destroy)') COMMAND='plan'; EXTRA='-detailed-exitcode -destroy';;
-  'destroy') EXTRA='-force';;
+  'destroy') EXTRA='-auto-approve';;
   'plan') EXTRA='-detailed-exitcode';;
 esac
 


### PR DESCRIPTION
Running a terraform build with the `destroy` action throws an error when the terraform version is v1.0+
This is because [the `-force` flag was deprecated in v1.0](https://community.harness.io/t/terraform-terraform-destroy-force-is-deprecated/863). For non-interactive execution of a `terraform destroy`, we now must supply `-auto-approve` instead. 

This PR changes the default `EXTRA` parameter on a `terraform destroy` to `auto-approve`, so that it will work on any build targetting v1.0+. 

We'll also need to work out how to deal with projects that target terraform v0.x. Options discussed include parsing the output of `terraform version` (fiddly and error-prone) or adding a new `COMMAND` option (say, destroy-v0 - but that would need adding to govuk-cli as well). 