### PR TITLE
Reference different certificate for Cloudfront Production

### DIFF
--- a/terraform/projects/infra-mirror-bucket/README.md
+++ b/terraform/projects/infra-mirror-bucket/README.md
@@ -14,6 +14,8 @@ The primary bucket should be in London and the backup in Ireland.
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 2.46.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 2.46.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 2.46.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 2.46.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 2.46.0 |
 | <a name="requirement_fastly"></a> [fastly](#requirement\_fastly) | ~> 0.26.0 |
 
 ## Providers
@@ -21,9 +23,11 @@ The primary bucket should be in London and the backup in Ireland.
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 1.3 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 2.46.0 2.46.0 2.46.0 |
-| <a name="provider_aws.aws_cloudfront_certificate"></a> [aws.aws\_cloudfront\_certificate](#provider\_aws.aws\_cloudfront\_certificate) | 2.46.0 2.46.0 2.46.0 |
-| <a name="provider_aws.aws_replica"></a> [aws.aws\_replica](#provider\_aws.aws\_replica) | 2.46.0 2.46.0 2.46.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 2.46.0 2.46.0 2.46.0 2.46.0 2.46.0 |
+| <a name="provider_aws.aws_cloudfront_assets_certificate"></a> [aws.aws\_cloudfront\_assets\_certificate](#provider\_aws.aws\_cloudfront\_assets\_certificate) | 2.46.0 2.46.0 2.46.0 2.46.0 2.46.0 |
+| <a name="provider_aws.aws_cloudfront_certificate"></a> [aws.aws\_cloudfront\_certificate](#provider\_aws.aws\_cloudfront\_certificate) | 2.46.0 2.46.0 2.46.0 2.46.0 2.46.0 |
+| <a name="provider_aws.aws_cloudfront_www_certificate"></a> [aws.aws\_cloudfront\_www\_certificate](#provider\_aws.aws\_cloudfront\_www\_certificate) | 2.46.0 2.46.0 2.46.0 2.46.0 2.46.0 |
+| <a name="provider_aws.aws_replica"></a> [aws.aws\_replica](#provider\_aws.aws\_replica) | 2.46.0 2.46.0 2.46.0 2.46.0 2.46.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | n/a |
 | <a name="provider_fastly"></a> [fastly](#provider\_fastly) | ~> 0.26.0 |
 | <a name="provider_template"></a> [template](#provider\_template) | n/a |
@@ -80,6 +84,8 @@ No modules.
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_integration_account_root_arn"></a> [aws\_integration\_account\_root\_arn](#input\_aws\_integration\_account\_root\_arn) | AWS account root ARN for the Integration account | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region where primary s3 bucket is located | `string` | `"eu-west-2"` | no |
+| <a name="input_aws_region_containing_cloudfront_assets_certificate_domain"></a> [aws\_region\_containing\_cloudfront\_assets\_certificate\_domain](#input\_aws\_region\_containing\_cloudfront\_assets\_certificate\_domain) | The AWS region containing the Assets CloudFront certificate. | `string` | `"eu-west-1"` | no |
+| <a name="input_aws_region_containing_cloudfront_www_certificate_domain"></a> [aws\_region\_containing\_cloudfront\_www\_certificate\_domain](#input\_aws\_region\_containing\_cloudfront\_www\_certificate\_domain) | The AWS region containing the WWW CloudFront certificate. | `string` | `"us-east-1"` | no |
 | <a name="input_aws_replica_region"></a> [aws\_replica\_region](#input\_aws\_replica\_region) | AWS region where replica s3 bucket is located | `string` | `"eu-west-1"` | no |
 | <a name="input_cloudfront_assets_certificate_domain"></a> [cloudfront\_assets\_certificate\_domain](#input\_cloudfront\_assets\_certificate\_domain) | The domain of the Assets CloudFront certificate to look up. | `string` | `""` | no |
 | <a name="input_cloudfront_assets_distribution_aliases"></a> [cloudfront\_assets\_distribution\_aliases](#input\_cloudfront\_assets\_distribution\_aliases) | Extra CNAMEs (alternate domain names), if any, for the Assets CloudFront distribution. | `list` | `[]` | no |

--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -69,6 +69,12 @@ variable "cloudfront_www_distribution_aliases" {
   default     = []
 }
 
+variable "aws_region_containing_cloudfront_www_certificate_domain" {
+  type        = string
+  description = "The AWS region containing the WWW CloudFront certificate."
+  default     = "us-east-1"
+}
+
 variable "cloudfront_www_certificate_domain" {
   type        = string
   description = "The domain of the WWW CloudFront certificate to look up."
@@ -79,6 +85,12 @@ variable "cloudfront_assets_distribution_aliases" {
   type        = list
   description = "Extra CNAMEs (alternate domain names), if any, for the Assets CloudFront distribution."
   default     = []
+}
+
+variable "aws_region_containing_cloudfront_assets_certificate_domain" {
+  type        = string
+  description = "The AWS region containing the Assets CloudFront certificate."
+  default     = "eu-west-1"
 }
 
 variable "cloudfront_assets_certificate_domain" {
@@ -134,6 +146,18 @@ provider "aws" {
 provider "aws" {
   region  = "us-east-1"
   alias   = "aws_cloudfront_certificate"
+  version = "2.46.0"
+}
+
+provider "aws" {
+  region  = var.aws_region_containing_cloudfront_www_certificate_domain
+  alias   = "aws_cloudfront_www_certificate"
+  version = "2.46.0"
+}
+
+provider "aws" {
+  region  = var.aws_region_containing_cloudfront_assets_certificate_domain
+  alias   = "aws_cloudfront_assets_certificate"
   version = "2.46.0"
 }
 
@@ -360,7 +384,7 @@ data "aws_acm_certificate" "www" {
 
   domain   = var.cloudfront_www_certificate_domain
   statuses = ["ISSUED"]
-  provider = aws.aws_cloudfront_certificate
+  provider = aws.aws_cloudfront_www_certificate
 }
 
 data "aws_acm_certificate" "assets" {
@@ -368,7 +392,7 @@ data "aws_acm_certificate" "assets" {
 
   domain   = var.cloudfront_assets_certificate_domain
   statuses = ["ISSUED"]
-  provider = aws.aws_cloudfront_certificate
+  provider = aws.aws_cloudfront_assets_certificate
 }
 
 resource "aws_cloudfront_distribution" "www_distribution" {


### PR DESCRIPTION
The assets Cloudfront distribution was referencing the (expired)
cert in us-east-1, for `*.publishing.service.gov.uk` - which had
been manually created, thus not auto-renewed.
https://us-east-1.console.aws.amazon.com/acm/home?region=us-east-1#/certificates/108d0f34-cf9f-4e04-81a2-231e42824b08

Instead we should be using the certificate that's created and
managed in Amazon Certificate Manager (ACM), in the eu-west-1
region:
https://eu-west-1.console.aws.amazon.com/acm/home?region=eu-west-1#/certificates/063a18cc-d4bf-4eaf-b1c1-41e86bbdd69d

That cert covers a number of domains, including the necessary
`*.publishing.service.gov.uk`.

However, we can't simply change the [aws_cloudfront_certificate](https://github.com/alphagov/govuk-aws/blob/18f25c90e6f14208ada49a452d8e726e069ffb71/terraform/projects/infra-mirror-bucket/main.tf#L146)
from us-east-1 to eu-west-2, as we still need the _www_ Cloudfront
distribution to work, and _that_ certificate is in us-east-1!

Therefore we've had to create multiple variables, to support
the multiple AWS regions where our certificates live. NB: the
default values have been applied so that the `plan` continues to
work on Integration & Staging.

Fixing the certificate configs will allow us to apply the changes
from #1691 to Production.

Successful plan on production: https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4756/console
Successful plan on integration:
https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4758/console

Trello: https://trello.com/c/PMsAXSoT/3029-review-govuks-usage-of-node-2