### PR TITLE
Add rule to `cache_public` ACL to block requests made via `*.cloudfront.net` URLs

### DIFF
--- a/terraform/projects/infra-public-wafs/cache_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/cache_public_rule.tf
@@ -199,6 +199,45 @@ resource "aws_wafv2_web_acl" "cache_public" {
     }
   }
 
+  # Block access via *.cloudfront.net URLs
+  rule {
+    name     = "block-cloudfront-urls"
+    priority = 6
+
+    action {
+      count {
+        custom_request_handling {
+          insert_header {
+            name  = "blocked"
+            value = "true"
+          }
+        }
+      }
+    }
+
+    statement {
+      byte_match_statement {
+        field_to_match {
+          single_header {
+            name = "host"
+          }
+        }
+        positional_constraint = "ENDS_WITH"
+        search_string         = "cloudfront.net"
+        text_transformation {
+          priority = 1
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "cache-public-block-cloudfront-urls"
+      sampled_requests_enabled   = true
+    }
+  }
+
   custom_response_body {
     key     = "cache-public-rule-429"
     content = <<HTML


### PR DESCRIPTION
[Trello card](https://trello.com/c/e9mH3LBJ/3295-lock-down-public-access-to-govuks-cloudfront-distributions)

We only want our CloudFront distributions to be accessible via GOV.UK's canonical URLs (e.g. `www.gov.uk`, `assets.publishing.service.gov.uk`), and not via their CloudFront domain names (e.g. `d2uru0rbwu9sz0.cloudfront.net` and `d3d1psggl6xqso.cloudfront.net`).

The easiest way to achieve this is to add a rule to the `cache_public` WAF ACL to block requests where the `Host` header ends with "cloudfront.net". This ACL is applied to both the `www-origin` and `assets-origin` load balancers.