### PR TITLE
[Do not merge] Temporarily switch Publishings AmazonMQ to apply modifications immediately

### DIFF
--- a/terraform/projects/app-publishing-amazonmq/main.tf
+++ b/terraform/projects/app-publishing-amazonmq/main.tf
@@ -104,6 +104,7 @@ data "dns_a_record_set" "mq_instances" {
 # --------------------------------------------------------------
 # The broker itself
 resource "aws_mq_broker" "publishing_amazonmq" {
+  apply_immediately   = true
   broker_name = var.publishing_amazonmq_broker_name
 
   engine_type         = var.engine_type


### PR DESCRIPTION
This allows us to monitor the rollout of an instance type change on staging, so that we can manage any downtime when we rollout the new instance types on production