### PR TITLE
Enable backend WAF

### DIFF
--- a/terraform/projects/infra-public-wafs/backend_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/backend_public_rule.tf
@@ -84,27 +84,23 @@ resource "aws_wafv2_web_acl" "backend_public" {
     priority = 10
 
     action {
-      count {}
-      # TODO: remove the above `count {}` statement and uncomment the below `block { ... }`
-      # statement once we're happy
-      #
-      # block {
-      #   custom_response {
-      #     response_code = 429
+      block {
+        custom_response {
+          response_code = 429
 
-      #     response_header {
-      #       name  = "Retry-After"
-      #       value = 30
-      #     }
+          response_header {
+            name  = "Retry-After"
+            value = 30
+          }
 
-      #     response_header {
-      #       name  = "Cache-Control"
-      #       value = "max-age=0, private"
-      #     }
+          response_header {
+            name  = "Cache-Control"
+            value = "max-age=0, private"
+          }
 
-      #     custom_response_body_key = "backend-public-rule-429"
-      #   }
-      # }
+          custom_response_body_key = "backend-public-rule-429"
+        }
+      }
     }
 
     statement {


### PR DESCRIPTION
This puts the WAF into blocking mode so that requests to apps behind the govuk_backend_public ALB will have a rate limit applied.

The limits are applied here: https://github.com/alphagov/govuk-aws-data/blob/2120cc8ff00012acc30123fb28bba883ca976f6c/data/infra-public-wafs/production/common.tfvars#L2 and are for the preceding 5 minutes, measured every 30 seconds.

https://trello.com/c/DQkJXVPJ/2810-set-backend-waf-rate-limit-rule-into-blocking-mode