### PR TITLE
Fix potential out-of-sequence AmazonMQ lambda invocation loophole

### DIFF
--- a/terraform/projects/app-publishing-amazonmq/main.tf
+++ b/terraform/projects/app-publishing-amazonmq/main.tf
@@ -329,7 +329,7 @@ resource "aws_route53_record" "publishing_amazonmq_internal_root_domain_name" {
 #
 # Write the decrypted definitions from govuk-aws-data to a local file
 resource "local_sensitive_file" "amazonmq_rabbitmq_definitions" {
-  filename = "/tmp/amazonmq_rabbitmq_definitions.json"
+  filename = join(".", ["/tmp/amazonmq_rabbitmq_definitions", formatdate("YYYY-MM-DD-hhmm-ZZZ", timestamp()), "json"])
   content = templatefile("${path.cwd}/publishing-rabbitmq-schema.json.tpl", {
     publishing_amazonmq_passwords   = local.publishing_amazonmq_passwords
     publishing_amazonmq_broker_name = var.publishing_amazonmq_broker_name
@@ -337,7 +337,11 @@ resource "local_sensitive_file" "amazonmq_rabbitmq_definitions" {
 }
 
 data "local_sensitive_file" "amazonmq_rabbitmq_definitions_interpolated" {
-  filename = "/tmp/amazonmq_rabbitmq_definitions.json"
+  filename = local_sensitive_file.amazonmq_rabbitmq_definitions.filename
+
+  depends_on = [
+    local_sensitive_file.amazonmq_rabbitmq_definitions
+  ]
 }
 
 


### PR DESCRIPTION
After [creating the AmazonMQ cluster on staging](https://trello.com/c/kdOCXjeM/437-create-amazonmq-ha-cluster-nlb-with-custom-domain-in-staging) as part of the [AmazonMQ migration process](https://trello.com/c/8a87xtft/428-run-amazonmq-migration-process-on-staging), we found that the passwords as listed in `terraform output` did not work when we tried to repoint the applications.

While [investigating](https://trello.com/c/zIYm3eUX/454-find-out-why-all-non-root-user-credentials-for-amazonmq-did-not-work-in-staging-when-deployed), we destroyed the stack and recreated it, to try and replicate the issue - the create [failed](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4953/console)  with an error 
`│ Error: open /tmp/amazonmq_rabbitmq_definitions.json: no such file or directory` 
on reading the interpolated JSON file.

This implies that terraform is trying to read the `data` reference to the file before it's been created in the `local_sensitive_file` reference. This is not _wrong_ - terraform is a declarative rather than procedural language, which will execute as much as possible in parallel and eventually coalesce towards the desired state - but there's a loophole there that we didn't anticipate,  which could have caused this problem.

If the following sequence occurs -

1. Terraform `create` generates passwords and interpolates them into JSON in `/tmp/amazonmq_rabbitmq_definitions.json`
2. Terraform `destroy` destroys the broker
3. Terraform `create` runs again on the same EC2 instance without a reboot inbetween
4. On this run, it attempts to read `/tmp/amazonmq_rabbitmq_definitions.json` and finds the file generated by the previous run 
5. It sees the file exists, and posts it to the broker before the new passwords are written to that file

.. then that's a mechanism by which old passwords could be POSTed to the new broker. 

This PR fixes this loophole by:

* Adding an explicit depends_on to the JSON data file, to make sure it's not read before the new content is written
* Adding a timestamp to the JSON filename, to prevent any possibility of unintentionally posting JSON leftover from a previous run


Tested with [this run on staging](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4957/console) and then [re-creating the broker](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/4959/console) - the new credentials worked first time for all usernames.