### PR TITLE
Stop URL-unsafe characters in auto-generated AmazonMQ passwords

### DIFF
--- a/terraform/projects/app-publishing-amazonmq/main.tf
+++ b/terraform/projects/app-publishing-amazonmq/main.tf
@@ -34,25 +34,32 @@ provider "aws" {
 # Generate passwords for the user accounts
 #
 resource "random_password" "root" {
-  length = 16
+  length  = 24
+  special = false
 }
 resource "random_password" "monitoring" {
-  length = 16
+  length  = 24
+  special = false
 }
 resource "random_password" "publishing_api" {
-  length = 16
+  length  = 24
+  special = false
 }
 resource "random_password" "search_api" {
-  length = 16
+  length  = 24
+  special = false
 }
 resource "random_password" "content_data_api" {
-  length = 16
+  length  = 24
+  special = false
 }
 resource "random_password" "email_alert_service" {
-  length = 16
+  length  = 24
+  special = false
 }
 resource "random_password" "cache_clearing_service" {
-  length = 16
+  length  = 24
+  special = false
 }
 
 locals {


### PR DESCRIPTION
PR #1655 introduced auto-generated passwords for AmazonMQ users. Now that we've tried connecting to the MQ using the `RABBITMQ_URL` format, the default 'special' characters (i.e. non-alphanumeric) cause problems when used in URLs. 

To prevent the need for all client apps to URL-encode the passwords, it's cleaner to just not include special characters in the passwords. I've also upped the length to 24 to compensate for the decreased complexity.