### PR TITLE
Update timeout for send-public-events-to-ga lambda

### DIFF
--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -999,7 +999,7 @@ resource "aws_lambda_function" "send_public_events_to_ga" {
   role          = "${aws_iam_role.download_logs_analytics.arn}"
   handler       = "send_public_api_events_to_ga.handle_lambda"
   runtime       = "python3.7"
-  timeout       = 10
+  timeout       = 120
 
   s3_bucket         = "${aws_s3_bucket.lambda_deployment_packages.id}"
   s3_key            = "${aws_s3_bucket_object.send_public_events_deployment_package.id}"


### PR DESCRIPTION
`send-public-events-to-ga` lambda function has a few `Task timed out after 10.08 seconds` errors.

Even though the original `SendPublicAPIEventsToGA`lambda function had 10s set as timeout, this was never seen in practice since the function always failed with other errors.

`DownloadLogsAnalytics` has the timeout set to 2m so we might want the same value for this too.