### PR TITLE
Add licensify backend waf

### DIFF
--- a/terraform/projects/infra-public-wafs/README.md
+++ b/terraform/projects/infra-public-wafs/README.md
@@ -20,6 +20,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_log_group.licensify_backend_public_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.public_backend_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.public_bouncer_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.public_cache_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
@@ -39,6 +40,7 @@ No modules.
 | [aws_wafv2_web_acl.bouncer_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [aws_wafv2_web_acl.cache_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [aws_wafv2_web_acl.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
+| [aws_wafv2_web_acl.licensify_backend_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [aws_wafv2_web_acl_association.ckan_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_association.deploy_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_association.graphite_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
@@ -46,6 +48,7 @@ No modules.
 | [aws_wafv2_web_acl_association.licensify_frontend_web_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_association.monitoring_public_web_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
 | [aws_wafv2_web_acl_logging_configuration.default_web_acl_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
+| [aws_wafv2_web_acl_logging_configuration.licensify_backend_public_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [aws_wafv2_web_acl_logging_configuration.public_backend_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [aws_wafv2_web_acl_logging_configuration.public_bouncer_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [aws_wafv2_web_acl_logging_configuration.public_cache_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
@@ -72,6 +75,8 @@ No modules.
 | <a name="input_cache_public_base_rate_warning"></a> [cache\_public\_base\_rate\_warning](#input\_cache\_public\_base\_rate\_warning) | For the cache ALB. Allows us to configure a warning level to detect what happens if we reduce the limit. | `number` | n/a | yes |
 | <a name="input_eks_egress_ips"></a> [eks\_egress\_ips](#input\_eks\_egress\_ips) | An array of CIDR blocks for the corresponding EKS environment's NAT gateway IPs | `list(string)` | n/a | yes |
 | <a name="input_fastly_rate_limit_token"></a> [fastly\_rate\_limit\_token](#input\_fastly\_rate\_limit\_token) | Token used by the CDN to skip rate limiting | `string` | `""` | no |
+| <a name="input_licensify_backend_public_base_rate_limit"></a> [licensify\_backend\_public\_base\_rate\_limit](#input\_licensify\_backend\_public\_base\_rate\_limit) | For the licensify backend ALB. Number of requests to allow in a 5 minute period before rate limiting is applied. | `number` | n/a | yes |
+| <a name="input_licensify_backend_public_base_rate_warning"></a> [licensify\_backend\_public\_base\_rate\_warning](#input\_licensify\_backend\_public\_base\_rate\_warning) | For the licensify backend ALB. Allows us to configure a warning level to detect what happens if we reduce the limit. | `number` | n/a | yes |
 | <a name="input_remote_state_bucket"></a> [remote\_state\_bucket](#input\_remote\_state\_bucket) | S3 bucket we store our terraform state in | `string` | n/a | yes |
 | <a name="input_remote_state_infra_database_backups_bucket_key_stack"></a> [remote\_state\_infra\_database\_backups\_bucket\_key\_stack](#input\_remote\_state\_infra\_database\_backups\_bucket\_key\_stack) | Override path to infra\_database\_backups\_bucket remote state | `string` | `""` | no |
 | <a name="input_remote_state_infra_monitoring_key_stack"></a> [remote\_state\_infra\_monitoring\_key\_stack](#input\_remote\_state\_infra\_monitoring\_key\_stack) | Override path to infra\_monitoring remote state | `string` | `""` | no |

--- a/terraform/projects/infra-public-wafs/licensify_backend_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/licensify_backend_public_rule.tf
@@ -1,0 +1,193 @@
+resource "aws_wafv2_web_acl" "licensify_backend_public" {
+  name  = "licensify_backend_public_web_acl"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  # this rule matches any request that contains the header X-Always-Block: true
+  # we use it as a simple sanity check / acceptance test from smokey to ensure that
+  # the waf is enabled and processing requests
+  rule {
+    name     = "x-always-block_web_acl_rule"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      rule_group_reference_statement {
+        arn = aws_wafv2_rule_group.x_always_block.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "x-always-block-rule-group"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # this rule matches any request from our NAT gateway IPs and allows it.
+  rule {
+    name     = "allow-govuk-infra"
+    priority = 2
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.govuk_requesting_ips.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "govuk-infra-backend-requests"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # This rule is intended for monitoring only
+  # set a base rate limit per IP looking back over the last 5 minutes
+  # this is checked every 30s
+  rule {
+    name     = "licensify-backend-public-base-rate-warning"
+    priority = 9
+
+    action {
+      count {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.licensify_backend_public_base_rate_warning
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "licensify-backend-public-base-rate-warning"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # set a base rate limit per IP looking back over the last 5 minutes
+  # this is checked every 30s
+  rule {
+    name     = "licensify-backend-public-base-rate-limit"
+    priority = 10
+
+    action {
+      count {}
+      # TODO: remove the above `count {}` statement and uncomment the below `block { ... }`
+      # statement once we're happy
+      #
+      # block {
+      #   custom_response {
+      #     response_code = 429
+
+      #     response_header {
+      #       name  = "Retry-After"
+      #       value = 30
+      #     }
+
+      #     response_header {
+      #       name  = "Cache-Control"
+      #       value = "max-age=0, private"
+      #     }
+
+      #     custom_response_body_key = "backend-public-rule-429"
+      #   }
+      # }
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.licensify_backend_public_base_rate_limit
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "licensify-backend-public-base-rate-limit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  custom_response_body {
+    key     = "backend-public-rule-429"
+    content = <<HTML
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>Sorry, there have been too many attempts to access this page.</p>
+          <p>Try again in a few minutes.</p>
+        </body>
+      </html>
+      HTML
+
+    content_type = "TEXT_HTML"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "licensify-backend-public-web-acl"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_cloudwatch_log_group" "licensify_backend_public_waf" {
+  # the name must start with aws-waf-logs
+  # https://docs.aws.amazon.com/waf/latest/developerguide/logging-cw-logs.html#logging-cw-logs-naming
+  name              = "aws-waf-logs-licensify-backend-public-${var.aws_environment}"
+  retention_in_days = var.waf_log_retention_days
+
+  tags = {
+    Project       = var.stackname
+    aws_stackname = var.stackname
+  }
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "licensify_backend_public_waf" {
+  log_destination_configs = [aws_cloudwatch_log_group.licensify_backend_public_waf.arn]
+  resource_arn            = aws_wafv2_web_acl.licensify_backend_public.arn
+
+  logging_filter {
+    default_behavior = "DROP"
+
+    filter {
+      behavior = "KEEP"
+
+      condition {
+        action_condition {
+          action = "COUNT"
+        }
+      }
+
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+
+      requirement = "MEETS_ANY"
+    }
+  }
+}

--- a/terraform/projects/infra-public-wafs/standard_config.tf
+++ b/terraform/projects/infra-public-wafs/standard_config.tf
@@ -37,7 +37,7 @@ resource "aws_shield_protection" "licensify_backend_public_lb" {
 
 resource "aws_wafv2_web_acl_association" "licensify_backend_public_web_acl" {
   resource_arn = data.terraform_remote_state.infra_public_services.outputs.licensify_backend_public_lb_id
-  web_acl_arn  = aws_wafv2_web_acl.default.arn
+  web_acl_arn  = aws_wafv2_web_acl.licensify_backend_public.arn
 }
 
 resource "aws_shield_protection" "licensify_frontend_public_lb" {

--- a/terraform/projects/infra-public-wafs/variables.tf
+++ b/terraform/projects/infra-public-wafs/variables.tf
@@ -75,6 +75,16 @@ variable "cache_public_base_rate_limit" {
   description = "For the cache ALB. Number of requests to allow in a 5 minute period before rate limiting is applied."
 }
 
+variable "licensify_backend_public_base_rate_warning" {
+  type        = number
+  description = "For the licensify backend ALB. Allows us to configure a warning level to detect what happens if we reduce the limit."
+}
+
+variable "licensify_backend_public_base_rate_limit" {
+  type        = number
+  description = "For the licensify backend ALB. Number of requests to allow in a 5 minute period before rate limiting is applied."
+}
+
 variable "traffic_replay_ips" {
   type        = list(string)
   description = "An array of CIDR blocks that will replay traffic against an environment"


### PR DESCRIPTION
This is mostly copied from the cache_public WAF.

We retain the x-always-block rule. This is the easiest way for Smokey to determine
that a WAF is applied.

We keep a warning/count rate limit rule.

We'll set the "blocking" rule to count for now while we confirm that the rest works as
expected.

For the rules we retain we do not need to parse the True-Client-IP header to
identify the IP of the client. We have therefore switched aggregate key types
from "FORWARDED_IP" (with some additional configuration) to "IP". The different
rules have slightly different ways of configuring this:

- [rate based statement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl.html#rate-based-statement)
- [IP set reference statement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl.html#ip-set-reference-statement)

Trello: https://trello.com/c/IpC6eYPp/3179-doable-create-waf-for-the-licensify-backend-public-load-balancer-3