### PR TITLE
Apply rate limit

### DIFF
--- a/terraform/projects/infra-public-wafs/README.md
+++ b/terraform/projects/infra-public-wafs/README.md
@@ -77,6 +77,7 @@ No modules.
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_cache_public_base_rate_limit"></a> [cache\_public\_base\_rate\_limit](#input\_cache\_public\_base\_rate\_limit) | Number of requests to allow in a 5 minute period before rate limiting is applied. | `number` | n/a | yes |
+| <a name="input_cache_public_base_rate_warning"></a> [cache\_public\_base\_rate\_warning](#input\_cache\_public\_base\_rate\_warning) | Allows us to configure a warning level to detect what happens if we reduce the limit. | `number` | n/a | yes |
 | <a name="input_fastly_rate_limit_token"></a> [fastly\_rate\_limit\_token](#input\_fastly\_rate\_limit\_token) | Token used by the CDN to skip rate limiting | `string` | `""` | no |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | <a name="input_remote_state_infra_database_backups_bucket_key_stack"></a> [remote\_state\_infra\_database\_backups\_bucket\_key\_stack](#input\_remote\_state\_infra\_database\_backups\_bucket\_key\_stack) | Override path to infra\_database\_backups\_bucket remote state | `string` | `""` | no |

--- a/terraform/projects/infra-public-wafs/cache_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/cache_public_rule.tf
@@ -120,6 +120,38 @@ resource "aws_wafv2_web_acl" "cache_public" {
     }
   }
 
+  # This rule is intended for monitoring only
+  # set a base rate limit per IP looking back over the last 5 minutes
+  # this is checked every 30s
+  rule {
+    name     = "cache-public-base-rate-warning"
+    priority = 9
+
+    action {
+      count {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.cache_public_base_rate_warning
+        aggregate_key_type = "FORWARDED_IP"
+
+        forwarded_ip_config {
+          # We expect all requests to have this header set. As we're counting,
+          #it's a good chance to verify that by matching any that don't
+          fallback_behavior = "MATCH"
+          header_name       = "true-client-ip"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "cache-public-base-rate-warning"
+      sampled_requests_enabled   = true
+    }
+  }
+
   # set a base rate limit per IP looking back over the last 5 minutes
   # this is checked every 30s
   rule {

--- a/terraform/projects/infra-public-wafs/cache_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/cache_public_rule.tf
@@ -172,6 +172,8 @@ resource "aws_wafv2_web_acl" "cache_public" {
             name  = "Cache-Control"
             value = "max-age=0, private"
           }
+
+          custom_response_body_key = "cache-public-rule-429"
         }
       }
     }
@@ -195,6 +197,31 @@ resource "aws_wafv2_web_acl" "cache_public" {
       metric_name                = "cache-public-base-rate-limit"
       sampled_requests_enabled   = true
     }
+  }
+
+  custom_response_body {
+    key     = "cache-public-rule-429"
+    content = <<HTML
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>Sorry, there have been too many attempts to access this page.</p>
+          <p>Try again in a few minutes.</p>
+        </body>
+      </html>
+      HTML
+
+    content_type = "TEXT_HTML"
   }
 
   visibility_config {

--- a/terraform/projects/infra-public-wafs/cache_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/cache_public_rule.tf
@@ -159,7 +159,21 @@ resource "aws_wafv2_web_acl" "cache_public" {
     priority = 10
 
     action {
-      count {}
+      block {
+        custom_response {
+          response_code = 429
+
+          response_header {
+            name  = "Retry-After"
+            value = 30
+          }
+
+          response_header {
+            name  = "Cache-Control"
+            value = "max-age=0, private"
+          }
+        }
+      }
     }
 
     statement {

--- a/terraform/projects/infra-public-wafs/variables.tf
+++ b/terraform/projects/infra-public-wafs/variables.tf
@@ -45,6 +45,11 @@ variable "fastly_rate_limit_token" {
   default     = ""
 }
 
+variable "cache_public_base_rate_warning" {
+  type        = number
+  description = "Allows us to configure a warning level to detect what happens if we reduce the limit."
+}
+
 variable "cache_public_base_rate_limit" {
   type        = number
   description = "Number of requests to allow in a 5 minute period before rate limiting is applied."


### PR DESCRIPTION
There are three steps to this:
- add a count only rate limit to allow us to monitor what happens at lower rate limits prior to reducing the blocking limit
- configure the existing rate limit to `block` instead of count and return 429, Cache-Control and Retry-After headers
- add a basic HTML response telling people what has happened should they fall foul of this limit

In future we may wish to do something better with the error page, such as writing VCL to retrieve a rendered one from S3, but I think this is OK for now. Based on the history of the limit we have set to `count` at present, it's only robots that will be affected.

https://trello.com/c/1B7DgFvt/3038-add-custom-response-headers-for-the-cache-public-waf