### PR TITLE
Include original policy in CSP logged data

### DIFF
--- a/terraform/lambda/CspReportsToFirehose/index.mjs
+++ b/terraform/lambda/CspReportsToFirehose/index.mjs
@@ -63,6 +63,7 @@ function buildReport (json, sourceIp, userAgent) {
     sample: normaliseInputString(cspReport['script-sample']),
     line_number: normaliseInteger(cspReport['line-number']),
     status_code: normaliseInteger(cspReport['status-code']),
+    original_policy: normaliseInputString(cspReport['original-policy']),
     source_ip: normaliseInputString(sourceIp),
     user_agent: normaliseInputString(userAgent)
   }

--- a/terraform/projects/infra-csp-reporter/glue.tf
+++ b/terraform/projects/infra-csp-reporter/glue.tf
@@ -68,6 +68,16 @@ resource "aws_glue_crawler" "csp_reports" {
   }
 
   schema_change_policy {
+    # This delete action performs two actions, one welcome and one not so
+    # welcome. The welcome one is that this deletes past partitions of data
+    # once data is removed from S3. The unwelcome action is that it will delete
+    # the table from AWS Glue if there is no data in the bucket - this is a
+    # risk in environments with low levels of reports such as integration
+    # and staging. If the table is deleted Kinesis can't write new data as
+    # it needs to read the table schema.
+    #
+    # Should this be a problem, we may want to change this to log or deprecate,
+    # however this will mean old partitions aren't cleaned up.
     delete_behavior = "DELETE_FROM_DATABASE"
     update_behavior = "LOG"
   }

--- a/terraform/projects/infra-csp-reporter/glue.tf
+++ b/terraform/projects/infra-csp-reporter/glue.tf
@@ -101,6 +101,8 @@ resource "aws_glue_catalog_table" "reports" {
     }
 
     // These columns correlate with the CspReportsToFirehose Lambda
+    // If you add a new column, add it to the end otherwise existing data
+    // can end up in the wrong column.
     columns {
       name    = "time"
       type    = "timestamp"
@@ -171,6 +173,12 @@ resource "aws_glue_catalog_table" "reports" {
       name    = "user_agent"
       type    = "string"
       comment = "User agent from the device that requested the resource"
+    }
+
+    columns {
+      name    = "original_policy"
+      type    = "string"
+      comment = "The policy that was in effect when this report was made"
     }
   }
 


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

Note, I've tried this out and it is operational. It is currently applied to integration.

---

The original policy is the CSP policy that is an effect when the
violation occurs. Initially I didn't include this as data stored as I
thought it would effectively be a constant - just the same data in every
report, as our policies have very low variances between URLs.

I've since found out that it seems to be common for ad-blockers to
rewrite policies and thus what might be in effect is not what we've set.
Therefore I actually think it could be valuable to store this
information. It may help with some of the more mysterious reports.

On initial testing I found that adding a column amongst existing columns
caused problems. The terraform plan didn't consider the column new and
instead edited existing columns until adding a new one later in the
process. Worse, when I ran the ran the terraform and queried the database
it showed existing data in the wrong column. Either running a Glue
crawler run didn't help. Therefore I concluded the only safe way to add
a new column is to add it to the end. I'm not sure exactly why this is the
case, as the ORC columnar file format maps columns to field names, so 🤷