### PR TITLE
Allow GOV.UK's EKS NAT IPs to bypass rate limiting

### DIFF
--- a/terraform/projects/infra-public-wafs/README.md
+++ b/terraform/projects/infra-public-wafs/README.md
@@ -73,6 +73,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_external_ips"></a> [allow\_external\_ips](#input\_allow\_external\_ips) | An array of CIDR blocks that are our partners using to send traffic to us | `list(string)` | n/a | yes |
+| <a name="input_aws_eks_nat_gateway_ips"></a> [aws\_eks\_nat\_gateway\_ips](#input\_aws\_eks\_nat\_gateway\_ips) | An array of CIDR blocks for the corresponding EKS environment's NAT gateway IPs | `list(string)` | n/a | yes |
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_cache_public_base_rate_limit"></a> [cache\_public\_base\_rate\_limit](#input\_cache\_public\_base\_rate\_limit) | Number of requests to allow in a 5 minute period before rate limiting is applied. | `number` | n/a | yes |

--- a/terraform/projects/infra-public-wafs/cache_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/cache_public_rule.tf
@@ -177,7 +177,7 @@ resource "aws_wafv2_ip_set" "govuk_requesting_ips" {
   description        = "The IP addresses used by our infra to make requests that hit the cache LB."
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
-  addresses          = concat(var.traffic_replay_ips, local.nat_gateway_ips)
+  addresses          = concat(var.traffic_replay_ips, local.nat_gateway_ips, var.aws_eks_nat_gateway_ips)
 }
 
 resource "aws_wafv2_ip_set" "external_partner_ips" {

--- a/terraform/projects/infra-public-wafs/variables.tf
+++ b/terraform/projects/infra-public-wafs/variables.tf
@@ -55,6 +55,11 @@ variable "traffic_replay_ips" {
   description = "An array of CIDR blocks that will replay traffic against an environment"
 }
 
+variable "aws_eks_nat_gateway_ips" {
+  type        = list(string)
+  description = "An array of CIDR blocks for the corresponding EKS environment's NAT gateway IPs"
+}
+
 variable "allow_external_ips" {
   type        = list(string)
   description = "An array of CIDR blocks that are our partners using to send traffic to us"


### PR DESCRIPTION
We already allow this for the EC2 environments' NAT Gateway IPs. This allows the replatformed environment to behave in the same way.