### PR TITLE
Update timeout for the analytics lambda functions

### DIFF
--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -964,6 +964,7 @@ resource "aws_lambda_function" "download_logs_analytics" {
   role          = "${aws_iam_role.download_logs_analytics.arn}"
   handler       = "handler.handle_lambda"
   runtime       = "python3.7"
+  timeout       = 120
 
   s3_bucket         = "${aws_s3_bucket.lambda_deployment_packages.id}"
   s3_key            = "${aws_s3_bucket_object.download_logs_analytics_deployment_package.id}"
@@ -998,6 +999,7 @@ resource "aws_lambda_function" "send_public_events_to_ga" {
   role          = "${aws_iam_role.download_logs_analytics.arn}"
   handler       = "send_public_api_events_to_ga.handle_lambda"
   runtime       = "python3.7"
+  timeout       = 10
 
   s3_bucket         = "${aws_s3_bucket.lambda_deployment_packages.id}"
   s3_key            = "${aws_s3_bucket_object.send_public_events_deployment_package.id}"


### PR DESCRIPTION
The default timeout is 3s, but this is not enough to run the functions.
The original ones have 2 min for DownloadLogsAnalytics and 10s for SendPublicAPIEventsToGA.

SendPublicAPIEventsToGA:
<img width="420" alt="Screenshot 2023-01-04 at 15 07 43" src="https://user-images.githubusercontent.com/96050928/210585376-afeb1ce8-09f5-45fc-8827-bc249fc95fe6.png">

DownloadLogsAnalytics:
<img width="304" alt="Screenshot 2023-01-04 at 15 06 12" src="https://user-images.githubusercontent.com/96050928/210585172-30f49bc2-1ef3-4442-bb9e-fedcd12fd06c.png">


Trello card: https://trello.com/c/6hvNCAhx/2957-check-if-govuk-lambda-app-deployment-is-still-needed-and-retire-if-not