### PR TITLE
Remove cache_clearing_service from Publishing AmazonMQ

### DIFF
--- a/terraform/projects/app-publishing-amazonmq/README.md
+++ b/terraform/projects/app-publishing-amazonmq/README.md
@@ -55,7 +55,6 @@ No modules.
 | [aws_security_group_rule.publishingamazonmq_ingress_management_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.rabbitmq_egress_self_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [local_sensitive_file.amazonmq_rabbitmq_definitions](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
-| [random_password.cache_clearing_service](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.content_data_api](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.email_alert_service](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.monitoring](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |

--- a/terraform/projects/app-publishing-amazonmq/main.tf
+++ b/terraform/projects/app-publishing-amazonmq/main.tf
@@ -57,20 +57,15 @@ resource "random_password" "email_alert_service" {
   length  = 24
   special = false
 }
-resource "random_password" "cache_clearing_service" {
-  length  = 24
-  special = false
-}
 
 locals {
   publishing_amazonmq_passwords = {
-    root                   = random_password.root.result
-    monitoring             = random_password.monitoring.result
-    publishing_api         = random_password.publishing_api.result
-    search_api             = random_password.search_api.result
-    content_data_api       = random_password.content_data_api.result
-    email_alert_service    = random_password.email_alert_service.result
-    cache_clearing_service = random_password.cache_clearing_service.result
+    root                = random_password.root.result
+    monitoring          = random_password.monitoring.result
+    publishing_api      = random_password.publishing_api.result
+    search_api          = random_password.search_api.result
+    content_data_api    = random_password.content_data_api.result
+    email_alert_service = random_password.email_alert_service.result
   }
 
   tags = {

--- a/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
+++ b/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
@@ -17,11 +17,6 @@
       "tags": ""
     },
     {
-      "name": "cache_clearing_service",
-      "password": "${publishing_amazonmq_passwords["cache_clearing_service"]}",
-      "tags": ""
-    },
-    {
       "name": "monitoring",
       "password": "${publishing_amazonmq_passwords["monitoring"]}",
       "tags": "monitoring"
@@ -80,13 +75,6 @@
       "write": ".*",
       "read": ".*"
     },
-    {
-      "user": "cache_clearing_service",
-      "vhost": "publishing",
-      "configure": "^$",
-      "write": "^$",
-      "read": "^cache_clearing_service-\\w+$"
-    }
   ],
   "parameters": [],
   "global_parameters": [
@@ -96,18 +84,6 @@
     }
   ],
   "policies": [
-    {
-      "vhost": "publishing",
-      "name": "cache_clearing_service-low-ttl",
-      "pattern": "cache_clearing_service-low.*",
-      "apply-to": "queues",
-      "definition": {
-        "ha-mode": "all",
-        "ha-sync-mode": "automatic",
-        "message-ttl": 1800000
-      },
-      "priority": 0
-    },
     {
       "vhost": "publishing",
       "name": "content_data_api-dlx",

--- a/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
+++ b/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
@@ -281,14 +281,6 @@
     {
       "source": "published_documents",
       "vhost": "publishing",
-      "destination": "cache_clearing_service-low",
-      "destination_type": "queue",
-      "routing_key": "*.links",
-      "arguments": {}
-    },
-    {
-      "source": "published_documents",
-      "vhost": "publishing",
       "destination": "content_data_api",
       "destination_type": "queue",
       "routing_key": "*.links",
@@ -300,14 +292,6 @@
       "destination": "search_api_to_be_indexed",
       "destination_type": "queue",
       "routing_key": "*.links",
-      "arguments": {}
-    },
-    {
-      "source": "published_documents",
-      "vhost": "publishing",
-      "destination": "cache_clearing_service-high",
-      "destination_type": "queue",
-      "routing_key": "*.major",
       "arguments": {}
     },
     {
@@ -337,14 +321,6 @@
     {
       "source": "published_documents",
       "vhost": "publishing",
-      "destination": "cache_clearing_service-medium",
-      "destination_type": "queue",
-      "routing_key": "*.minor",
-      "arguments": {}
-    },
-    {
-      "source": "published_documents",
-      "vhost": "publishing",
       "destination": "content_data_api",
       "destination_type": "queue",
       "routing_key": "*.minor",
@@ -361,25 +337,9 @@
     {
       "source": "published_documents",
       "vhost": "publishing",
-      "destination": "cache_clearing_service-medium",
-      "destination_type": "queue",
-      "routing_key": "*.republish",
-      "arguments": {}
-    },
-    {
-      "source": "published_documents",
-      "vhost": "publishing",
       "destination": "content_data_api",
       "destination_type": "queue",
       "routing_key": "*.republish",
-      "arguments": {}
-    },
-    {
-      "source": "published_documents",
-      "vhost": "publishing",
-      "destination": "cache_clearing_service-high",
-      "destination_type": "queue",
-      "routing_key": "*.unpublish",
       "arguments": {}
     },
     {

--- a/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
+++ b/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
@@ -134,13 +134,6 @@
   ],
   "queues": [
     {
-      "name": "cache_clearing_service-low",
-      "vhost": "publishing",
-      "durable": true,
-      "auto_delete": false,
-      "arguments": {}
-    },
-    {
       "name": "email_alert_service",
       "vhost": "publishing",
       "durable": true,
@@ -197,13 +190,6 @@
       "arguments": {}
     },
     {
-      "name": "cache_clearing_service-high",
-      "vhost": "publishing",
-      "durable": true,
-      "auto_delete": false,
-      "arguments": {}
-    },
-    {
       "name": "search_api_govuk_index",
       "vhost": "publishing",
       "durable": true,
@@ -212,13 +198,6 @@
     },
     {
       "name": "email_unpublishing",
-      "vhost": "publishing",
-      "durable": true,
-      "auto_delete": false,
-      "arguments": {}
-    },
-    {
-      "name": "cache_clearing_service-medium",
       "vhost": "publishing",
       "durable": true,
       "auto_delete": false,


### PR DESCRIPTION
We are retiring Cache clearing service. Monitoring will be removed later on.

[Plan output](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/5336/console)

[GIFT week summer 2023 card](https://trello.com/c/ENPwB2vT/41-retire-cache-clearing-service)
[Tech debt card](https://trello.com/c/TX9wLihh/101-cache-clearing-app-exists-and-we-dont-think-its-necessary-replacing-cache-clearing-app-only-clears-path-not-query-strings)