### PR TITLE
Upgrade terraform version for Fastly DGU

### DIFF
--- a/terraform/projects/fastly-datagovuk/README.md
+++ b/terraform/projects/fastly-datagovuk/README.md
@@ -6,7 +6,7 @@ Manages the Fastly service for data.gov.uk
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 0.11.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 0.12.30 |
 | <a name="requirement_fastly"></a> [fastly](#requirement\_fastly) | ~> 0.26.0 |
 
 ## Providers

--- a/terraform/projects/fastly-datagovuk/main.tf
+++ b/terraform/projects/fastly-datagovuk/main.tf
@@ -48,7 +48,7 @@ variable "backend_domain" {
 # --------------------------------------------------------------
 terraform {
   backend "s3" {}
-  required_version = "= 0.11.15"
+  required_version = "= 0.12.30"
 }
 
 provider "fastly" {

--- a/terraform/projects/fastly-datagovuk/main.tf
+++ b/terraform/projects/fastly-datagovuk/main.tf
@@ -4,43 +4,43 @@
 * Manages the Fastly service for data.gov.uk
 */
 variable "aws_region" {
-  type        = "string"
+  type        = string
   description = "AWS region"
   default     = "eu-west-1"
 }
 
 variable "stackname" {
-  type        = "string"
+  type        = string
   description = "Stackname"
 }
 
 variable "aws_environment" {
-  type        = "string"
+  type        = string
   description = "AWS Environment"
 }
 
 variable "fastly_api_key" {
-  type        = "string"
+  type        = string
   description = "API key to authenticate with Fastly"
 }
 
 variable "logging_aws_access_key_id" {
-  type        = "string"
+  type        = string
   description = "IAM key ID with access to put logs into the S3 bucket"
 }
 
 variable "logging_aws_secret_access_key" {
-  type        = "string"
+  type        = string
   description = "IAM secret key with access to put logs into the S3 bucket"
 }
 
 variable "domain" {
-  type        = "string"
+  type        = string
   description = "The domain of the data.gov.uk service to manage"
 }
 
 variable "backend_domain" {
-  type        = "string"
+  type        = string
   description = "The domain of the data.gov.uk PaaS instance to forward requests to"
 }
 
@@ -52,7 +52,7 @@ terraform {
 }
 
 provider "fastly" {
-  api_key = "${var.fastly_api_key}"
+  api_key = var.fastly_api_key
   version = "~> 0.26.0"
 }
 
@@ -64,7 +64,7 @@ resource "fastly_service_v1" "datagovuk" {
   name = "${title(var.aws_environment)} data.gov.uk"
 
   domain {
-    name = "${var.domain}"
+    name = var.domain
   }
 
   domain {
@@ -73,7 +73,7 @@ resource "fastly_service_v1" "datagovuk" {
 
   backend {
     name               = "cname ${var.backend_domain}"
-    address            = "${var.backend_domain}"
+    address            = var.backend_domain
     port               = "443"
     use_ssl            = true
     auto_loadbalance   = false
@@ -105,7 +105,7 @@ resource "fastly_service_v1" "datagovuk" {
 
   vcl {
     name    = "datagovuk_vcl"
-    content = "${file(data.external.fastly.result.fastly)}"
+    content = file(data.external.fastly.result.fastly)
     main    = true
   }
 
@@ -173,7 +173,7 @@ resource "fastly_service_v1" "datagovuk" {
 
   s3logging {
     # Apache log format documentation: https://www.loggly.com/ultimate-guide/apache-logging-basics/
-    format = "${join("\t",
+    format = join("\t",
       [
         "%h",
         "%%{%Y-%m-%d %H:%M:%S}t.%%{msec_frac}t",
@@ -186,7 +186,7 @@ resource "fastly_service_v1" "datagovuk" {
         "%\"Referer\"i",
         "%\"User-Agent\"i",
       ]
-    )}"
+    )
     bucket_name        = "govuk-${var.aws_environment}-fastly-logs"
     domain             = "s3-eu-west-1.amazonaws.com"
     format_version     = "2"
@@ -197,8 +197,8 @@ resource "fastly_service_v1" "datagovuk" {
     period             = "600"
     redundancy         = "standard"
     response_condition = ""
-    s3_access_key      = "${var.logging_aws_access_key_id}"
-    s3_secret_key      = "${var.logging_aws_secret_access_key}"
+    s3_access_key      = var.logging_aws_access_key_id
+    s3_secret_key      = var.logging_aws_secret_access_key
     timestamp_format   = ""
   }
 

--- a/terraform/projects/fastly-datagovuk/main.tf
+++ b/terraform/projects/fastly-datagovuk/main.tf
@@ -173,20 +173,7 @@ resource "fastly_service_v1" "datagovuk" {
 
   s3logging {
     # Apache log format documentation: https://www.loggly.com/ultimate-guide/apache-logging-basics/
-    format = join("\t",
-      [
-        "%h",
-        "%%{%Y-%m-%d %H:%M:%S}t.%%{msec_frac}t",
-        "%m",
-        "%U%q",
-        "%>s",
-        "%B",
-        "%%{tls.client.protocol}V",
-        "${fastly_info.state}V",
-        "%\"Referer\"i",
-        "%\"User-Agent\"i",
-      ]
-    )
+    format             = "%h\\t%%{%Y-%m-%d %H:%M:%S}t.%%{msec_frac}t\\t%m\\t%U%q\\t%>s\\t%B\\t%%{tls.client.protocol}V\\t%%{fastly_info.state}V\\t%%{Referer}i\\t%%{User-Agent}i"
     bucket_name        = "govuk-${var.aws_environment}-fastly-logs"
     domain             = "s3-eu-west-1.amazonaws.com"
     format_version     = "2"

--- a/terraform/projects/fastly-datagovuk/remote_state.tf
+++ b/terraform/projects/fastly-datagovuk/remote_state.tf
@@ -53,7 +53,7 @@ variable "remote_state_infra_monitoring_key_stack" {
 data "terraform_remote_state" "infra_vpc" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
     region = "${var.aws_region}"
@@ -63,7 +63,7 @@ data "terraform_remote_state" "infra_vpc" {
 data "terraform_remote_state" "infra_networking" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
     region = "${var.aws_region}"
@@ -73,7 +73,7 @@ data "terraform_remote_state" "infra_networking" {
 data "terraform_remote_state" "infra_security_groups" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_security_groups_key_stack, var.stackname)}/infra-security-groups.tfstate"
     region = "${var.aws_region}"
@@ -83,7 +83,7 @@ data "terraform_remote_state" "infra_security_groups" {
 data "terraform_remote_state" "infra_root_dns_zones" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
     region = "${var.aws_region}"
@@ -93,7 +93,7 @@ data "terraform_remote_state" "infra_root_dns_zones" {
 data "terraform_remote_state" "infra_stack_dns_zones" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_stack_dns_zones_key_stack, var.stackname)}/infra-stack-dns-zones.tfstate"
     region = "${var.aws_region}"
@@ -103,7 +103,7 @@ data "terraform_remote_state" "infra_stack_dns_zones" {
 data "terraform_remote_state" "infra_monitoring" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "${var.remote_state_bucket}"
     key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
     region = "${var.aws_region}"

--- a/terraform/projects/fastly-datagovuk/remote_state.tf
+++ b/terraform/projects/fastly-datagovuk/remote_state.tf
@@ -7,42 +7,42 @@
 */
 
 variable "remote_state_bucket" {
-  type        = "string"
+  type        = string
   description = "S3 bucket we store our terraform state in"
 }
 
 variable "remote_state_infra_vpc_key_stack" {
-  type        = "string"
+  type        = string
   description = "Override infra_vpc remote state path"
   default     = ""
 }
 
 variable "remote_state_infra_networking_key_stack" {
-  type        = "string"
+  type        = string
   description = "Override infra_networking remote state path"
   default     = ""
 }
 
 variable "remote_state_infra_security_groups_key_stack" {
-  type        = "string"
+  type        = string
   description = "Override infra_security_groups stackname path to infra_vpc remote state "
   default     = ""
 }
 
 variable "remote_state_infra_root_dns_zones_key_stack" {
-  type        = "string"
+  type        = string
   description = "Override stackname path to infra_root_dns_zones remote state "
   default     = ""
 }
 
 variable "remote_state_infra_stack_dns_zones_key_stack" {
-  type        = "string"
+  type        = string
   description = "Override stackname path to infra_stack_dns_zones remote state "
   default     = ""
 }
 
 variable "remote_state_infra_monitoring_key_stack" {
-  type        = "string"
+  type        = string
   description = "Override stackname path to infra_monitoring remote state "
   default     = ""
 }


### PR DESCRIPTION
It's not possible to plan/apply infrastructure changes in this project as we are now using Terraform version 0.12. 

Running a Terraform `plan` threw this error:
```
Error: Unsupported Terraform Core version

This configuration does not support Terraform version 0.12.30. To proceed,
either choose another supported Terraform version or update the root module's
version constraint. Version constraints are normally set for good reason, so
updating the constraint may lead to other errors or unexpected behavior.
```

The new changes have been tested running a `plan` - see the [console output ](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/5403/console)

Trello card: https://trello.com/c/lN55wEjL/3289-finish-retiring-contracts-finder-archive-3