### PR TITLE
Remove unused Terraform in infra-security

### DIFF
--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -13,7 +13,6 @@ Infrastructure security settings:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.25 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | 0.7.2 |
 
 ## Providers
 

--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -74,7 +74,6 @@ Infrastructure security settings:
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_environment"></a> [aws\_environment](#input\_aws\_environment) | AWS Environment | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
-| <a name="input_office_ips"></a> [office\_ips](#input\_office\_ips) | An array of CIDR blocks that will be allowed offsite access. | `list(any)` | n/a | yes |
 | <a name="input_role_admin_policy_arns"></a> [role\_admin\_policy\_arns](#input\_role\_admin\_policy\_arns) | List of ARNs of policies to attach to the role | `list(any)` | `[]` | no |
 | <a name="input_role_admin_user_arns"></a> [role\_admin\_user\_arns](#input\_role\_admin\_user\_arns) | List of ARNs of external users that can assume the role | `list(any)` | `[]` | no |
 | <a name="input_role_dataengineeruser_policy_arns"></a> [role\_dataengineeruser\_policy\_arns](#input\_role\_dataengineeruser\_policy\_arns) | List of ARNs of policies to attach to the role | `list(any)` | `[]` | no |

--- a/terraform/projects/infra-security/README.md
+++ b/terraform/projects/infra-security/README.md
@@ -84,7 +84,6 @@ Infrastructure security settings:
 | <a name="input_role_user_policy_arns"></a> [role\_user\_policy\_arns](#input\_role\_user\_policy\_arns) | List of ARNs of policies to attach to the role | `list(any)` | `[]` | no |
 | <a name="input_role_user_user_arns"></a> [role\_user\_user\_arns](#input\_role\_user\_user\_arns) | List of ARNs of external users that can assume the role | `list(any)` | `[]` | no |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The public part of an SSH keypair | `string` | `null` | no |
-| <a name="input_stackname"></a> [stackname](#input\_stackname) | Stackname | `string` | `""` | no |
 
 ## Outputs
 

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -104,15 +104,8 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.25"
     }
-
-    time = {
-      source  = "hashicorp/time"
-      version = "0.7.2"
-    }
   }
 }
-
-provider "time" {}
 
 provider "aws" {
   region = var.aws_region

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -92,11 +92,6 @@ variable "ssh_public_key" {
   default     = null
 }
 
-variable "office_ips" {
-  type        = list(any)
-  description = "An array of CIDR blocks that will be allowed offsite access."
-}
-
 # Resources
 # --------------------------------------------------------------
 
@@ -130,7 +125,6 @@ module "gds_role_admin" {
   role_suffix      = "admin"
   role_user_arns   = toset(var.role_admin_user_arns)
   role_policy_arns = var.role_admin_policy_arns
-  office_ips       = var.office_ips
 }
 
 module "gds_role_poweruser" {
@@ -138,7 +132,6 @@ module "gds_role_poweruser" {
   role_suffix      = "poweruser"
   role_user_arns   = toset(var.role_admin_user_arns)
   role_policy_arns = var.role_poweruser_policy_arns
-  office_ips       = var.office_ips
 }
 
 module "role_datascienceuser" {
@@ -237,7 +230,6 @@ module "gds_role_user" {
   role_suffix      = "user"
   role_user_arns   = toset(concat(var.role_user_user_arns, var.role_admin_user_arns))
   role_policy_arns = var.role_user_policy_arns
-  office_ips       = var.office_ips
 }
 
 resource "aws_iam_account_password_policy" "tighten_passwords" {

--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -20,12 +20,6 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
-variable "stackname" {
-  type        = string
-  description = "Stackname"
-  default     = ""
-}
-
 variable "role_admin_user_arns" {
   type        = list(any)
   description = "List of ARNs of external users that can assume the role"


### PR DESCRIPTION
The variables office_ip, stack name and the time resource are no longer used.