### PR TITLE
Make our amazonmq exchanges durable

### DIFF
--- a/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
+++ b/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
@@ -230,7 +230,7 @@
       "name": "published_documents",
       "vhost": "publishing",
       "type": "topic",
-      "durable": false,
+      "durable": true,
       "auto_delete": false,
       "internal": false,
       "arguments": {}
@@ -239,7 +239,7 @@
       "name": "content_data_api_dlx",
       "vhost": "publishing",
       "type": "topic",
-      "durable": false,
+      "durable": true,
       "auto_delete": false,
       "internal": false,
       "arguments": {}


### PR DESCRIPTION
The exchanges auto-created on the AmazonMQ broker are not durable by default. This means if any of the underlying EC2 instances or the RabbitMQ processes running on them are restarted, the exchange will disappear.

This PR adds the `durable: true` flag to the exchange definitions.  