### PR TITLE
Remove proxy for the Contracts Finder Archive

### DIFF
--- a/terraform/projects/fastly-datagovuk/main.tf
+++ b/terraform/projects/fastly-datagovuk/main.tf
@@ -92,17 +92,6 @@ resource "fastly_service_v1" "datagovuk" {
     request_condition  = "education_standards"
   }
 
-  backend {
-    name               = "cname contracts-finder-archive"
-    address            = "34.249.103.20"
-    port               = "80"
-    use_ssl            = false
-    auto_loadbalance   = false
-    first_byte_timeout = 120000
-    ssl_check_cert     = false
-    request_condition  = "contracts_finder_archive"
-  }
-
   vcl {
     name    = "datagovuk_vcl"
     content = file(data.external.fastly.result.fastly)
@@ -131,39 +120,6 @@ resource "fastly_service_v1" "datagovuk" {
     destination       = "http.host"
     source            = "\"dfe-app1.codeenigma.net\""
     request_condition = "education_standards"
-  }
-
-  condition {
-    name      = "contracts_finder_archive"
-    type      = "REQUEST"
-    statement = "req.url ~ \"^/data/contracts-finder-archive\""
-  }
-
-  header {
-    name              = "contracts_finder_archive_url"
-    action            = "set"
-    type              = "request"
-    destination       = "url"
-    source            = "regsub(req.url, \"^/data/contracts-finder-archive\", \"\")"
-    request_condition = "contracts_finder_archive"
-  }
-
-  header {
-    name              = "contracts_finder_archive_host"
-    action            = "set"
-    type              = "request"
-    destination       = "http.host"
-    source            = "\"34.249.103.20\""
-    request_condition = "contracts_finder_archive"
-  }
-
-  header {
-    name              = "contracts_finder_archive_script_name"
-    action            = "set"
-    type              = "request"
-    destination       = "http.X-Script-Name"
-    source            = "\"/data/contracts-finder-archive\""
-    request_condition = "contracts_finder_archive"
   }
 
   request_setting {


### PR DESCRIPTION
We are retiring the service and deleting the [DGU AWS account](https://dgu.signin.aws.amazon.com/console) it lives in. The instance is not running and is unavailable.

The new changes have been tested running a plan - see the [console output](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/5409/console)

Trello card: https://trello.com/c/lN55wEjL/3289-finish-retiring-contracts-finder-archive-3

