### PR TITLE
Add EKS egress addresses to IP ACLs.

### DIFF
--- a/terraform/projects/infra-mirror-bucket/README.md
+++ b/terraform/projects/infra-mirror-bucket/README.md
@@ -84,6 +84,7 @@ No modules.
 | <a name="input_cloudfront_enable"></a> [cloudfront\_enable](#input\_cloudfront\_enable) | Enable Cloudfront distributions. | `bool` | `false` | no |
 | <a name="input_cloudfront_www_certificate_domain"></a> [cloudfront\_www\_certificate\_domain](#input\_cloudfront\_www\_certificate\_domain) | The domain of the WWW CloudFront certificate to look up. | `string` | `""` | no |
 | <a name="input_cloudfront_www_distribution_aliases"></a> [cloudfront\_www\_distribution\_aliases](#input\_cloudfront\_www\_distribution\_aliases) | Extra CNAMEs (alternate domain names), if any, for the WWW CloudFront distribution. | `list` | `[]` | no |
+| <a name="input_eks_egress_ips"></a> [eks\_egress\_ips](#input\_eks\_egress\_ips) | Egress addresses for the corresponding EKS environment, in CIDR notation. | `list(string)` | n/a | yes |
 | <a name="input_lifecycle_government_uploads"></a> [lifecycle\_government\_uploads](#input\_lifecycle\_government\_uploads) | Number of days for the lifecycle rule for the mirror in the case where the prefix path is www.gov.uk/government/uploads/ | `string` | `"8"` | no |
 | <a name="input_lifecycle_main"></a> [lifecycle\_main](#input\_lifecycle\_main) | Number of days for the lifecycle rule for the mirror | `string` | `"5"` | no |
 | <a name="input_notify_cloudfront_domain"></a> [notify\_cloudfront\_domain](#input\_notify\_cloudfront\_domain) | The domain of the Notify CloudFront to proxy /alerts requests to. | `string` | `""` | no |

--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -52,6 +52,11 @@ variable "office_ips" {
   description = "An array of CIDR blocks that will be allowed offsite access."
 }
 
+variable "eks_egress_ips" {
+  type        = list(string)
+  description = "Egress addresses for the corresponding EKS environment, in CIDR notation."
+}
+
 variable "cloudfront_create" {
   description = "Create Cloudfront resources."
   type        = bool

--- a/terraform/projects/infra-mirror-bucket/mirror-read-policy.tf
+++ b/terraform/projects/infra-mirror-bucket/mirror-read-policy.tf
@@ -8,6 +8,13 @@ variable "aws_integration_account_root_arn" {
   description = "AWS account root ARN for the Integration account"
 }
 
+locals {
+  egress_ips = concat(
+    var.eks_egress_ips,
+    data.terraform_remote_state.infra_networking.outputs.nat_gateway_elastic_ips_list,
+  )
+}
+
 data "fastly_ip_ranges" "fastly" {}
 
 data "external" "pingdom" {
@@ -90,7 +97,7 @@ data "aws_iam_policy_document" "s3_mirror_read_policy_doc" {
     condition {
       test     = "IpAddress"
       variable = "aws:SourceIp"
-      values   = data.terraform_remote_state.infra_networking.outputs.nat_gateway_elastic_ips_list
+      values   = local.egress_ips
     }
 
     principals {
@@ -216,7 +223,7 @@ data "aws_iam_policy_document" "s3_mirror_replica_read_policy_doc" {
     condition {
       test     = "IpAddress"
       variable = "aws:SourceIp"
-      values   = data.terraform_remote_state.infra_networking.outputs.nat_gateway_elastic_ips_list
+      values   = local.egress_ips
     }
 
     principals {

--- a/terraform/projects/infra-public-wafs/README.md
+++ b/terraform/projects/infra-public-wafs/README.md
@@ -79,7 +79,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_external_ips"></a> [allow\_external\_ips](#input\_allow\_external\_ips) | An array of CIDR blocks that are our partners using to send traffic to us | `list(string)` | n/a | yes |
-| <a name="input_aws_eks_nat_gateway_ips"></a> [aws\_eks\_nat\_gateway\_ips](#input\_aws\_eks\_nat\_gateway\_ips) | An array of CIDR blocks for the corresponding EKS environment's NAT gateway IPs | `list(string)` | n/a | yes |
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_backend_public_base_rate_limit"></a> [backend\_public\_base\_rate\_limit](#input\_backend\_public\_base\_rate\_limit) | For the backend ALB. Number of requests to allow in a 5 minute period before rate limiting is applied. | `number` | n/a | yes |
@@ -88,6 +87,7 @@ No modules.
 | <a name="input_bouncer_public_base_rate_warning"></a> [bouncer\_public\_base\_rate\_warning](#input\_bouncer\_public\_base\_rate\_warning) | For the bouncer ALB. Allows us to configure a warning level to detect what happens if we reduce the limit. | `number` | n/a | yes |
 | <a name="input_cache_public_base_rate_limit"></a> [cache\_public\_base\_rate\_limit](#input\_cache\_public\_base\_rate\_limit) | For the cache ALB. Number of requests to allow in a 5 minute period before rate limiting is applied. | `number` | n/a | yes |
 | <a name="input_cache_public_base_rate_warning"></a> [cache\_public\_base\_rate\_warning](#input\_cache\_public\_base\_rate\_warning) | For the cache ALB. Allows us to configure a warning level to detect what happens if we reduce the limit. | `number` | n/a | yes |
+| <a name="input_eks_egress_ips"></a> [eks\_egress\_ips](#input\_eks\_egress\_ips) | An array of CIDR blocks for the corresponding EKS environment's NAT gateway IPs | `list(string)` | n/a | yes |
 | <a name="input_fastly_rate_limit_token"></a> [fastly\_rate\_limit\_token](#input\_fastly\_rate\_limit\_token) | Token used by the CDN to skip rate limiting | `string` | `""` | no |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | <a name="input_remote_state_infra_database_backups_bucket_key_stack"></a> [remote\_state\_infra\_database\_backups\_bucket\_key\_stack](#input\_remote\_state\_infra\_database\_backups\_bucket\_key\_stack) | Override path to infra\_database\_backups\_bucket remote state | `string` | `""` | no |

--- a/terraform/projects/infra-public-wafs/cache_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/cache_public_rule.tf
@@ -250,7 +250,7 @@ resource "aws_wafv2_ip_set" "govuk_requesting_ips" {
   description        = "The IP addresses used by our infra to make requests that hit the cache LB."
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
-  addresses          = concat(var.traffic_replay_ips, local.nat_gateway_ips, var.aws_eks_nat_gateway_ips)
+  addresses          = concat(var.traffic_replay_ips, local.nat_gateway_ips, var.eks_egress_ips)
 }
 
 resource "aws_wafv2_ip_set" "external_partner_ips" {

--- a/terraform/projects/infra-public-wafs/variables.tf
+++ b/terraform/projects/infra-public-wafs/variables.tf
@@ -80,7 +80,7 @@ variable "traffic_replay_ips" {
   description = "An array of CIDR blocks that will replay traffic against an environment"
 }
 
-variable "aws_eks_nat_gateway_ips" {
+variable "eks_egress_ips" {
   type        = list(string)
   description = "An array of CIDR blocks for the corresponding EKS environment's NAT gateway IPs"
 }


### PR DESCRIPTION
- Allow traffic from EKS NAT gateways to S3 mirror buckets.
- In the WAF ratelimit exemptions, take the list of EKS NAT gateways from the new var in govuk-aws-data `data/common` instead of duplicating it in the module vars. (No diff from this, just avoid duplication.)

This fixes the Smokey probe failures for mirrors when running from the production EKS cluster.

Rollout: with alphagov/govuk-aws-data#1179. Already applied in production.