### PR TITLE
Add production backend for app-publishing-amazonmq

### DIFF
--- a/terraform/projects/app-publishing-amazonmq/production.blue.backend
+++ b/terraform/projects/app-publishing-amazonmq/production.blue.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-steppingstone-production"
+key     = "blue/app-publishing-amazonmq.tfstate"
+encrypt = true
+region  = "eu-west-1"


### PR DESCRIPTION
Needed in order to [create AmazonMQ cluster in production](https://trello.com/c/RKnTTZv6/460-create-amazonmq-ha-cluster-nlb-with-custom-domain-in-production) as part of [running the AmazonMQ migration process in production](https://trello.com/c/to4fHvoa/458-run-amazonmq-migration-process-on-production) 