### PR TITLE
Add warning messages if branches used are not main

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -44,6 +44,18 @@ if [[ "$GOVUK_AWS_DATA_BRANCH" == "" ]]; then
   GOVUK_AWS_DATA_BRANCH="main"
 fi
 
+if [[ $COMMAND == "plan" && $GOVUK_AWS_BRANCH != "main" ]]; then
+echo -e "\e[31m===============================================================\e[0m"
+echo -e "\e[31mWARNING: you have run a 'plan' of a branch of govuk-aws that may be a number of commits behind 'main'.\nApplying this branch may lead to unintended infrastructural changes.\nYou should rebase your branch before proceeding.\e[0m"
+echo -e "\e[31m===============================================================\e[0m"
+fi
+
+if [[ $COMMAND == "plan" && $GOVUK_AWS_DATA_BRANCH != "main" ]]; then
+echo -e "\e[31m===============================================================\e[0m"
+echo -e "\e[31mWARNING: you have run a 'plan' of a branch of govuk-aws-data that may be a number of commits behind 'main'.\nApplying this branch may lead to unintended infrastructural changes.\nYou should rebase your branch before proceeding.\e[0m"
+echo -e "\e[31m===============================================================\e[0m"
+fi
+
 echo "Cloning govuk-aws-data $GOVUK_AWS_DATA_BRANCH"
 git clone --single-branch --branch "$GOVUK_AWS_DATA_BRANCH" git@github.com:alphagov/govuk-aws-data.git
 
@@ -52,7 +64,7 @@ case $COMMAND in
   'plan (destroy)') COMMAND='plan'; EXTRA='-detailed-exitcode -destroy';;
   # This flag must be -auto-approve for terraform v1.0+
   # TODO: either also support -force for terraform v0.x, or update remaining
-  #       projects that require terraform v0.x 
+  #       projects that require terraform v0.x
   'destroy') EXTRA='-auto-approve';;
   'plan') EXTRA='-detailed-exitcode';;
 esac


### PR DESCRIPTION
There has been some previous instances where developers have run `apply` using a branch that has a significant number of commits behind `main`.

Adding a warning message in the console output of the `plan` job should hopefully avoid confusion and potential incident due to being out of sync with `main`.

Co-authored-by: Catalina Ilie <catalina.ilie@digital.cabinet-office.gov.uk>

Example [console output](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4905/console)

![Screenshot 2023-01-26 at 16 33 49](https://user-images.githubusercontent.com/19667619/214893715-c5972591-d364-4d41-87f4-9eb5d7bebddd.png)

Trello card: https://trello.com/c/Po3ln1BC/3041-make-deploy-terraform-warn-when-ran-against-outdated-branch-3