### PR TITLE
Improve DGU Fastly cache hit rate

### DIFF
--- a/terraform/projects/fastly-datagovuk/datagovuk.vcl
+++ b/terraform/projects/fastly-datagovuk/datagovuk.vcl
@@ -21,6 +21,17 @@ sub vcl_recv {
     error 403 "Forbidden";
   }
 
+  # Remove any Google Analytics campaign params
+  set req.url = querystring.globfilter(req.url, "utm_*");
+
+  # Sort query params (improve cache hit rate)
+  set req.url = querystring.sort(req.url);
+
+  if (req.url.path == "/") {
+    # get rid of all query parameters
+    set req.url = querystring.remove(req.url);
+  }
+
   if (req.method != "HEAD" && req.method != "GET" && req.method != "FASTLYPURGE") {
     return(pass);
   }


### PR DESCRIPTION
Remove UTM query params as they have little effect on the backend.

Sort remaining query params so that the resulting URL has a greater chance of being cacheable/retrievable from cache.

Discard query params from the home page. The home page doesn't respond to query params, so there's little point in accepting them at the origin.