### PR TITLE
Add a backend specific WAF

### DIFF
--- a/terraform/projects/infra-public-wafs/README.md
+++ b/terraform/projects/infra-public-wafs/README.md
@@ -20,6 +20,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_log_group.public_backend_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.public_cache_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_shield_protection.account_public_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
@@ -41,6 +42,7 @@ No modules.
 | [aws_wafv2_ip_set.nat_gateway_ips](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set) | resource |
 | [aws_wafv2_regex_pattern_set.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_regex_pattern_set) | resource |
 | [aws_wafv2_rule_group.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_rule_group) | resource |
+| [aws_wafv2_web_acl.backend_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [aws_wafv2_web_acl.cache_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [aws_wafv2_web_acl.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [aws_wafv2_web_acl_association.account_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
@@ -59,6 +61,7 @@ No modules.
 | [aws_wafv2_web_acl_association.sidekiq_monitoring_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_association.whitehall_backend_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_logging_configuration.default_web_acl_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
+| [aws_wafv2_web_acl_logging_configuration.public_backend_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [aws_wafv2_web_acl_logging_configuration.public_cache_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [terraform_remote_state.infra_database_backups_bucket](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_monitoring](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -76,8 +79,10 @@ No modules.
 | <a name="input_aws_eks_nat_gateway_ips"></a> [aws\_eks\_nat\_gateway\_ips](#input\_aws\_eks\_nat\_gateway\_ips) | An array of CIDR blocks for the corresponding EKS environment's NAT gateway IPs | `list(string)` | n/a | yes |
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
-| <a name="input_cache_public_base_rate_limit"></a> [cache\_public\_base\_rate\_limit](#input\_cache\_public\_base\_rate\_limit) | Number of requests to allow in a 5 minute period before rate limiting is applied. | `number` | n/a | yes |
-| <a name="input_cache_public_base_rate_warning"></a> [cache\_public\_base\_rate\_warning](#input\_cache\_public\_base\_rate\_warning) | Allows us to configure a warning level to detect what happens if we reduce the limit. | `number` | n/a | yes |
+| <a name="input_backend_public_base_rate_limit"></a> [backend\_public\_base\_rate\_limit](#input\_backend\_public\_base\_rate\_limit) | For the backend ALB. Number of requests to allow in a 5 minute period before rate limiting is applied. | `number` | n/a | yes |
+| <a name="input_backend_public_base_rate_warning"></a> [backend\_public\_base\_rate\_warning](#input\_backend\_public\_base\_rate\_warning) | For the backend ALB. Allows us to configure a warning level to detect what happens if we reduce the limit. | `number` | n/a | yes |
+| <a name="input_cache_public_base_rate_limit"></a> [cache\_public\_base\_rate\_limit](#input\_cache\_public\_base\_rate\_limit) | For the cache ALB. Number of requests to allow in a 5 minute period before rate limiting is applied. | `number` | n/a | yes |
+| <a name="input_cache_public_base_rate_warning"></a> [cache\_public\_base\_rate\_warning](#input\_cache\_public\_base\_rate\_warning) | For the cache ALB. Allows us to configure a warning level to detect what happens if we reduce the limit. | `number` | n/a | yes |
 | <a name="input_fastly_rate_limit_token"></a> [fastly\_rate\_limit\_token](#input\_fastly\_rate\_limit\_token) | Token used by the CDN to skip rate limiting | `string` | `""` | no |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | <a name="input_remote_state_infra_database_backups_bucket_key_stack"></a> [remote\_state\_infra\_database\_backups\_bucket\_key\_stack](#input\_remote\_state\_infra\_database\_backups\_bucket\_key\_stack) | Override path to infra\_database\_backups\_bucket remote state | `string` | `""` | no |

--- a/terraform/projects/infra-public-wafs/backend_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/backend_public_rule.tf
@@ -1,0 +1,193 @@
+resource "aws_wafv2_web_acl" "backend_public" {
+  name  = "backend_public_web_acl"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  # this rule matches any request that contains the header X-Always-Block: true
+  # we use it as a simple sanity check / acceptance test from smokey to ensure that
+  # the waf is enabled and processing requests
+  rule {
+    name     = "x-always-block_web_acl_rule"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      rule_group_reference_statement {
+        arn = aws_wafv2_rule_group.x_always_block.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "x-always-block-rule-group"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # this rule matches any request from our NAT gateway IPs and allows it.
+  rule {
+    name     = "allow-govuk-infra"
+    priority = 2
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.govuk_requesting_ips.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "govuk-infra-backend-requests"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # This rule is intended for monitoring only
+  # set a base rate limit per IP looking back over the last 5 minutes
+  # this is checked every 30s
+  rule {
+    name     = "backend-public-base-rate-warning"
+    priority = 9
+
+    action {
+      count {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.backend_public_base_rate_warning
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "backend-public-base-rate-warning"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # set a base rate limit per IP looking back over the last 5 minutes
+  # this is checked every 30s
+  rule {
+    name     = "backend-public-base-rate-limit"
+    priority = 10
+
+    action {
+      count {}
+      # TODO: remove the above `count {}` statement and uncomment the below `block { ... }`
+      # statement once we're happy
+      #
+      # block {
+      #   custom_response {
+      #     response_code = 429
+
+      #     response_header {
+      #       name  = "Retry-After"
+      #       value = 30
+      #     }
+
+      #     response_header {
+      #       name  = "Cache-Control"
+      #       value = "max-age=0, private"
+      #     }
+
+      #     custom_response_body_key = "backend-public-rule-429"
+      #   }
+      # }
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.backend_public_base_rate_limit
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "backend-public-base-rate-limit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  custom_response_body {
+    key     = "backend-public-rule-429"
+    content = <<HTML
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>Sorry, there have been too many attempts to access this page.</p>
+          <p>Try again in a few minutes.</p>
+        </body>
+      </html>
+      HTML
+
+    content_type = "TEXT_HTML"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "backend-public-web-acl"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_cloudwatch_log_group" "public_backend_waf" {
+  # the name must start with aws-waf-logs
+  # https://docs.aws.amazon.com/waf/latest/developerguide/logging-cw-logs.html#logging-cw-logs-naming
+  name              = "aws-waf-logs-backend-public-${var.aws_environment}"
+  retention_in_days = var.waf_log_retention_days
+
+  tags = {
+    Project       = var.stackname
+    aws_stackname = var.stackname
+  }
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "public_backend_waf" {
+  log_destination_configs = [aws_cloudwatch_log_group.public_backend_waf.arn]
+  resource_arn            = aws_wafv2_web_acl.backend_public.arn
+
+  logging_filter {
+    default_behavior = "DROP"
+
+    filter {
+      behavior = "KEEP"
+
+      condition {
+        action_condition {
+          action = "COUNT"
+        }
+      }
+
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+
+      requirement = "MEETS_ANY"
+    }
+  }
+}

--- a/terraform/projects/infra-public-wafs/standard_config.tf
+++ b/terraform/projects/infra-public-wafs/standard_config.tf
@@ -16,7 +16,7 @@ resource "aws_shield_protection" "backend_public_lb" {
 
 resource "aws_wafv2_web_acl_association" "backend_public_web_acl" {
   resource_arn = data.terraform_remote_state.infra_public_services.outputs.backend_public_lb_id
-  web_acl_arn  = aws_wafv2_web_acl.default.arn
+  web_acl_arn  = aws_wafv2_web_acl.backend_public.arn
 }
 
 resource "aws_shield_protection" "bouncer_public_lb" {

--- a/terraform/projects/infra-public-wafs/variables.tf
+++ b/terraform/projects/infra-public-wafs/variables.tf
@@ -45,14 +45,24 @@ variable "fastly_rate_limit_token" {
   default     = ""
 }
 
+variable "backend_public_base_rate_warning" {
+  type        = number
+  description = "For the backend ALB. Allows us to configure a warning level to detect what happens if we reduce the limit."
+}
+
+variable "backend_public_base_rate_limit" {
+  type        = number
+  description = "For the backend ALB. Number of requests to allow in a 5 minute period before rate limiting is applied."
+}
+
 variable "cache_public_base_rate_warning" {
   type        = number
-  description = "Allows us to configure a warning level to detect what happens if we reduce the limit."
+  description = "For the cache ALB. Allows us to configure a warning level to detect what happens if we reduce the limit."
 }
 
 variable "cache_public_base_rate_limit" {
   type        = number
-  description = "Number of requests to allow in a 5 minute period before rate limiting is applied."
+  description = "For the cache ALB. Number of requests to allow in a 5 minute period before rate limiting is applied."
 }
 
 variable "traffic_replay_ips" {


### PR DESCRIPTION
This is mostly copied from the cache_public WAF.

We retain the x-always-block rule. This is the easiest way for Smokey to determine that a WAF is applied.

We retain the rule allowing traffic from GOV.UK's infrastructure. Smokey is the heaviest user here.

We do not need to specifically allow Fastly health checks, as they're not running against this resource.

We don't need to allow traffic from an external set of IPs, as we don't have that requirement here yet.

We keep a warning/count rate limit rule.

We'll set the "blocking" rule to count for now while we confirm that the rest works as expected.

For the rules we retain we do not need to parse the True-Client-IP header to identify the IP of the client. We have therefore switched aggregate key types from "FORWARDED_IP" (removing some of the additional configuration that this required) to simply "IP". The different rules have slightly different ways of configuring this:

- [rate based statement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl.html#rate-based-statement)
- [IP set reference statement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl.html#ip-set-reference-statement)