### PR TITLE
Add an output for the content-publisher bucket ARN.

### DIFF
--- a/terraform/projects/infra-content-publisher/README.md
+++ b/terraform/projects/infra-content-publisher/README.md
@@ -84,6 +84,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_activestorage_s3_bucket_arn"></a> [activestorage\_s3\_bucket\_arn](#output\_activestorage\_s3\_bucket\_arn) | n/a |
 | <a name="output_integration_content_publisher_active_storage_bucket_reader_writer_policy_arn"></a> [integration\_content\_publisher\_active\_storage\_bucket\_reader\_writer\_policy\_arn](#output\_integration\_content\_publisher\_active\_storage\_bucket\_reader\_writer\_policy\_arn) | ARN of the staging content publisher storage bucket reader writer policy |
 | <a name="output_production_content_publisher_active_storage_bucket_reader_policy_arn"></a> [production\_content\_publisher\_active\_storage\_bucket\_reader\_policy\_arn](#output\_production\_content\_publisher\_active\_storage\_bucket\_reader\_policy\_arn) | ARN of the production content publisher storage bucket reader policy |
 | <a name="output_staging_content_publisher_active_storage_bucket_reader_policy_arn"></a> [staging\_content\_publisher\_active\_storage\_bucket\_reader\_policy\_arn](#output\_staging\_content\_publisher\_active\_storage\_bucket\_reader\_policy\_arn) | ARN of the staging content publisher storage bucket reader policy |

--- a/terraform/projects/infra-content-publisher/main.tf
+++ b/terraform/projects/infra-content-publisher/main.tf
@@ -170,3 +170,7 @@ data "template_file" "s3_writer_policy" {
     bucket = "${aws_s3_bucket.activestorage.id}"
   }
 }
+
+output "activestorage_s3_bucket_arn" {
+  value = "${aws_s3_bucket.activestorage.arn}"
+}


### PR DESCRIPTION
Needed for alphagov/govuk-infrastructure#815.

#### Rollout

```sh
tools/build-terraform-project.sh -c refresh \
    -d ../govuk-aws-data/data -s govuk -p infra-content-publisher -e ${ENV?}
```
For each environment. No need need for `apply`.

#### Testing

New output is as expected in integration:

```
activestorage_s3_bucket_arn = arn:aws:s3:::govuk-integration-content-publisher-activestorage
```

Related: https://github.com/alphagov/content-publisher/pull/2705