### PR TITLE
Use variables for RabbitMQ auto-scaling group sizes

### DIFF
--- a/terraform/projects/app-rabbitmq/README.md
+++ b/terraform/projects/app-rabbitmq/README.md
@@ -48,6 +48,9 @@ Rabbitmq cluster
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_asg_desired_capacity"></a> [asg\_desired\_capacity](#input\_asg\_desired\_capacity) | Desired number of EC2 instances in the auto-scaling group | `string` | `"3"` | no |
+| <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | Maximum number of EC2 instances in the auto-scaling group | `string` | `"3"` | no |
+| <a name="input_asg_min_size"></a> [asg\_min\_size](#input\_asg\_min\_size) | Minimum number of EC2 instances in the auto-scaling group | `string` | `"3"` | no |
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_esm_trusty_token"></a> [esm\_trusty\_token](#input\_esm\_trusty\_token) | n/a | `string` | n/a | yes |

--- a/terraform/projects/app-rabbitmq/main.tf
+++ b/terraform/projects/app-rabbitmq/main.tf
@@ -83,6 +83,24 @@ variable "rabbitmq_3_ip" {
   description = "IP address of the private IP to assign to the instance"
 }
 
+variable "asg_min_size" {
+  default     = "3"
+  type        = "string"
+  description = "Minimum number of EC2 instances in the auto-scaling group"
+}
+
+variable "asg_max_size" {
+  default     = "3"
+  type        = "string"
+  description = "Maximum number of EC2 instances in the auto-scaling group"
+}
+
+variable "asg_desired_capacity" {
+  default     = "3"
+  type        = "string"
+  description = "Desired number of EC2 instances in the auto-scaling group"
+}
+
 # Resources
 # --------------------------------------------------------------
 terraform {
@@ -160,9 +178,9 @@ module "rabbitmq" {
   instance_elb_ids              = ["${aws_elb.rabbitmq_elb.id}"]
   instance_ami_filter_name      = "${var.instance_ami_filter_name}"
   root_block_device_volume_size = "20"
-  asg_max_size                  = "3"
-  asg_min_size                  = "3"
-  asg_desired_capacity          = "3"
+  asg_max_size                  = "${var.asg_max_size}"
+  asg_min_size                  = "${var.asg_min_size}"
+  asg_desired_capacity          = "${var.asg_desired_capacity}"
   asg_notification_topic_arn    = "${data.terraform_remote_state.infra_monitoring.sns_topic_autoscaling_group_events_arn}"
 }
 


### PR DESCRIPTION
Part of the [Trial AmazonMQ deployment process on integration](https://trello.com/c/oqsXryjz/389-update-monitoring-alerting-from-rabbitmq-amazonmq) epic. 

Nothing is publishing to or consuming from the self-hosted RabbitMQ on integration, we've [repointed all apps over to AmazonMQ](https://github.com/alphagov/govuk-puppet/pull/11930) now. However, the RabbitMQ instances are now (rightly) triggering Icinga alerts because they have no consumers connected, and other related alerts.

This PR updates the RabbitMQ auto-scaling group definition to use parameters for min, max, and desired size,, which are defined in [this govuk-aws-data PR](https://github.com/alphagov/govuk-aws-data/pull/1141)  to be 0 on integration only, and 3 everywhere else.  

We've tested (by deploying & applying this branch on integration) that this gets rid of almost all of the remaining alerts
  