### PR TITLE
Lambda for writing CSP report-uri responses to Kinese Firehose

### DIFF
--- a/terraform/lambda/CspReportsToFirehose/README.md
+++ b/terraform/lambda/CspReportsToFirehose/README.md
@@ -1,0 +1,10 @@
+# CspReportsToFirehose
+
+
+This lambda is to receive Content Security Policy reports using the [report-uri](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri) directive. It will write valid ones to Kinesis Firehose for storing.
+
+It is not configured for the CSP [report-to](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to) usage where a different JSON structure is used, at the time of writing report-to is not available in all browsers. It is also caught up in the browser [Reporting API](https://www.w3.org/TR/reporting-1/) which is currently a draft standard.
+
+This was built targeting nodejs 18 and needs and an env var of FIREHOSE_DELIVERY_STREAM to specify the Kinesis
+
+You can test this lambda in the AWS console by setting up a test event based on `apigateway-aws-proxy` with a customised body and Content-Type, you may want to comment out the Kinesis Firehose aspect for easier testing.

--- a/terraform/lambda/CspReportsToFirehose/index.mjs
+++ b/terraform/lambda/CspReportsToFirehose/index.mjs
@@ -1,0 +1,89 @@
+import { Firehose } from '@aws-sdk/client-firehose'
+
+function buildReport (json, sourceIp, userAgent) {
+  const cspReport = json['csp-report'] || {}
+  const now = new Date()
+
+  // using snake casing for easier usage in AWS Glue
+  return {
+    time: now.toISOString(),
+    document_uri: normaliseInputString(cspReport['document-uri']),
+    referrer: normaliseInputString(cspReport.referrer),
+    blocked_uri: normaliseInputString(cspReport['blocked-uri']),
+    effective_directive: normaliseInputString(cspReport['effective-directive']),
+    violated_directive: normaliseInputString(cspReport['violated-directive']),
+    disposition: normaliseInputString(cspReport.disposition),
+    sample: normaliseInputString(cspReport['script-sample']),
+    line_number: normaliseInteger(cspReport['line-number']),
+    status_code: normaliseInteger(cspReport['status-code']),
+    source_ip: normaliseInputString(sourceIp),
+    user_agent: normaliseInputString(userAgent)
+  }
+}
+
+function normaliseInputString (input) {
+  if (!input) return null
+
+  const string = String(input)
+
+  if (string.length > 4000) {
+    // lets not store anything suspiciously long
+    return string.slice(0, 4000)
+  } else {
+    return string
+  }
+}
+
+function normaliseInteger (input) {
+  return Number.isInteger(input) ? input : null
+}
+
+// we seem to get base64 submitted, not sure if this is something API gateway
+// can resolve
+function parseBody (body) {
+  // Try decode base64
+  try {
+    const buffer = Buffer.from(body, 'base64')
+    return JSON.parse(buffer.toString())
+  } catch {
+    // otherwise try regular body
+    return JSON.parse(body)
+  }
+}
+
+async function sendReportToFirehose (report) {
+  console.log('sending data to firehose')
+  console.log(report)
+
+  const client = new Firehose()
+  await client.putRecord({ DeliveryStreamName: process.env.FIREHOSE_DELIVERY_STREAM, Record: { Data: Buffer.from(JSON.stringify(report)) } })
+}
+
+export const handler = async (event) => {
+  // Not sure whether the case of this is dependent on the client or API Gateway
+  const contentType = event.headers['Content-Type'] || event.headers['content-type']
+
+  if (!['application/csp-report', 'application/json'].includes(contentType)) {
+    return { statusCode: 415 }
+  }
+
+  let json
+
+  try {
+    json = parseBody(event.body)
+  } catch {
+    return { statusCode: 400 }
+  }
+
+  // These identity variables are present if API Gateway proxies to this
+  const report = buildReport(json, event.requestContext?.identity?.sourceIp, event.requestContext?.identity?.userAgent)
+
+  // if we have no data lets not bother sending
+  if (!report.blocked_uri) {
+    return { statusCode: 400 }
+  // TODO: filter out common browser extensions
+  } else {
+    await sendReportToFirehose(report)
+    return { statusCode: 201 }
+  }
+}


### PR DESCRIPTION
Trello: https://trello.com/c/7DukQQ9k/35-finish-off-the-govuk-content-security-policy

This is open as a draft as it will need a wider terraform integration

This is a lambda that is intended to be an endpoint for browsers reporting Content Security Policy violations via the report-uri directive.