### PR TITLE
Remove disused load balancers.

### DIFF
--- a/terraform/projects/infra-public-services/README.md
+++ b/terraform/projects/infra-public-services/README.md
@@ -24,45 +24,27 @@ This project adds global resources for app components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_account_public_lb"></a> [account\_public\_lb](#module\_account\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_account_public_lb_rules"></a> [account\_public\_lb\_rules](#module\_account\_public\_lb\_rules) | ../../modules/aws/lb_listener_rules | n/a |
 | <a name="module_alarms-elb-jumpbox-public"></a> [alarms-elb-jumpbox-public](#module\_alarms-elb-jumpbox-public) | ../../modules/aws/alarms/elb | n/a |
-| <a name="module_backend_public_lb"></a> [backend\_public\_lb](#module\_backend\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_backend_public_lb_rules"></a> [backend\_public\_lb\_rules](#module\_backend\_public\_lb\_rules) | ../../modules/aws/lb_listener_rules | n/a |
-| <a name="module_bouncer_public_lb"></a> [bouncer\_public\_lb](#module\_bouncer\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_cache_public_lb"></a> [cache\_public\_lb](#module\_cache\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_cache_public_lb_rules"></a> [cache\_public\_lb\_rules](#module\_cache\_public\_lb\_rules) | ../../modules/aws/lb_listener_rules | n/a |
 | <a name="module_ckan_public_lb"></a> [ckan\_public\_lb](#module\_ckan\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_deploy_public_lb"></a> [deploy\_public\_lb](#module\_deploy\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_draft_cache_public_lb"></a> [draft\_cache\_public\_lb](#module\_draft\_cache\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_email_alert_api_public_lb"></a> [email\_alert\_api\_public\_lb](#module\_email\_alert\_api\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_graphite_public_lb"></a> [graphite\_public\_lb](#module\_graphite\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_licensify_backend_public_lb"></a> [licensify\_backend\_public\_lb](#module\_licensify\_backend\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_licensify_frontend_public_lb"></a> [licensify\_frontend\_public\_lb](#module\_licensify\_frontend\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_monitoring_public_lb"></a> [monitoring\_public\_lb](#module\_monitoring\_public\_lb) | ../../modules/aws/lb | n/a |
 | <a name="module_prometheus_public_lb"></a> [prometheus\_public\_lb](#module\_prometheus\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_sidekiq_monitoring_public_lb"></a> [sidekiq\_monitoring\_public\_lb](#module\_sidekiq\_monitoring\_public\_lb) | ../../modules/aws/lb | n/a |
-| <a name="module_whitehall_backend_public_lb"></a> [whitehall\_backend\_public\_lb](#module\_whitehall\_backend\_public\_lb) | ../../modules/aws/lb | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_autoscaling_attachment.backend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.bouncer_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.cache_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.ckan_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.deploy_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.draft_cache_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.email_alert_api_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.graphite_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.jumpbox_asg_attachment_elb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.licensify_backend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.licensify_frontend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.monitoring_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_attachment.prometheus_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.sidekiq_monitoring_backend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
-| [aws_autoscaling_attachment.whitehall_backend_asg_attachment_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
 | [aws_elb.jumpbox_public_elb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elb) | resource |
 | [aws_iam_role.aws_waf_firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.aws_waf_log_trimmer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -71,53 +53,19 @@ This project adds global resources for app components:
 | [aws_lambda_function.aws_waf_log_trimmer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lb_listener.licensify_backend_http_80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.licensify_frontend_public_http_80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
-| [aws_lb_listener_rule.backend_alb_blocked_host_headers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
-| [aws_route53_record.account_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.account_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.account_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.account_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.apt_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.asset_master_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.backend_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.backend_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.backend_internal_service_redirected_via_public_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.backend_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.backend_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.backend_redis_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.bouncer_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.bouncer_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.cache_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.cache_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.cache_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.cache_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.calculators_frontend_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.calculators_frontend_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ckan_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ckan_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ckan_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ckan_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.content_data_api_db_admin_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.content_data_api_postgresql_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.content_store_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.db_admin_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.deploy_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.deploy_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.docker_management_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.draft_cache_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.draft_cache_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.draft_cache_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.draft_cache_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.draft_content_store_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.draft_content_store_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.draft_frontend_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.draft_frontend_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.draft_whitehall_frontend_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.elasticsearch6_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.email_alert_api_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.email_alert_api_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.frontend_cache_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.frontend_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.frontend_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.graphite_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.graphite_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.jumpbox_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -126,38 +74,23 @@ This project adds global resources for app components:
 | [aws_route53_record.licensify_frontend_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.licensify_frontend_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.licensify_frontend_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.locations_api_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.locations_api_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.mongo_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.monitoring_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.monitoring_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.prometheus_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.prometheus_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.publishing_api_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.puppetmaster_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rabbitmq_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rate_limit_redis_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.router_backend_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.search_internal_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.search_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.sidekiq_monitoring_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.transition_db_admin_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.transition_postgresql_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.whitehall_backend_public_service_cnames](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.whitehall_backend_public_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.whitehall_frontend_internal_service_names](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_s3_bucket.aws_waf_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [archive_file.aws_waf_log_trimmer](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
-| [aws_autoscaling_group.account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_group) | data source |
-| [aws_autoscaling_group.backend](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_group) | data source |
-| [aws_autoscaling_group.cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_group) | data source |
-| [aws_autoscaling_groups.bouncer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
 | [aws_autoscaling_groups.ckan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
-| [aws_autoscaling_groups.content-store](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
 | [aws_autoscaling_groups.deploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
-| [aws_autoscaling_groups.draft_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
-| [aws_autoscaling_groups.email_alert_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
-| [aws_autoscaling_groups.frontend](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
 | [aws_autoscaling_groups.graphite](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
 | [aws_autoscaling_groups.jumpbox](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
 | [aws_autoscaling_groups.licensify_backend](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
@@ -165,9 +98,6 @@ This project adds global resources for app components:
 | [aws_autoscaling_groups.monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
 | [aws_autoscaling_groups.prometheus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
 | [aws_autoscaling_groups.search](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
-| [aws_autoscaling_groups.static](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
-| [aws_autoscaling_groups.whitehall_backend](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
-| [aws_autoscaling_groups.whitehall_frontend](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
 | [terraform_remote_state.infra_monitoring](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_networking](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.infra_root_dns_zones](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -179,65 +109,28 @@ This project adds global resources for app components:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_internal_service_cnames"></a> [account\_internal\_service\_cnames](#input\_account\_internal\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_account_internal_service_names"></a> [account\_internal\_service\_names](#input\_account\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_account_public_service_cnames"></a> [account\_public\_service\_cnames](#input\_account\_public\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_account_public_service_names"></a> [account\_public\_service\_names](#input\_account\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_app_stackname"></a> [app\_stackname](#input\_app\_stackname) | Stackname of the app projects in this environment | `string` | `"blue"` | no |
 | <a name="input_apt_internal_service_names"></a> [apt\_internal\_service\_names](#input\_apt\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_apt_public_service_cnames"></a> [apt\_public\_service\_cnames](#input\_apt\_public\_service\_cnames) | n/a | `list` | `[]` | no |
 | <a name="input_apt_public_service_names"></a> [apt\_public\_service\_names](#input\_apt\_public\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_asset_master_internal_service_names"></a> [asset\_master\_internal\_service\_names](#input\_asset\_master\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
-| <a name="input_backend_alb_blocked_host_headers"></a> [backend\_alb\_blocked\_host\_headers](#input\_backend\_alb\_blocked\_host\_headers) | n/a | `list` | `[]` | no |
-| <a name="input_backend_allow_routing_for_absent_host_header_rules"></a> [backend\_allow\_routing\_for\_absent\_host\_header\_rules](#input\_backend\_allow\_routing\_for\_absent\_host\_header\_rules) | n/a | `string` | `"true"` | no |
-| <a name="input_backend_internal_service_cnames"></a> [backend\_internal\_service\_cnames](#input\_backend\_internal\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_backend_internal_service_names"></a> [backend\_internal\_service\_names](#input\_backend\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_backend_internal_service_redirected_via_public_cnames"></a> [backend\_internal\_service\_redirected\_via\_public\_cnames](#input\_backend\_internal\_service\_redirected\_via\_public\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_backend_public_service_cnames"></a> [backend\_public\_service\_cnames](#input\_backend\_public\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_backend_public_service_names"></a> [backend\_public\_service\_names](#input\_backend\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_backend_redis_internal_service_names"></a> [backend\_redis\_internal\_service\_names](#input\_backend\_redis\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_backend_renamed_public_service_cnames"></a> [backend\_renamed\_public\_service\_cnames](#input\_backend\_renamed\_public\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_backend_rules_for_existing_target_groups"></a> [backend\_rules\_for\_existing\_target\_groups](#input\_backend\_rules\_for\_existing\_target\_groups) | create an additional rule for a target group already created via rules\_host | `map` | `{}` | no |
-| <a name="input_bouncer_internal_service_names"></a> [bouncer\_internal\_service\_names](#input\_bouncer\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_bouncer_public_service_names"></a> [bouncer\_public\_service\_names](#input\_bouncer\_public\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_cache_internal_service_cnames"></a> [cache\_internal\_service\_cnames](#input\_cache\_internal\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_cache_internal_service_names"></a> [cache\_internal\_service\_names](#input\_cache\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_cache_public_service_cnames"></a> [cache\_public\_service\_cnames](#input\_cache\_public\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_cache_public_service_names"></a> [cache\_public\_service\_names](#input\_cache\_public\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_calculators_frontend_internal_service_cnames"></a> [calculators\_frontend\_internal\_service\_cnames](#input\_calculators\_frontend\_internal\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_calculators_frontend_internal_service_names"></a> [calculators\_frontend\_internal\_service\_names](#input\_calculators\_frontend\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_ckan_internal_service_cnames"></a> [ckan\_internal\_service\_cnames](#input\_ckan\_internal\_service\_cnames) | n/a | `list` | `[]` | no |
 | <a name="input_ckan_internal_service_names"></a> [ckan\_internal\_service\_names](#input\_ckan\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_ckan_public_service_cnames"></a> [ckan\_public\_service\_cnames](#input\_ckan\_public\_service\_cnames) | n/a | `list` | `[]` | no |
 | <a name="input_ckan_public_service_names"></a> [ckan\_public\_service\_names](#input\_ckan\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_content_data_api_db_admin_internal_service_names"></a> [content\_data\_api\_db\_admin\_internal\_service\_names](#input\_content\_data\_api\_db\_admin\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_content_data_api_postgresql_internal_service_names"></a> [content\_data\_api\_postgresql\_internal\_service\_names](#input\_content\_data\_api\_postgresql\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_content_store_internal_service_names"></a> [content\_store\_internal\_service\_names](#input\_content\_store\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_content_store_public_service_names"></a> [content\_store\_public\_service\_names](#input\_content\_store\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_db_admin_internal_service_names"></a> [db\_admin\_internal\_service\_names](#input\_db\_admin\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_deploy_internal_service_names"></a> [deploy\_internal\_service\_names](#input\_deploy\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_deploy_public_service_names"></a> [deploy\_public\_service\_names](#input\_deploy\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_docker_management_internal_service_names"></a> [docker\_management\_internal\_service\_names](#input\_docker\_management\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_draft_cache_internal_service_cnames"></a> [draft\_cache\_internal\_service\_cnames](#input\_draft\_cache\_internal\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_draft_cache_internal_service_names"></a> [draft\_cache\_internal\_service\_names](#input\_draft\_cache\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_draft_cache_public_service_cnames"></a> [draft\_cache\_public\_service\_cnames](#input\_draft\_cache\_public\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_draft_cache_public_service_names"></a> [draft\_cache\_public\_service\_names](#input\_draft\_cache\_public\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_draft_content_store_internal_service_names"></a> [draft\_content\_store\_internal\_service\_names](#input\_draft\_content\_store\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_draft_content_store_public_service_names"></a> [draft\_content\_store\_public\_service\_names](#input\_draft\_content\_store\_public\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_draft_frontend_internal_service_cnames"></a> [draft\_frontend\_internal\_service\_cnames](#input\_draft\_frontend\_internal\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_draft_frontend_internal_service_names"></a> [draft\_frontend\_internal\_service\_names](#input\_draft\_frontend\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_draft_whitehall_frontend_internal_service_names"></a> [draft\_whitehall\_frontend\_internal\_service\_names](#input\_draft\_whitehall\_frontend\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_elasticsearch6_internal_service_names"></a> [elasticsearch6\_internal\_service\_names](#input\_elasticsearch6\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_elb_public_certname"></a> [elb\_public\_certname](#input\_elb\_public\_certname) | The ACM cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_public_internal_certname"></a> [elb\_public\_internal\_certname](#input\_elb\_public\_internal\_certname) | The ACM secondary cert domain name to find the ARN of | `string` | n/a | yes |
 | <a name="input_elb_public_secondary_certname"></a> [elb\_public\_secondary\_certname](#input\_elb\_public\_secondary\_certname) | The ACM secondary cert domain name to find the ARN of | `string` | `""` | no |
-| <a name="input_email_alert_api_internal_service_names"></a> [email\_alert\_api\_internal\_service\_names](#input\_email\_alert\_api\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_email_alert_api_public_service_names"></a> [email\_alert\_api\_public\_service\_names](#input\_email\_alert\_api\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_enable_lb_app_healthchecks"></a> [enable\_lb\_app\_healthchecks](#input\_enable\_lb\_app\_healthchecks) | Use application specific target groups and healthchecks based on the list of services in the cname variable. | `string` | `false` | no |
-| <a name="input_frontend_internal_service_cnames"></a> [frontend\_internal\_service\_cnames](#input\_frontend\_internal\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_frontend_internal_service_names"></a> [frontend\_internal\_service\_names](#input\_frontend\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_graphite_internal_service_names"></a> [graphite\_internal\_service\_names](#input\_graphite\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_graphite_public_service_names"></a> [graphite\_public\_service\_names](#input\_graphite\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_jumpbox_public_service_names"></a> [jumpbox\_public\_service\_names](#input\_jumpbox\_public\_service\_names) | n/a | `list` | `[]` | no |
@@ -247,15 +140,12 @@ This project adds global resources for app components:
 | <a name="input_licensify_frontend_internal_service_names"></a> [licensify\_frontend\_internal\_service\_names](#input\_licensify\_frontend\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_licensify_frontend_public_service_cnames"></a> [licensify\_frontend\_public\_service\_cnames](#input\_licensify\_frontend\_public\_service\_cnames) | n/a | `list` | `[]` | no |
 | <a name="input_licensify_frontend_public_service_names"></a> [licensify\_frontend\_public\_service\_names](#input\_licensify\_frontend\_public\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_locations_api_internal_service_names"></a> [locations\_api\_internal\_service\_names](#input\_locations\_api\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_locations_api_public_service_cnames"></a> [locations\_api\_public\_service\_cnames](#input\_locations\_api\_public\_service\_cnames) | n/a | `list` | `[]` | no |
 | <a name="input_mongo_internal_service_names"></a> [mongo\_internal\_service\_names](#input\_mongo\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_monitoring_internal_service_names"></a> [monitoring\_internal\_service\_names](#input\_monitoring\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_monitoring_internal_service_names_cname_dest"></a> [monitoring\_internal\_service\_names\_cname\_dest](#input\_monitoring\_internal\_service\_names\_cname\_dest) | This variable specifies the CNAME record destination to be associated with the service names defined in monitoring\_internal\_service\_names | `string` | `"alert"` | no |
 | <a name="input_monitoring_public_service_names"></a> [monitoring\_public\_service\_names](#input\_monitoring\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_prometheus_internal_service_names"></a> [prometheus\_internal\_service\_names](#input\_prometheus\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_prometheus_public_service_names"></a> [prometheus\_public\_service\_names](#input\_prometheus\_public\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_publishing_api_internal_service_names"></a> [publishing\_api\_internal\_service\_names](#input\_publishing\_api\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_puppetmaster_internal_service_names"></a> [puppetmaster\_internal\_service\_names](#input\_puppetmaster\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_rabbitmq_internal_service_names"></a> [rabbitmq\_internal\_service\_names](#input\_rabbitmq\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_rate_limit_redis_internal_service_names"></a> [rate\_limit\_redis\_internal\_service\_names](#input\_rate\_limit\_redis\_internal\_service\_names) | n/a | `list` | `[]` | no |
@@ -267,38 +157,23 @@ This project adds global resources for app components:
 | <a name="input_remote_state_infra_stack_dns_zones_key_stack"></a> [remote\_state\_infra\_stack\_dns\_zones\_key\_stack](#input\_remote\_state\_infra\_stack\_dns\_zones\_key\_stack) | Override stackname path to infra\_stack\_dns\_zones remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_vpc_key_stack"></a> [remote\_state\_infra\_vpc\_key\_stack](#input\_remote\_state\_infra\_vpc\_key\_stack) | Override infra\_vpc remote state path | `string` | `""` | no |
 | <a name="input_router_backend_internal_service_names"></a> [router\_backend\_internal\_service\_names](#input\_router\_backend\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_search_api_public_service_names"></a> [search\_api\_public\_service\_names](#input\_search\_api\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_search_internal_service_cnames"></a> [search\_internal\_service\_cnames](#input\_search\_internal\_service\_cnames) | n/a | `list` | `[]` | no |
 | <a name="input_search_internal_service_names"></a> [search\_internal\_service\_names](#input\_search\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_sidekiq_monitoring_public_service_names"></a> [sidekiq\_monitoring\_public\_service\_names](#input\_sidekiq\_monitoring\_public\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | n/a | yes |
 | <a name="input_transition_db_admin_internal_service_names"></a> [transition\_db\_admin\_internal\_service\_names](#input\_transition\_db\_admin\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_transition_postgresql_internal_service_names"></a> [transition\_postgresql\_internal\_service\_names](#input\_transition\_postgresql\_internal\_service\_names) | n/a | `list` | `[]` | no |
 | <a name="input_waf_logs_hec_endpoint"></a> [waf\_logs\_hec\_endpoint](#input\_waf\_logs\_hec\_endpoint) | Splunk endpoint for shipping application firewall logs | `string` | n/a | yes |
 | <a name="input_waf_logs_hec_token"></a> [waf\_logs\_hec\_token](#input\_waf\_logs\_hec\_token) | Splunk token for shipping application firewall logs | `string` | n/a | yes |
-| <a name="input_whitehall_backend_internal_service_cnames"></a> [whitehall\_backend\_internal\_service\_cnames](#input\_whitehall\_backend\_internal\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_whitehall_backend_internal_service_names"></a> [whitehall\_backend\_internal\_service\_names](#input\_whitehall\_backend\_internal\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_whitehall_backend_public_service_cnames"></a> [whitehall\_backend\_public\_service\_cnames](#input\_whitehall\_backend\_public\_service\_cnames) | n/a | `list` | `[]` | no |
-| <a name="input_whitehall_backend_public_service_names"></a> [whitehall\_backend\_public\_service\_names](#input\_whitehall\_backend\_public\_service\_names) | n/a | `list` | `[]` | no |
-| <a name="input_whitehall_frontend_internal_service_names"></a> [whitehall\_frontend\_internal\_service\_names](#input\_whitehall\_frontend\_internal\_service\_names) | n/a | `list` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_account_public_lb_id"></a> [account\_public\_lb\_id](#output\_account\_public\_lb\_id) | The ID of the account\_public load balancer |
-| <a name="output_backend_public_lb_id"></a> [backend\_public\_lb\_id](#output\_backend\_public\_lb\_id) | The ID of the backend\_public load balancer |
-| <a name="output_bouncer_public_lb_id"></a> [bouncer\_public\_lb\_id](#output\_bouncer\_public\_lb\_id) | The ID of the bouncer\_public load balancer |
-| <a name="output_cache_public_lb_id"></a> [cache\_public\_lb\_id](#output\_cache\_public\_lb\_id) | The ID of the cache\_public load balancer |
 | <a name="output_ckan_public_lb_id"></a> [ckan\_public\_lb\_id](#output\_ckan\_public\_lb\_id) | The ID of the ckan\_public load balancer |
 | <a name="output_deploy_public_lb_id"></a> [deploy\_public\_lb\_id](#output\_deploy\_public\_lb\_id) | The ID of the deploy\_public load balancer |
-| <a name="output_draft_cache_public_lb_id"></a> [draft\_cache\_public\_lb\_id](#output\_draft\_cache\_public\_lb\_id) | The ID of the draft\_cache\_public load balancer |
-| <a name="output_email_alert_api_public_lb_id"></a> [email\_alert\_api\_public\_lb\_id](#output\_email\_alert\_api\_public\_lb\_id) | The ID of the email\_alert\_api\_public load balancer |
 | <a name="output_graphite_public_lb_id"></a> [graphite\_public\_lb\_id](#output\_graphite\_public\_lb\_id) | The ID of the graphite\_public load balancer |
 | <a name="output_kinesis_firehose_splunk_arn"></a> [kinesis\_firehose\_splunk\_arn](#output\_kinesis\_firehose\_splunk\_arn) | The ARN of the splunk endpoint of the kinesis firehose stream |
 | <a name="output_licensify_backend_public_lb_id"></a> [licensify\_backend\_public\_lb\_id](#output\_licensify\_backend\_public\_lb\_id) | The ID of the licensify\_backend\_public load balancer |
 | <a name="output_licensify_frontend_public_lb_id"></a> [licensify\_frontend\_public\_lb\_id](#output\_licensify\_frontend\_public\_lb\_id) | The ID of the licensify\_frontend\_public\_lb load balancer |
 | <a name="output_monitoring_public_lb_id"></a> [monitoring\_public\_lb\_id](#output\_monitoring\_public\_lb\_id) | The ID of the monitoring\_public load balancer |
 | <a name="output_prometheus_public_lb_id"></a> [prometheus\_public\_lb\_id](#output\_prometheus\_public\_lb\_id) | The ID of the prometheus\_public load balancer |
-| <a name="output_sidekiq_monitoring_public_lb_id"></a> [sidekiq\_monitoring\_public\_lb\_id](#output\_sidekiq\_monitoring\_public\_lb\_id) | The ID of the sidekiq\_monitoring\_public\_lb load balancer |
-| <a name="output_whitehall_backend_public_lb_id"></a> [whitehall\_backend\_public\_lb\_id](#output\_whitehall\_backend\_public\_lb\_id) | The ID of the whitehall\_backend\_public load balancer |

--- a/terraform/projects/infra-public-services/main.tf
+++ b/terraform/projects/infra-public-services/main.tf
@@ -50,78 +50,12 @@ variable "enable_lb_app_healthchecks" {
   default     = false
 }
 
-variable "account_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "account_internal_service_cnames" {
-  type    = "list"
-  default = []
-}
-
-variable "account_public_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "account_public_service_cnames" {
-  type    = "list"
-  default = []
-}
-
 variable "apt_public_service_names" {
   type    = "list"
   default = []
 }
 
 variable "apt_public_service_cnames" {
-  type    = "list"
-  default = []
-}
-
-variable "backend_alb_blocked_host_headers" {
-  type    = "list"
-  default = []
-}
-
-variable "backend_allow_routing_for_absent_host_header_rules" {
-  type    = "string"
-  default = "true"
-}
-
-variable "backend_public_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "backend_public_service_cnames" {
-  type    = "list"
-  default = []
-}
-
-variable "backend_renamed_public_service_cnames" {
-  type    = "list"
-  default = []
-}
-
-variable "backend_rules_for_existing_target_groups" {
-  type        = "map"
-  description = "create an additional rule for a target group already created via rules_host"
-  default     = {}
-}
-
-variable "bouncer_public_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "cache_public_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "cache_public_service_cnames" {
   type    = "list"
   default = []
 }
@@ -146,42 +80,12 @@ variable "content_data_api_postgresql_internal_service_names" {
   default = []
 }
 
-variable "content_store_public_service_names" {
-  type    = "list"
-  default = []
-}
-
 variable "deploy_public_service_names" {
   type    = "list"
   default = []
 }
 
-variable "draft_cache_public_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "draft_cache_public_service_cnames" {
-  type    = "list"
-  default = []
-}
-
-variable "email_alert_api_public_service_names" {
-  type    = "list"
-  default = []
-}
-
 variable "graphite_public_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "locations_api_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "locations_api_public_service_cnames" {
   type    = "list"
   default = []
 }
@@ -231,26 +135,6 @@ variable "monitoring_public_service_names" {
   default = []
 }
 
-variable "sidekiq_monitoring_public_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "whitehall_backend_public_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "whitehall_backend_public_service_cnames" {
-  type    = "list"
-  default = []
-}
-
-variable "asset_master_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
 variable "apt_internal_service_names" {
   type    = "list"
   default = []
@@ -261,57 +145,12 @@ variable "backend_redis_internal_service_names" {
   default = []
 }
 
-variable "backend_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "backend_internal_service_cnames" {
-  type    = "list"
-  default = []
-}
-
-variable "backend_internal_service_redirected_via_public_cnames" {
-  type    = "list"
-  default = []
-}
-
-variable "bouncer_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "cache_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "cache_internal_service_cnames" {
-  type    = "list"
-  default = []
-}
-
-variable "calculators_frontend_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "calculators_frontend_internal_service_cnames" {
-  type    = "list"
-  default = []
-}
-
 variable "ckan_internal_service_names" {
   type    = "list"
   default = []
 }
 
 variable "ckan_internal_service_cnames" {
-  type    = "list"
-  default = []
-}
-
-variable "content_store_internal_service_names" {
   type    = "list"
   default = []
 }
@@ -331,52 +170,7 @@ variable "docker_management_internal_service_names" {
   default = []
 }
 
-variable "draft_cache_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "draft_cache_internal_service_cnames" {
-  type    = "list"
-  default = []
-}
-
-variable "draft_content_store_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "draft_frontend_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "draft_frontend_internal_service_cnames" {
-  type    = "list"
-  default = []
-}
-
-variable "draft_whitehall_frontend_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
 variable "elasticsearch6_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "email_alert_api_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "frontend_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "frontend_internal_service_cnames" {
   type    = "list"
   default = []
 }
@@ -405,11 +199,6 @@ variable "monitoring_internal_service_names_cname_dest" {
   description = "This variable specifies the CNAME record destination to be associated with the service names defined in monitoring_internal_service_names"
   type        = "string"
   default     = "alert"
-}
-
-variable "publishing_api_internal_service_names" {
-  type    = "list"
-  default = []
 }
 
 variable "puppetmaster_internal_service_names" {
@@ -442,37 +231,12 @@ variable "search_internal_service_cnames" {
   default = []
 }
 
-variable "search_api_public_service_names" {
-  type    = "list"
-  default = []
-}
-
 variable "transition_db_admin_internal_service_names" {
   type    = "list"
   default = []
 }
 
 variable "transition_postgresql_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "whitehall_backend_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "whitehall_backend_internal_service_cnames" {
-  type    = "list"
-  default = []
-}
-
-variable "whitehall_frontend_internal_service_names" {
-  type    = "list"
-  default = []
-}
-
-variable "draft_content_store_public_service_names" {
   type    = "list"
   default = []
 }
@@ -511,83 +275,6 @@ provider "archive" {
 }
 
 #
-# account
-#
-
-module "account_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-account-public"
-  internal                                   = false
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.outputs.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.outputs.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-account-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-  listener_internal_certificate_domain_name  = "${var.elb_public_internal_certname}"
-  listener_action                            = "${map("HTTPS:443", "HTTP:80")}"
-  subnets                                    = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
-  security_groups                            = ["${data.terraform_remote_state.infra_security_groups.outputs.sg_account_elb_external_id}"]
-  alarm_actions                              = ["${data.terraform_remote_state.infra_monitoring.outputs.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                               = "${map("Project", var.stackname, "aws_migration", "account", "aws_environment", var.aws_environment)}"
-  target_group_health_check_path             = "/_healthcheck-ready_account-api"
-}
-
-module "account_public_lb_rules" {
-  source                 = "../../modules/aws/lb_listener_rules"
-  name                   = "account"
-  autoscaling_group_name = "${data.aws_autoscaling_group.account.name}"
-  rules_host_domain      = "*"
-  vpc_id                 = "${data.terraform_remote_state.infra_vpc.outputs.vpc_id}"
-  listener_arn           = "${module.account_public_lb.load_balancer_ssl_listeners[0]}"
-  rules_host             = var.enable_lb_app_healthchecks ? var.account_public_service_cnames : []
-  default_tags           = "${map("Project", var.stackname, "aws_migration", "account", "aws_environment", var.aws_environment)}"
-}
-
-resource "aws_route53_record" "account_public_service_names" {
-  count   = "${length(var.account_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.account_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.account_public_lb.lb_dns_name}"
-    zone_id                = "${module.account_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_route53_record" "account_public_service_cnames" {
-  count   = "${length(var.account_public_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.account_public_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.account_public_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"]
-  ttl     = "300"
-}
-
-data "aws_autoscaling_group" "account" {
-  name = "${var.app_stackname}-account"
-}
-
-resource "aws_route53_record" "account_internal_service_names" {
-  count   = "${length(var.account_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.account_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.account_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "account_internal_service_cnames" {
-  count   = "${length(var.account_internal_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.account_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.account_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
 # Apt: TODO EXTERNAL
 #
 
@@ -601,19 +288,6 @@ resource "aws_route53_record" "apt_internal_service_names" {
 }
 
 #
-# asset-master
-#
-
-resource "aws_route53_record" "asset_master_internal_service_names" {
-  count   = "${length(var.asset_master_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.asset_master_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.asset_master_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
 # Backend-redis
 #
 
@@ -623,290 +297,6 @@ resource "aws_route53_record" "backend_redis_internal_service_names" {
   name    = "${element(var.backend_redis_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
   type    = "CNAME"
   records = ["${element(var.backend_redis_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
-# Backend
-#
-
-module "backend_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-backend-public"
-  internal                                   = false
-  allow_routing_for_absent_host_header_rules = "${var.backend_allow_routing_for_absent_host_header_rules}"
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.outputs.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.outputs.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-backend-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-  listener_internal_certificate_domain_name  = "${var.elb_public_internal_certname}"
-  listener_action                            = "${map("HTTPS:443", "HTTP:80")}"
-  subnets                                    = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
-  security_groups                            = ["${data.terraform_remote_state.infra_security_groups.outputs.sg_backend_elb_external_id}"]
-  alarm_actions                              = ["${data.terraform_remote_state.infra_monitoring.outputs.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                               = "${map("Project", var.stackname, "aws_migration", "backend", "aws_environment", var.aws_environment)}"
-  idle_timeout                               = 400
-}
-
-resource "aws_lb_listener_rule" "backend_alb_blocked_host_headers" {
-  count        = "${length(var.backend_alb_blocked_host_headers)}"
-  listener_arn = "${element(module.backend_public_lb.load_balancer_ssl_listeners, 0)}"
-  priority     = "${count.index + 1}"
-
-  action {
-    type             = "fixed-response"
-    target_group_arn = "${element(module.backend_public_lb.target_group_arns, 0)}"
-
-    fixed_response {
-      content_type = "text/html"
-      status_code  = "403"
-    }
-  }
-
-  condition {
-    host_header {
-      values = ["${element(var.backend_alb_blocked_host_headers, count.index)}"]
-    }
-  }
-}
-
-module "backend_public_lb_rules" {
-  source                           = "../../modules/aws/lb_listener_rules"
-  name                             = "backend"
-  autoscaling_group_name           = "${data.aws_autoscaling_group.backend.name}"
-  rules_host_domain                = "*"
-  vpc_id                           = "${data.terraform_remote_state.infra_vpc.outputs.vpc_id}"
-  listener_arn                     = "${module.backend_public_lb.load_balancer_ssl_listeners[0]}"
-  rules_host                       = var.enable_lb_app_healthchecks ? var.backend_public_service_cnames : []
-  rules_for_existing_target_groups = "${var.backend_rules_for_existing_target_groups}"
-  priority_offset                  = "${length(var.backend_alb_blocked_host_headers) + 1}"
-  default_tags                     = "${map("Project", var.stackname, "aws_migration", "backend", "aws_environment", var.aws_environment)}"
-}
-
-resource "aws_route53_record" "backend_public_service_names" {
-  count   = "${length(var.backend_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.backend_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.backend_public_lb.lb_dns_name}"
-    zone_id                = "${module.backend_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_route53_record" "backend_public_service_cnames" {
-  count   = "${length(concat(var.backend_public_service_cnames, var.backend_renamed_public_service_cnames))}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(concat(var.backend_public_service_cnames, var.backend_renamed_public_service_cnames), count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.backend_public_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"]
-  ttl     = "300"
-}
-
-data "aws_autoscaling_group" "backend" {
-  name = "${var.app_stackname}-backend"
-}
-
-resource "aws_autoscaling_attachment" "backend_asg_attachment_alb" {
-  count                  = "${data.aws_autoscaling_group.backend.name != "" ? 1 : 0}"
-  autoscaling_group_name = "${data.aws_autoscaling_group.backend.name}"
-  alb_target_group_arn   = "${element(module.backend_public_lb.target_group_arns, 0)}"
-}
-
-resource "aws_route53_record" "backend_internal_service_names" {
-  count   = "${length(var.backend_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.backend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.backend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "backend_internal_service_cnames" {
-  count   = "${length(var.backend_internal_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.backend_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.backend_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "backend_internal_service_redirected_via_public_cnames" {
-  count   = "${length(var.backend_internal_service_redirected_via_public_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.backend_internal_service_redirected_via_public_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.backend_public_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
-# Bouncer
-#
-
-module "bouncer_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-bouncer-public"
-  internal                                   = false
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.outputs.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.outputs.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-bouncer-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-
-  listener_action = {
-    "HTTP:80"   = "HTTP:80"
-    "HTTPS:443" = "HTTP:80"
-  }
-
-  target_group_health_check_path = "/healthcheck/ready"
-  subnets                        = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
-  security_groups                = ["${data.terraform_remote_state.infra_security_groups.outputs.sg_bouncer_elb_id}"]
-  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.outputs.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                   = "${map("Project", var.stackname, "aws_migration", "bouncer", "aws_environment", var.aws_environment)}"
-}
-
-resource "aws_route53_record" "bouncer_public_service_names" {
-  count   = "${length(var.bouncer_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.bouncer_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.bouncer_public_lb.lb_dns_name}"
-    zone_id                = "${module.bouncer_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-data "aws_autoscaling_groups" "bouncer" {
-  filter {
-    name   = "key"
-    values = ["Name"]
-  }
-
-  filter {
-    name   = "value"
-    values = ["blue-bouncer"]
-  }
-}
-
-resource "aws_autoscaling_attachment" "bouncer_asg_attachment_alb" {
-  count                  = "${length(data.aws_autoscaling_groups.bouncer.names) > 0 ? 1 : 0}"
-  autoscaling_group_name = "${element(data.aws_autoscaling_groups.bouncer.names, 0)}"
-  alb_target_group_arn   = "${element(module.bouncer_public_lb.target_group_arns, 0)}"
-}
-
-resource "aws_route53_record" "bouncer_internal_service_names" {
-  count   = "${length(var.bouncer_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.bouncer_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.bouncer_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
-# Cache
-#
-
-module "cache_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-cache-public"
-  internal                                   = false
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.outputs.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.outputs.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-cache-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-  listener_action                            = "${map("HTTPS:443", "HTTP:80")}"
-  subnets                                    = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
-  security_groups                            = ["${data.terraform_remote_state.infra_security_groups.outputs.sg_cache_external_elb_id}"]
-  alarm_actions                              = ["${data.terraform_remote_state.infra_monitoring.outputs.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                               = "${map("Project", var.stackname, "aws_migration", "cache", "aws_environment", var.aws_environment)}"
-}
-
-resource "aws_route53_record" "cache_public_service_names" {
-  count   = "${length(var.cache_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.cache_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.cache_public_lb.lb_dns_name}"
-    zone_id                = "${module.cache_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_route53_record" "cache_public_service_cnames" {
-  count   = "${length(var.cache_public_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.cache_public_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.cache_public_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"]
-  ttl     = "300"
-}
-
-module "cache_public_lb_rules" {
-  source                 = "../../modules/aws/lb_listener_rules"
-  name                   = "cache"
-  autoscaling_group_name = "${data.aws_autoscaling_group.cache.name}"
-  rules_host_domain      = "*"
-  vpc_id                 = "${data.terraform_remote_state.infra_vpc.outputs.vpc_id}"
-  listener_arn           = "${module.cache_public_lb.load_balancer_ssl_listeners[0]}"
-  rules_host             = var.enable_lb_app_healthchecks ? var.cache_public_service_cnames : []
-  default_tags           = "${map("Project", var.stackname, "aws_migration", "cache", "aws_environment", var.aws_environment)}"
-}
-
-data "aws_autoscaling_group" "cache" {
-  name = "${var.app_stackname}-cache"
-}
-
-resource "aws_autoscaling_attachment" "cache_asg_attachment_alb" {
-  count                  = "${data.aws_autoscaling_group.cache.name != "" ? 1 : 0}"
-  autoscaling_group_name = "${data.aws_autoscaling_group.cache.name}"
-  alb_target_group_arn   = "${element(module.cache_public_lb.target_group_arns, 0)}"
-}
-
-resource "aws_route53_record" "cache_internal_service_names" {
-  count   = "${length(var.cache_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.cache_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.cache_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "cache_internal_service_cnames" {
-  count   = "${length(var.cache_internal_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.cache_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.cache_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-# Calculators-frontend
-
-resource "aws_route53_record" "calculators_frontend_internal_service_names" {
-  count   = "${length(var.calculators_frontend_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.calculators_frontend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.calculators_frontend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "calculators_frontend_internal_service_cnames" {
-  count   = "${length(var.calculators_frontend_internal_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.calculators_frontend_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.calculators_frontend_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
   ttl     = "300"
 }
 
@@ -1014,29 +404,6 @@ resource "aws_route53_record" "content_data_api_postgresql_internal_service_name
   ttl     = "300"
 }
 
-# Content-store
-
-data "aws_autoscaling_groups" "content-store" {
-  filter {
-    name   = "key"
-    values = ["Name"]
-  }
-
-  filter {
-    name   = "value"
-    values = ["blue-content-store"]
-  }
-}
-
-resource "aws_route53_record" "content_store_internal_service_names" {
-  count   = "${length(var.content_store_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.content_store_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.content_store_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
 # Db-admin
 
 resource "aws_route53_record" "db_admin_internal_service_names" {
@@ -1120,118 +487,6 @@ resource "aws_route53_record" "docker_management_internal_service_names" {
 }
 
 #
-# Draft-cache
-#
-module "draft_cache_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-draft-cache-public"
-  internal                                   = false
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.outputs.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.outputs.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-draft-cache-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-  listener_action                            = "${map("HTTPS:443", "HTTP:80")}"
-  subnets                                    = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
-  security_groups                            = ["${data.terraform_remote_state.infra_security_groups.outputs.sg_draft-cache_external_elb_id}"]
-  alarm_actions                              = ["${data.terraform_remote_state.infra_monitoring.outputs.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                               = "${map("Project", var.stackname, "aws_migration", "draft_cache", "aws_environment", var.aws_environment)}"
-}
-
-resource "aws_route53_record" "draft_cache_public_service_names" {
-  count   = "${length(var.draft_cache_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.draft_cache_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.draft_cache_public_lb.lb_dns_name}"
-    zone_id                = "${module.draft_cache_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_route53_record" "draft_cache_public_service_cnames" {
-  count   = "${length(var.draft_cache_public_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.draft_cache_public_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.draft_cache_public_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"]
-  ttl     = "300"
-}
-
-data "aws_autoscaling_groups" "draft_cache" {
-  filter {
-    name   = "key"
-    values = ["Name"]
-  }
-
-  filter {
-    name   = "value"
-    values = ["blue-draft-cache"]
-  }
-}
-
-resource "aws_autoscaling_attachment" "draft_cache_asg_attachment_alb" {
-  count                  = "${length(data.aws_autoscaling_groups.draft_cache.names) > 0 ? 1 : 0}"
-  autoscaling_group_name = "${element(data.aws_autoscaling_groups.draft_cache.names, 0)}"
-  alb_target_group_arn   = "${element(module.draft_cache_public_lb.target_group_arns, 0)}"
-}
-
-resource "aws_route53_record" "draft_cache_internal_service_names" {
-  count   = "${length(var.draft_cache_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.draft_cache_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.draft_cache_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "draft_cache_internal_service_cnames" {
-  count   = "${length(var.draft_cache_internal_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.draft_cache_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.draft_cache_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
-# Draft-content-store
-#
-
-resource "aws_route53_record" "draft_content_store_internal_service_names" {
-  count   = "${length(var.draft_content_store_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.draft_content_store_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.draft_content_store_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
-# Draft-frontend
-#
-
-resource "aws_route53_record" "draft_frontend_internal_service_names" {
-  count   = "${length(var.draft_frontend_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.draft_frontend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.draft_frontend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "draft_frontend_internal_service_cnames" {
-  count   = "${length(var.draft_frontend_internal_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.draft_frontend_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.draft_frontend_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
 # elasticsearch6
 #
 
@@ -1241,109 +496,6 @@ resource "aws_route53_record" "elasticsearch6_internal_service_names" {
   name    = "${element(var.elasticsearch6_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
   type    = "CNAME"
   records = ["${element(var.elasticsearch6_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
-# email_alert_api
-#
-
-module "email_alert_api_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-email-alert-api-public"
-  internal                                   = false
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.outputs.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.outputs.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-email-alert-api-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-  listener_action                            = "${map("HTTPS:443", "HTTP:80")}"
-  target_group_health_check_path             = "/_healthcheck-ready_email-alert-api"
-  subnets                                    = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
-  security_groups                            = ["${data.terraform_remote_state.infra_security_groups.outputs.sg_email-alert-api_elb_external_id}"]
-  alarm_actions                              = ["${data.terraform_remote_state.infra_monitoring.outputs.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                               = "${map("Project", var.stackname, "aws_migration", "email_alert_api", "aws_environment", var.aws_environment)}"
-}
-
-resource "aws_route53_record" "email_alert_api_public_service_names" {
-  count   = "${length(var.email_alert_api_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.email_alert_api_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.email_alert_api_public_lb.lb_dns_name}"
-    zone_id                = "${module.email_alert_api_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-data "aws_autoscaling_groups" "email_alert_api" {
-  filter {
-    name   = "key"
-    values = ["Name"]
-  }
-
-  filter {
-    name   = "value"
-    values = ["blue-email-alert-api"]
-  }
-}
-
-resource "aws_autoscaling_attachment" "email_alert_api_asg_attachment_alb" {
-  count                  = "${length(data.aws_autoscaling_groups.email_alert_api.names) > 0 ? 1 : 0}"
-  autoscaling_group_name = "${element(data.aws_autoscaling_groups.email_alert_api.names, 0)}"
-  alb_target_group_arn   = "${element(module.email_alert_api_public_lb.target_group_arns, 0)}"
-}
-
-resource "aws_route53_record" "email_alert_api_internal_service_names" {
-  count   = "${length(var.email_alert_api_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.email_alert_api_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.email_alert_api_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-data "aws_autoscaling_groups" "frontend" {
-  filter {
-    name   = "key"
-    values = ["Name"]
-  }
-
-  filter {
-    name   = "value"
-    values = ["blue-frontend"]
-  }
-}
-
-#
-# frontend
-#
-
-resource "aws_route53_record" "frontend_internal_service_names" {
-  count   = "${length(var.frontend_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.frontend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.frontend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "frontend_internal_service_cnames" {
-  count   = "${length(var.frontend_internal_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.frontend_internal_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.frontend_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "frontend_cache_name" {
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "frontend-memcached.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["frontend-memcached.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
   ttl     = "300"
 }
 
@@ -1469,28 +621,6 @@ resource "aws_route53_record" "graphite_internal_service_names" {
   name    = "${element(var.graphite_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
   type    = "CNAME"
   records = ["${element(var.graphite_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
-# locations-api
-#
-
-resource "aws_route53_record" "locations_api_internal_service_names" {
-  count   = "${length(var.locations_api_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.locations_api_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.locations_api_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "locations_api_public_service_cnames" {
-  count   = "${length(var.locations_api_public_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.locations_api_public_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.locations_api_internal_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"]
   ttl     = "300"
 }
 
@@ -1835,19 +965,6 @@ resource "aws_route53_record" "monitoring_internal_service_names" {
 }
 
 #
-# publishing_api
-#
-
-resource "aws_route53_record" "publishing_api_internal_service_names" {
-  count   = "${length(var.publishing_api_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.publishing_api_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.publishing_api_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-#
 # puppetmaster
 #
 
@@ -1934,66 +1051,6 @@ resource "aws_route53_record" "search_internal_service_cnames" {
 }
 
 #
-# Static
-#
-
-data "aws_autoscaling_groups" "static" {
-  filter {
-    name   = "key"
-    values = ["Name"]
-  }
-
-  filter {
-    name   = "value"
-    values = ["blue-frontend"]
-  }
-}
-
-#
-# sidekiq-monitoring
-#
-
-module "sidekiq_monitoring_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-sidekiq-monitoring-public"
-  internal                                   = false
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.outputs.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.outputs.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-sidekiq-monitoring-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-
-  listener_action = {
-    "HTTPS:443" = "HTTP:80"
-  }
-
-  target_group_health_check_path = "/_healthcheck-ready_sidekiq-monitoring"
-  subnets                        = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
-  security_groups                = ["${data.terraform_remote_state.infra_security_groups.outputs.sg_sidekiq-monitoring_external_elb_id}"]
-  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.outputs.sns_topic_cloudwatch_alarms_arn}"]
-  default_tags                   = "${map("Project", var.stackname, "aws_migration", "sidekiq-monitoring", "aws_environment", var.aws_environment)}"
-}
-
-resource "aws_route53_record" "sidekiq_monitoring_public_service_names" {
-  count   = "${length(var.sidekiq_monitoring_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.sidekiq_monitoring_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.sidekiq_monitoring_public_lb.lb_dns_name}"
-    zone_id                = "${module.sidekiq_monitoring_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_autoscaling_attachment" "sidekiq_monitoring_backend_asg_attachment_alb" {
-  count                  = "${data.aws_autoscaling_group.backend.name != "" ? 1 : 0}"
-  autoscaling_group_name = "${data.aws_autoscaling_group.backend.name}"
-  alb_target_group_arn   = "${element(module.sidekiq_monitoring_public_lb.target_group_arns, 0)}"
-}
-
-#
 # transition_db_admin
 #
 
@@ -2019,146 +1076,12 @@ resource "aws_route53_record" "transition_postgresql_internal_service_names" {
   ttl     = "300"
 }
 
-#
-# Whitehall-backend
-#
-
-module "whitehall_backend_public_lb" {
-  source                                     = "../../modules/aws/lb"
-  name                                       = "${var.stackname}-whitehall-public"
-  internal                                   = false
-  vpc_id                                     = "${data.terraform_remote_state.infra_vpc.outputs.vpc_id}"
-  access_logs_bucket_name                    = "${data.terraform_remote_state.infra_monitoring.outputs.aws_logging_bucket_id}"
-  access_logs_bucket_prefix                  = "elb/${var.stackname}-whitehall-backend-public-elb"
-  listener_certificate_domain_name           = "${var.elb_public_certname}"
-  listener_secondary_certificate_domain_name = "${var.elb_public_secondary_certname}"
-
-  listener_action = {
-    "HTTPS:443" = "HTTP:80"
-  }
-
-  target_group_health_check_path = "/_healthcheck-ready_whitehall-admin"
-  subnets                        = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
-  security_groups                = ["${data.terraform_remote_state.infra_security_groups.outputs.sg_whitehall-backend_external_elb_id}"]
-  alarm_actions                  = ["${data.terraform_remote_state.infra_monitoring.outputs.sns_topic_cloudwatch_alarms_arn}"]
-
-  default_tags = {
-    Project         = "${var.stackname}"
-    aws_migration   = "whitehall_backend"
-    aws_environment = "${var.aws_environment}"
-  }
-}
-
-resource "aws_route53_record" "whitehall_backend_public_service_names" {
-  count   = "${length(var.whitehall_backend_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.whitehall_backend_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.whitehall_backend_public_lb.lb_dns_name}"
-    zone_id                = "${module.whitehall_backend_public_lb.lb_zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_route53_record" "whitehall_backend_public_service_cnames" {
-  count   = "${length(var.whitehall_backend_public_service_cnames)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.whitehall_backend_public_service_cnames, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.whitehall_backend_public_service_names, 0)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"]
-  ttl     = "300"
-}
-
-data "aws_autoscaling_groups" "whitehall_backend" {
-  filter {
-    name   = "key"
-    values = ["Name"]
-  }
-
-  filter {
-    name   = "value"
-    values = ["blue-whitehall-backend"]
-  }
-}
-
-resource "aws_autoscaling_attachment" "whitehall_backend_asg_attachment_alb" {
-  count                  = "${length(data.aws_autoscaling_groups.whitehall_backend.names) > 0 ? 1 : 0}"
-  autoscaling_group_name = "${element(data.aws_autoscaling_groups.whitehall_backend.names, 0)}"
-  alb_target_group_arn   = "${element(module.whitehall_backend_public_lb.target_group_arns, 0)}"
-}
-
-#
-# whitehall-frontend
-#
-
-data "aws_autoscaling_groups" "whitehall_frontend" {
-  filter {
-    name   = "key"
-    values = ["Name"]
-  }
-
-  filter {
-    name   = "value"
-    values = ["blue-whitehall-frontend"]
-  }
-}
-
-# draft_whitehall internal names are actually alias for whitehall internal names
-resource "aws_route53_record" "draft_whitehall_frontend_internal_service_names" {
-  count   = "${length(var.draft_whitehall_frontend_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.draft_whitehall_frontend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.whitehall_frontend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "whitehall_frontend_internal_service_names" {
-  count   = "${length(var.whitehall_frontend_internal_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id}"
-  name    = "${element(var.whitehall_frontend_internal_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.whitehall_frontend_internal_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_domain_name}"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "draft_content_store_public_service_names" {
-  count   = "${length(var.draft_content_store_public_service_names)}"
-  zone_id = "${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id}"
-  name    = "${element(var.draft_content_store_public_service_names, count.index)}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
-  type    = "CNAME"
-  records = ["${element(var.draft_content_store_public_service_names, count.index)}.blue.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"]
-  ttl     = "300"
-}
-
 # Outputs
 # ---------------------
 
 output "kinesis_firehose_splunk_arn" {
   value       = "${aws_kinesis_firehose_delivery_stream.splunk.arn}"
   description = "The ARN of the splunk endpoint of the kinesis firehose stream"
-}
-
-output "account_public_lb_id" {
-  value       = "${module.account_public_lb.lb_id}"
-  description = "The ID of the account_public load balancer"
-}
-
-output "backend_public_lb_id" {
-  value       = "${module.backend_public_lb.lb_id}"
-  description = "The ID of the backend_public load balancer"
-}
-
-output "bouncer_public_lb_id" {
-  value       = "${module.bouncer_public_lb.lb_id}"
-  description = "The ID of the bouncer_public load balancer"
-}
-
-output "cache_public_lb_id" {
-  value       = "${module.cache_public_lb.lb_id}"
-  description = "The ID of the cache_public load balancer"
 }
 
 output "ckan_public_lb_id" {
@@ -2169,16 +1092,6 @@ output "ckan_public_lb_id" {
 output "deploy_public_lb_id" {
   value       = "${module.deploy_public_lb.lb_id}"
   description = "The ID of the deploy_public load balancer"
-}
-
-output "draft_cache_public_lb_id" {
-  value       = "${module.draft_cache_public_lb.lb_id}"
-  description = "The ID of the draft_cache_public load balancer"
-}
-
-output "email_alert_api_public_lb_id" {
-  value       = "${module.email_alert_api_public_lb.lb_id}"
-  description = "The ID of the email_alert_api_public load balancer"
 }
 
 output "graphite_public_lb_id" {
@@ -2204,14 +1117,4 @@ output "licensify_backend_public_lb_id" {
 output "monitoring_public_lb_id" {
   value       = "${module.monitoring_public_lb.lb_id}"
   description = "The ID of the monitoring_public load balancer"
-}
-
-output "sidekiq_monitoring_public_lb_id" {
-  value       = "${module.sidekiq_monitoring_public_lb.lb_id}"
-  description = "The ID of the sidekiq_monitoring_public_lb load balancer"
-}
-
-output "whitehall_backend_public_lb_id" {
-  value       = "${module.whitehall_backend_public_lb.lb_id}"
-  description = "The ID of the whitehall_backend_public load balancer"
 }


### PR DESCRIPTION
These are no longer in use since the Kubernetes migration (and had been deleted, but it turns out this module is a bit more active than we thought so we need to get rid of them from here so they don't keep getting re-created).

The names that referred to these were deleted in https://github.com/alphagov/govuk-dns-tf/pull/17.

Tested: [`terraform plan` in integration](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/5199/console) (needs VPN, sorry)