### PR TITLE
Clean up dangling ACL entries from Carrenza.

### DIFF
--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -106,7 +106,6 @@ No modules.
 | [aws_security_group.transition-postgresql-primary](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group.transition-postgresql-standby](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group) | resource |
 | [aws_security_group_rule.apt-external-elb_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.apt-external-elb_ingress_carrenza_production_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.apt-external-elb_ingress_fastly_http](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.apt-external-elb_ingress_fastly_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.apt-external-elb_ingress_office_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
@@ -144,7 +143,6 @@ No modules.
 | [aws_security_group_rule.ci-agent-5_ingress_ci-agent-5-ci_master_ssh_tcp](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ci-agent-5_ingress_ci-agent-5-elb_ssh_tcp](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ci-master-elb_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.ci-master-elb_ingress_carrenza_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ci-master-elb_ingress_github_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ci-master-elb_ingress_office_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ci-master-internal-elb_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
@@ -166,7 +164,6 @@ No modules.
 | [aws_security_group_rule.deploy-elb_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.deploy-elb_ingress_aws_integration_access_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.deploy-elb_ingress_aws_staging_access_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.deploy-elb_ingress_carrenza_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.deploy-elb_ingress_office_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.deploy-internal-elb_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.deploy-internal-elb_ingress_management_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
@@ -264,7 +261,6 @@ No modules.
 | [aws_security_group_rule.rabbitmq-elb_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.rabbitmq-elb_ingress_management_amqp](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.rabbitmq-elb_ingress_management_rabbitmq-stomp](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.rabbitmq_ingress_carrenza-rabbitmq_amqp](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.rabbitmq_ingress_rabbitmq-elb_amqp](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.rabbitmq_ingress_rabbitmq-elb_rabbitmq-stomp](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.rabbitmq_ingress_rabbitmq_rabbitmq-epmd](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
@@ -276,7 +272,6 @@ No modules.
 | [aws_security_group_rule.search-ltr-generation_ingress_jenkins_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.shared-documentdb_ingress_db-admin_mongodb](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.support-api_egress_external_elb_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.support-api_ingress_external-elb_https](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.transition-db-admin-elb_egress_any_any](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.transition-db-admin-elb_ingress_management_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.transition-db-admin_ingress_transition-db-admin-elb_ssh](https://registry.terraform.io/providers/hashicorp/aws/2.46.0/docs/resources/security_group_rule) | resource |
@@ -294,13 +289,6 @@ No modules.
 | <a name="input_aws_integration_external_nat_gateway_ips"></a> [aws\_integration\_external\_nat\_gateway\_ips](#input\_aws\_integration\_external\_nat\_gateway\_ips) | An array of public IPs of the AWS integration external NAT gateways. | `list` | `[]` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
 | <a name="input_aws_staging_external_nat_gateway_ips"></a> [aws\_staging\_external\_nat\_gateway\_ips](#input\_aws\_staging\_external\_nat\_gateway\_ips) | An array of public IPs of the AWS staging external NAT gateways. | `list` | `[]` | no |
-| <a name="input_carrenza_draft_frontend_ips"></a> [carrenza\_draft\_frontend\_ips](#input\_carrenza\_draft\_frontend\_ips) | An array of CIDR blocks for the current environment that will allow access to draft-content-store from Carrenza. | `list` | `[]` | no |
-| <a name="input_carrenza_env_ips"></a> [carrenza\_env\_ips](#input\_carrenza\_env\_ips) | An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox. | `list` | `[]` | no |
-| <a name="input_carrenza_integration_ips"></a> [carrenza\_integration\_ips](#input\_carrenza\_integration\_ips) | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | `list` | n/a | yes |
-| <a name="input_carrenza_production_ips"></a> [carrenza\_production\_ips](#input\_carrenza\_production\_ips) | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | `list` | n/a | yes |
-| <a name="input_carrenza_rabbitmq_ips"></a> [carrenza\_rabbitmq\_ips](#input\_carrenza\_rabbitmq\_ips) | An array of CIDR blocks that will be allowed to federate with the rabbitmq nodes. | `list` | <pre>[<br>  ""<br>]</pre> | no |
-| <a name="input_carrenza_staging_ips"></a> [carrenza\_staging\_ips](#input\_carrenza\_staging\_ips) | An array of CIDR blocks that will be allowed to SSH to the jumpbox. | `list` | n/a | yes |
-| <a name="input_carrenza_vpn_subnet_cidr"></a> [carrenza\_vpn\_subnet\_cidr](#input\_carrenza\_vpn\_subnet\_cidr) | The Carrenza VPN subnet CIDR | `list` | `[]` | no |
 | <a name="input_ithc_access_ips"></a> [ithc\_access\_ips](#input\_ithc\_access\_ips) | An array of CIDR blocks that will be allowed temporary access for ITHC purposes. | `list` | `[]` | no |
 | <a name="input_office_ips"></a> [office\_ips](#input\_office\_ips) | An array of CIDR blocks that will be allowed offsite access. | `list` | n/a | yes |
 | <a name="input_paas_ireland_egress_ips"></a> [paas\_ireland\_egress\_ips](#input\_paas\_ireland\_egress\_ips) | An array of CIDR blocks that are used for egress from the GOV.UK PaaS Ireland region | `list` | `[]` | no |

--- a/terraform/projects/infra-security-groups/apt.tf
+++ b/terraform/projects/infra-security-groups/apt.tf
@@ -69,17 +69,6 @@ resource "aws_security_group_rule" "apt-external-elb_ingress_office_https" {
   cidr_blocks       = var.office_ips
 }
 
-resource "aws_security_group_rule" "apt-external-elb_ingress_carrenza_production_https" {
-  count     = "${var.aws_environment == "production" ? 1 : 0}"
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  security_group_id = "${aws_security_group.apt_external_elb.id}"
-  cidr_blocks       = var.carrenza_production_ips
-}
-
 resource "aws_security_group_rule" "apt-external-elb_ingress_fastly_https" {
   type      = "ingress"
   from_port = 443

--- a/terraform/projects/infra-security-groups/ci-master.tf
+++ b/terraform/projects/infra-security-groups/ci-master.tf
@@ -72,18 +72,6 @@ resource "aws_security_group_rule" "ci-master-elb_ingress_office_https" {
   cidr_blocks       = var.office_ips
 }
 
-# Allow Carrenza Integration and Production access to trigger automated ci-masterments
-resource "aws_security_group_rule" "ci-master-elb_ingress_carrenza_https" {
-  count     = "${var.aws_environment == "integration" ? 1 : 0}"
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  security_group_id = "${aws_security_group.ci-master_elb[0].id}"
-  cidr_blocks       = flatten(["${var.carrenza_integration_ips}", "${var.carrenza_production_ips}"])
-}
-
 resource "aws_security_group_rule" "ci-master-elb_ingress_github_https" {
   count     = "${var.aws_environment == "integration" ? 1 : 0}"
   type      = "ingress"

--- a/terraform/projects/infra-security-groups/deploy.tf
+++ b/terraform/projects/infra-security-groups/deploy.tf
@@ -67,17 +67,6 @@ resource "aws_security_group_rule" "deploy-elb_ingress_office_https" {
   cidr_blocks       = var.office_ips
 }
 
-# Allow Carrenza Integration and Production access to trigger automated deployments
-resource "aws_security_group_rule" "deploy-elb_ingress_carrenza_https" {
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  security_group_id = "${aws_security_group.deploy_elb.id}"
-  cidr_blocks       = flatten(["${var.carrenza_integration_ips}", "${var.carrenza_production_ips}"])
-}
-
 resource "aws_security_group_rule" "deploy-elb_ingress_aws_integration_access_https" {
   count     = "${(var.aws_environment == "integration") || (var.aws_environment == "staging") ? 1 : 0}"
   type      = "ingress"

--- a/terraform/projects/infra-security-groups/offsite_ssh.tf
+++ b/terraform/projects/infra-security-groups/offsite_ssh.tf
@@ -26,7 +26,7 @@ resource "aws_security_group_rule" "offsite-ssh_ingress_office-and-carrenza_ssh"
   from_port   = 22
   to_port     = 22
   protocol    = "tcp"
-  cidr_blocks = flatten(["${concat(var.office_ips, var.carrenza_production_ips, var.carrenza_staging_ips, var.ithc_access_ips)}"])
+  cidr_blocks = flatten(["${concat(var.office_ips, var.ithc_access_ips)}"])
 
   security_group_id = "${aws_security_group.offsite_ssh.id}"
 }

--- a/terraform/projects/infra-security-groups/rabbitmq.tf
+++ b/terraform/projects/infra-security-groups/rabbitmq.tf
@@ -34,18 +34,6 @@ resource "aws_security_group_rule" "rabbitmq_ingress_rabbitmq-elb_amqp" {
   source_security_group_id = "${aws_security_group.rabbitmq_elb.id}"
 }
 
-resource "aws_security_group_rule" "rabbitmq_ingress_carrenza-rabbitmq_amqp" {
-  count     = "${var.carrenza_rabbitmq_ips[0] != "" ? 1 : 0}"
-  type      = "ingress"
-  from_port = 5672
-  to_port   = 5672
-  protocol  = "tcp"
-
-  # Which security group is the rule assigned to
-  security_group_id = "${aws_security_group.rabbitmq.id}"
-  cidr_blocks       = var.carrenza_rabbitmq_ips
-}
-
 resource "aws_security_group_rule" "rabbitmq_ingress_rabbitmq-elb_rabbitmq-stomp" {
   type      = "ingress"
   from_port = 6163

--- a/terraform/projects/infra-security-groups/support-api.tf
+++ b/terraform/projects/infra-security-groups/support-api.tf
@@ -20,17 +20,6 @@ resource "aws_security_group" "support-api_external_elb" {
   }
 }
 
-resource "aws_security_group_rule" "support-api_ingress_external-elb_https" {
-  count     = "${length(var.carrenza_env_ips) > 0 ? 1 : 0}"
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  security_group_id = "${aws_security_group.support-api_external_elb.id}"
-  cidr_blocks       = var.carrenza_env_ips
-}
-
 resource "aws_security_group_rule" "support-api_egress_external_elb_any_any" {
   type              = "egress"
   from_port         = 0

--- a/terraform/projects/infra-security-groups/variables.tf
+++ b/terraform/projects/infra-security-groups/variables.tf
@@ -29,48 +29,9 @@ variable "office_ips" {
   description = "An array of CIDR blocks that will be allowed offsite access."
 }
 
-variable "carrenza_integration_ips" {
-  type        = "list"
-  description = "An array of CIDR blocks that will be allowed to SSH to the jumpbox."
-}
-
-variable "carrenza_staging_ips" {
-  type        = "list"
-  description = "An array of CIDR blocks that will be allowed to SSH to the jumpbox."
-}
-
-variable "carrenza_production_ips" {
-  type        = "list"
-  description = "An array of CIDR blocks that will be allowed to SSH to the jumpbox."
-}
-
-variable "carrenza_env_ips" {
-  type        = "list"
-  description = "An array of CIDR blocks for the current environment that will be allowed to SSH to the jumpbox."
-  default     = []
-}
-
-variable "carrenza_draft_frontend_ips" {
-  type        = "list"
-  description = "An array of CIDR blocks for the current environment that will allow access to draft-content-store from Carrenza."
-  default     = []
-}
-
-variable "carrenza_rabbitmq_ips" {
-  type        = "list"
-  description = "An array of CIDR blocks that will be allowed to federate with the rabbitmq nodes."
-  default     = [""]
-}
-
 variable "traffic_replay_ips" {
   type        = "list"
   description = "An array of CIDR blocks that will replay traffic against an environment"
-}
-
-variable "carrenza_vpn_subnet_cidr" {
-  type        = "list"
-  description = "The Carrenza VPN subnet CIDR"
-  default     = []
 }
 
 variable "paas_ireland_egress_ips" {

--- a/tools/build-terraform-project.sh
+++ b/tools/build-terraform-project.sh
@@ -63,8 +63,10 @@ echo "data dir is " $DATA_DIR
 DATA_DIR="../../../${DATA_DIR}"
 
 COMMON_DATA_DIR="${DATA_DIR}/common/${ENVIRONMENT}"
+GLOBAL_DATA_DIR="${DATA_DIR}/common"
 
 COMMON_DATA="${COMMON_DATA_DIR}/common.tfvars"
+GLOBAL_DATA="${GLOBAL_DATA_DIR}/global.tfvars"
 SECRET_COMMON_DATA="${COMMON_DATA_DIR}/common.secret.tfvars"
 STACK_COMMON_DATA="${COMMON_DATA_DIR}/${STACKNAME}.tfvars"
 
@@ -104,7 +106,8 @@ elif [[ $CMD == "init" ]] && [[ ! -f $PROJECT_DIR/$BACKEND_FILE ]]; then
 elif [[ ! -f $PROJECT_DIR/$STACK_COMMON_DATA ]] && \
      [[ ! -f $PROJECT_DIR/$STACK_PROJECT_DATA ]] && \
      [[ ! -f $PROJECT_DIR/$SECRET_PROJECT_DATA ]] && \
-     [[ ! -f $PROJECT_DIR/$COMMON_DATA ]]  && \
+     [[ ! -f $PROJECT_DIR/$COMMON_DATA ]] && \
+     [[ ! -f $PROJECT_DIR/$GLOBAL_DATA ]] && \
      [[ ! -f $PROJECT_DIR/$SECRET_COMMON_PROJECT_DATA ]]  && \
      [[ ! -f $PROJECT_DIR/$COMMON_PROJECT_DATA ]]; then
   log_error 'Could not find any tfvar files. Looked for:\n' \
@@ -112,6 +115,7 @@ elif [[ ! -f $PROJECT_DIR/$STACK_COMMON_DATA ]] && \
             "\t$PROJECT_DIR/$STACK_PROJECT_DATA \n " \
             "\t$PROJECT_DIR/$SECRET_PROJECT_DATA \n " \
             "\t$PROJECT_DIR/$COMMON_DATA\n " \
+            "\t$PROJECT_DIR/$GLOBAL_DATA\n " \
             "\t$PROJECT_DIR/$SECRET_COMMON_PROJECT_DATA\n " \
             "\t$PROJECT_DIR/$COMMON_PROJECT_DATA"
 fi
@@ -146,6 +150,7 @@ function init() {
 TO_RUN="init && terraform $CMD"
 # Append which ever tfvar files exist
 for TFVAR_FILE in "$COMMON_DATA" \
+                  "$GLOBAL_DATA" \
                   "$SECRET_COMMON_DATA" \
                   "$STACK_COMMON_DATA" \
                   "$COMMON_PROJECT_DATA" \


### PR DESCRIPTION
We haven't had anything running in Carrenza/6degrees for years now.

Goes with https://github.com/alphagov/govuk-aws-data/pull/1253

Tested: applied in staging (see other PR for example plan output).