### PR TITLE
Revert "Upgrade nodejs versions"

### DIFF
--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -621,6 +621,6 @@ resource "aws_lambda_function" "url_rewrite" {
   function_name = "url_rewrite"
   role          = "${aws_iam_role.basic_lambda_role.arn}"
   handler       = "index.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs10.x"
   provider      = "aws.aws_cloudfront_certificate"
 }

--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -96,7 +96,7 @@ resource "aws_lambda_function" "aws_waf_log_trimmer" {
   source_code_hash = "${data.archive_file.aws_waf_log_trimmer.output_base64sha256}"
   role             = "${aws_iam_role.aws_waf_log_trimmer.arn}"
   handler          = "lambda.handler"
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs12.x"
   timeout          = 190
 }
 


### PR DESCRIPTION
Reverts alphagov/govuk-aws#1652

See https://github.com/alphagov/govuk-aws/pull/1652#issuecomment-1378923671 - the version of Node is incompatible with the old version of Terraform we have. I've decided to revert so that we have time to address this, rather than live with a broken Terraform project and wait for somebody to fix-forward.

Trello: https://trello.com/c/PMsAXSoT/3029-review-govuks-usage-of-node-2