### PR TITLE
Fix list outputs from networking modules.

### DIFF
--- a/terraform/modules/aws/network/nat/main.tf
+++ b/terraform/modules/aws/network/nat/main.tf
@@ -66,6 +66,6 @@ output "nat_gateway_subnets_ids_map" {
 }
 
 output "nat_gateway_elastic_ips_list" {
-  value       = ["${aws_eip.nat.*.public_ip}"]
+  value       = "${aws_eip.nat.*.public_ip}"
   description = "List containing the public IPs associated with the NAT gateways"
 }

--- a/terraform/modules/aws/network/private_subnet/main.tf
+++ b/terraform/modules/aws/network/private_subnet/main.tf
@@ -126,7 +126,7 @@ resource "aws_vpc_endpoint_route_table_association" "private_s3" {
 #--------------------------------------------------------------
 
 output "subnet_ids" {
-  value       = ["${aws_subnet.private.*.id}"]
+  value       = "${aws_subnet.private.*.id}"
   description = "List of private subnet IDs"
 }
 
@@ -136,7 +136,7 @@ output "subnet_names_ids_map" {
 }
 
 output "subnet_route_table_ids" {
-  value       = ["${aws_route_table.private.*.id}"]
+  value       = "${aws_route_table.private.*.id}"
   description = "List of route_table IDs"
 }
 

--- a/terraform/modules/aws/network/public_subnet/main.tf
+++ b/terraform/modules/aws/network/public_subnet/main.tf
@@ -78,7 +78,7 @@ resource "aws_route_table_association" "public" {
 #--------------------------------------------------------------
 
 output "subnet_ids" {
-  value       = ["${aws_subnet.public.*.id}"]
+  value       = "${aws_subnet.public.*.id}"
   description = "List containing the IDs of the created subnets."
 }
 


### PR DESCRIPTION
These were being wrapped in an extra list, i.e.

    [['foo', 'bar', 'baz']]

instead of

    ['foo', 'bar', 'baz']

as expected by the modules which consume these outputs.

The semantics of the original TF 0.11 syntax for list values changed (in 0.12?) so this started returning the wrong type.

Rollout: already done; it seems only staging had been updated since the Terraform upgrade that broke this, and I've run `terraform refresh` there and now the consumer modules (such as `infra-public-services`) are working again.