### PR TITLE
Add explicit --lockfile=false flag to terraform-docs invocation

### DIFF
--- a/tools/update-docs.sh
+++ b/tools/update-docs.sh
@@ -8,5 +8,5 @@ if [[ ! $(command -v terraform-docs) ]]; then
 fi
 
 for i in $(find terraform/ -name main.tf |sed 's/\/main.tf//g'); do
-  terraform-docs md $i > $i/README.md
+  terraform-docs --lockfile=false md $i > $i/README.md
 done


### PR DESCRIPTION
Builds were [failing at the docs check linting stage](https://github.com/alphagov/govuk-aws/actions/runs/3619471834/jobs/6100553287#step:7:45), as the version numbers generated in CI were using the version spec given in the `required_providers` block, whereas running locally (at least on Ubuntu) they were using the exact version numbers in the .hcl lock file. This mean that the instruction `You should run ./tools/update-docs.sh and commit the results.` did not fix the broken builds.

It looks like there was [a bit of back-and-forth on this with the developers](https://github.com/terraform-docs/terraform-docs/issues/517) but a `--lockfile` flag was introduced in [terraform-docs v0.15](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.15.0)

I assume the default setting for this differs in the Github Action hosted runner compared to a .deb package install on Ubuntu, possibly through a bundled settings file, but I have not been able to verify this.

This commit adds an explicit flag to the invocation so that whatever environment you're running `tools/update-docs.sh` in, it will use the same setting. I've tested that this [solves the problem](https://github.com/alphagov/govuk-aws/pull/1655/commits/44244f12fde06b17396a56ad2d1717b2e9bbfd1d)