### PR TITLE
Upgrade nodejs to v18

### DIFF
--- a/terraform/projects/infra-mirror-bucket/main.tf
+++ b/terraform/projects/infra-mirror-bucket/main.tf
@@ -630,6 +630,6 @@ resource "aws_lambda_function" "url_rewrite" {
   function_name = "url_rewrite"
   role          = aws_iam_role.basic_lambda_role.arn
   handler       = "index.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs18.x"
   provider      = aws.aws_cloudfront_certificate
 }

--- a/terraform/projects/infra-public-services/waf.tf
+++ b/terraform/projects/infra-public-services/waf.tf
@@ -95,7 +95,7 @@ resource "aws_lambda_function" "aws_waf_log_trimmer" {
   source_code_hash = "${data.archive_file.aws_waf_log_trimmer.output_base64sha256}"
   role             = "${aws_iam_role.aws_waf_log_trimmer.arn}"
   handler          = "lambda.handler"
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs18.x"
   timeout          = 190
 }
 


### PR DESCRIPTION
The current versions are nearing EOL and will no longer be supported. So this PR upgrades nodejs from v16 to v18

Trello: https://trello.com/c/SOmvaQgr/3135-upgrade-nodejs-from-v16-to-v18-3