### PR TITLE
Fix array list for account access

### DIFF
--- a/terraform/projects/infra-database-backups-bucket/bucket_policy.tf
+++ b/terraform/projects/infra-database-backups-bucket/bucket_policy.tf
@@ -18,9 +18,7 @@ data "aws_iam_policy_document" "database_backups_cross_account_access" {
     principals = {
       type = "AWS"
 
-      identifiers = [
-        "${var.database_backups_access_list}",
-      ]
+      identifiers = "${var.database_backups_access_list}"
     }
 
     actions = ["s3:Get*", "s3:List*"]


### PR DESCRIPTION
- The access list is an array, therefore, creating a list from the identifiers will cause an array inside an array. This will fix this behaviour