### PR TITLE
Filter out commonly reported blocked URIs from CSP reporter

### DIFF
--- a/terraform/lambda/CspReportsToFirehose/index.mjs
+++ b/terraform/lambda/CspReportsToFirehose/index.mjs
@@ -100,7 +100,12 @@ function parseBody (body) {
 
 async function sendReportToFirehose (report) {
   const client = new Firehose()
-  await client.putRecord({ DeliveryStreamName: process.env.FIREHOSE_DELIVERY_STREAM, Record: { Data: Buffer.from(JSON.stringify(report)) } })
+  await client.putRecord({
+    DeliveryStreamName: process.env.FIREHOSE_DELIVERY_STREAM,
+    Record: {
+      Data: Buffer.from(JSON.stringify(report))
+    }
+  })
 }
 
 function filterBlockedUri (uri) {

--- a/terraform/projects/infra-csp-reporter/lambda.tf
+++ b/terraform/projects/infra-csp-reporter/lambda.tf
@@ -9,6 +9,7 @@ resource "aws_lambda_function" "lambda" {
   source_code_hash = data.archive_file.lambda_dist.output_base64sha256
 
   function_name = "CspReportsToFirehose"
+  description   = "Handles Content Security Policy reports, passing valid ones to Kinesis Firehose"
   role          = aws_iam_role.lambda_role.arn
   handler       = "index.handler"
   runtime       = "nodejs18.x"


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

This is to reduce the noise in the Content Security Policy reports. We
get a lot of reports related to things we don't have control over, such
as browser extensions or apps that inject scripts into browsers. A lot
of these are hosting providers for fonts.

This is just an effort to filter out the most prolific of the reports
and does not attempt to remove all non-reports. The theory is that if we
reduce the most common false-positives then an actual positive will be
quite evident from it's volume in comparison to other reports.