### PR TITLE
Simplify SOPs and DocumentDB KMS key policies

### DIFF
--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -65,6 +65,7 @@ Infrastructure security settings:
 | [aws_iam_policy_document.data-science-access-sagemaker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.deny-eip-release](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.google_s3_mirror](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kms_docdb_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_sops_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.pass_step_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.shield-response-team-access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -20,7 +20,6 @@ Infrastructure security settings:
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.25 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.7.2 |
 
 ## Modules
 
@@ -58,7 +57,6 @@ Infrastructure security settings:
 | [aws_kms_key.licensify_documentdb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.shared_documentdb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.sops](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
-| [time_sleep.wait_30_seconds](https://registry.terraform.io/providers/hashicorp/time/0.7.2/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.allow-iam-key-rotation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.data-science-access-glue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -459,7 +459,7 @@ resource "aws_iam_role_policy_attachment" "google-s3-mirror-access" {
 
 data "aws_iam_policy_document" "kms_sops_policy" {
   statement {
-    sid = "Enable IAM User Permission"
+    sid = "Delegate permissions to IAM policies"
 
     actions = [
       "kms:*",
@@ -471,88 +471,6 @@ data "aws_iam_policy_document" "kms_sops_policy" {
       type        = "AWS"
       identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
-  }
-
-  statement {
-    sid = "Allow access for Key Administrators"
-
-    actions = [
-      "kms:Create*",
-      "kms:Describe*",
-      "kms:Enable*",
-      "kms:List*",
-      "kms:Put*",
-      "kms:Update*",
-      "kms:Revoke*",
-      "kms:Disable*",
-      "kms:Get*",
-      "kms:Delete*",
-      "kms:TagResource",
-      "kms:UntagResource",
-      "kms:ScheduleKeyDeletion",
-      "kms:CancelKeyDeletion",
-    ]
-
-    resources = ["*"]
-
-    principals {
-      type        = "AWS"
-      identifiers = jsondecode(time_sleep.wait_30_seconds.triggers["gds_admin_roles_and_arns"])
-    }
-  }
-
-  statement {
-    sid = "Allow use of the key"
-
-    actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:DescribeKey",
-    ]
-
-    resources = ["*"]
-
-    principals {
-      type        = "AWS"
-      identifiers = jsondecode(time_sleep.wait_30_seconds.triggers["gds_admin_roles_and_arns"])
-    }
-  }
-
-  statement {
-    sid = "Allow attachment of persistent resources"
-
-    actions = [
-      "kms:CreateGrant",
-      "kms:ListGrants",
-      "kms:RevokeGrant",
-    ]
-
-    resources = ["*"]
-
-    principals {
-      type        = "AWS"
-      identifiers = jsondecode(time_sleep.wait_30_seconds.triggers["gds_admin_roles_and_arns"])
-    }
-  }
-}
-
-
-/*
-wait resource that will be used by the aws_kms_key resources so that they
-wait until the iam_roles are created and propagated before attaching kms
-policies referring the newly created iam_roles
-
-See issues:
-1. https://github.com/hashicorp/terraform-provider-aws/issues/245
-2. https://discuss.hashicorp.com/t/terraform-malformed-policy/11281/2
-*/
-resource "time_sleep" "wait_30_seconds" {
-  create_duration = "30s"
-
-  triggers = {
-    gds_admin_roles_and_arns = jsonencode([for role, arn in module.gds_role_admin.roles_and_arns : arn])
   }
 }
 


### PR DESCRIPTION
This simplifies the key policy statements for the SOPs and DocumentDB KMS keys.  The top level statement "Enable IAM User Permission" delegates all access control to IAM policies. 
```json
{
    "Sid": "Enable IAM User Permissions",
    "Effect": "Allow",
    "Principal": {
        "AWS": "arn:aws:iam::<aws_account_id>:root"
    },
    "Action": "kms:*",
    "Resource": "*"
}
```
From [the AWS docs](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-overview.html):

>When the principal in a key policy statement is an [AWS account principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-accounts) expressed as `arn:aws:iam::111122223333:root`, the policy statement doesn't give permission to any IAM principal. Instead, it gives the AWS account permission to use IAM policies to delegate the permissions specified in the key policy. (A principal in `arn:aws:iam::111122223333:root` format does not represent the [AWS account root user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html), despite the use of "root" in the account identifier. However, the account principal represents the account and its administrators, including the account root user.)


This means the statements allowing administrator and user permissions to explicit IAM Roles had no net effect - especially as the IAM Roles already had IAM Permissions to access the keys.

This simplifies the key policy and allows us to no longer need to updated the list of IAM Roles. (Which was a pain, as we had to put in a hack to wait for the IAM Roles to propergate).

---

This also adds a statement to explicitly give permission to RDS to use the key. This statement probably also has no effect given the top "Enable IAM User Permission" statement, but added to make sure we don't accidentally remove permissions for DocumentDB to use the key.