### PR TITLE
Add rate monitoring WAF for Bouncer

### DIFF
--- a/terraform/projects/infra-public-wafs/README.md
+++ b/terraform/projects/infra-public-wafs/README.md
@@ -21,6 +21,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_group.public_backend_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.public_bouncer_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.public_cache_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_shield_protection.account_public_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.backend_public_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
@@ -43,6 +44,7 @@ No modules.
 | [aws_wafv2_regex_pattern_set.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_regex_pattern_set) | resource |
 | [aws_wafv2_rule_group.x_always_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_rule_group) | resource |
 | [aws_wafv2_web_acl.backend_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
+| [aws_wafv2_web_acl.bouncer_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [aws_wafv2_web_acl.cache_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [aws_wafv2_web_acl.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [aws_wafv2_web_acl_association.account_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
@@ -62,6 +64,7 @@ No modules.
 | [aws_wafv2_web_acl_association.whitehall_backend_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_logging_configuration.default_web_acl_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [aws_wafv2_web_acl_logging_configuration.public_backend_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
+| [aws_wafv2_web_acl_logging_configuration.public_bouncer_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [aws_wafv2_web_acl_logging_configuration.public_cache_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [terraform_remote_state.infra_database_backups_bucket](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_monitoring](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -81,6 +84,7 @@ No modules.
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_backend_public_base_rate_limit"></a> [backend\_public\_base\_rate\_limit](#input\_backend\_public\_base\_rate\_limit) | For the backend ALB. Number of requests to allow in a 5 minute period before rate limiting is applied. | `number` | n/a | yes |
 | <a name="input_backend_public_base_rate_warning"></a> [backend\_public\_base\_rate\_warning](#input\_backend\_public\_base\_rate\_warning) | For the backend ALB. Allows us to configure a warning level to detect what happens if we reduce the limit. | `number` | n/a | yes |
+| <a name="input_bouncer_public_base_rate_warning"></a> [bouncer\_public\_base\_rate\_warning](#input\_bouncer\_public\_base\_rate\_warning) | For the bouncer ALB. Allows us to configure a warning level to detect what happens if we reduce the limit. | `number` | n/a | yes |
 | <a name="input_cache_public_base_rate_limit"></a> [cache\_public\_base\_rate\_limit](#input\_cache\_public\_base\_rate\_limit) | For the cache ALB. Number of requests to allow in a 5 minute period before rate limiting is applied. | `number` | n/a | yes |
 | <a name="input_cache_public_base_rate_warning"></a> [cache\_public\_base\_rate\_warning](#input\_cache\_public\_base\_rate\_warning) | For the cache ALB. Allows us to configure a warning level to detect what happens if we reduce the limit. | `number` | n/a | yes |
 | <a name="input_fastly_rate_limit_token"></a> [fastly\_rate\_limit\_token](#input\_fastly\_rate\_limit\_token) | Token used by the CDN to skip rate limiting | `string` | `""` | no |

--- a/terraform/projects/infra-public-wafs/bouncer_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/bouncer_public_rule.tf
@@ -1,0 +1,109 @@
+resource "aws_wafv2_web_acl" "bouncer_public" {
+  name  = "bouncer_public_web_acl"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  # this rule matches any request that contains the header X-Always-Block: true
+  # we use it as a simple sanity check / acceptance test from smokey to ensure that
+  # the waf is enabled and processing requests
+  rule {
+    name     = "x-always-block_web_acl_rule"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      rule_group_reference_statement {
+        arn = aws_wafv2_rule_group.x_always_block.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "x-always-block-rule-group"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # This rule is intended for monitoring only
+  # set a base rate limit per IP looking back over the last 5 minutes
+  # this is checked every 30s
+  rule {
+    name     = "bouncer-public-base-rate-warning"
+    priority = 9
+
+    action {
+      count {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.bouncer_public_base_rate_warning
+        aggregate_key_type = "FORWARDED_IP"
+
+        forwarded_ip_config {
+          # We expect all requests to have this header set. As we're counting,
+          #it's a good chance to verify that by matching any that don't
+          fallback_behavior = "MATCH"
+          header_name       = "true-client-ip"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "bouncer-public-base-rate-warning"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "bouncer-public-web-acl"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_cloudwatch_log_group" "public_bouncer_waf" {
+  # the name must start with aws-waf-logs
+  # https://docs.aws.amazon.com/waf/latest/developerguide/logging-cw-logs.html#logging-cw-logs-naming
+  name              = "aws-waf-logs-bouncer-public-${var.aws_environment}"
+  retention_in_days = var.waf_log_retention_days
+
+  tags = {
+    Project       = var.stackname
+    aws_stackname = var.stackname
+  }
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "public_bouncer_waf" {
+  log_destination_configs = [aws_cloudwatch_log_group.public_bouncer_waf.arn]
+  resource_arn            = aws_wafv2_web_acl.bouncer_public.arn
+
+  logging_filter {
+    default_behavior = "DROP"
+
+    filter {
+      behavior = "KEEP"
+
+      condition {
+        action_condition {
+          action = "COUNT"
+        }
+      }
+
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+
+      requirement = "MEETS_ANY"
+    }
+  }
+}

--- a/terraform/projects/infra-public-wafs/standard_config.tf
+++ b/terraform/projects/infra-public-wafs/standard_config.tf
@@ -26,7 +26,7 @@ resource "aws_shield_protection" "bouncer_public_lb" {
 
 resource "aws_wafv2_web_acl_association" "bouncer_public_web_acl" {
   resource_arn = data.terraform_remote_state.infra_public_services.outputs.bouncer_public_lb_id
-  web_acl_arn  = aws_wafv2_web_acl.default.arn
+  web_acl_arn  = aws_wafv2_web_acl.bouncer_public.arn
 }
 
 resource "aws_wafv2_web_acl_association" "cache_public_web_acl" {

--- a/terraform/projects/infra-public-wafs/variables.tf
+++ b/terraform/projects/infra-public-wafs/variables.tf
@@ -55,6 +55,11 @@ variable "backend_public_base_rate_limit" {
   description = "For the backend ALB. Number of requests to allow in a 5 minute period before rate limiting is applied."
 }
 
+variable "bouncer_public_base_rate_warning" {
+  type        = number
+  description = "For the bouncer ALB. Allows us to configure a warning level to detect what happens if we reduce the limit."
+}
+
 variable "cache_public_base_rate_warning" {
   type        = number
   description = "For the cache ALB. Allows us to configure a warning level to detect what happens if we reduce the limit."


### PR DESCRIPTION
Bouncer lives behind a CDN, so this WAF is of a similar style to the [cache WAF](https://github.com/alphagov/govuk-aws/blob/main/terraform/projects/infra-public-wafs/cache_public_rule.tf) in the way it determines the original IP address.

It's stripped back to begin with so it only has the default x-always-block rule and a rule to count breaches of the rate limit.

This helps us determine whether we need to add any other rules to effectively manage legitimate traffic.

https://trello.com/c/z65OXqJ1/2845-bouncer-rate-limit-waf