### PR TITLE
Set up RabbitMQ for `search-api-v2`

### DIFF
--- a/terraform/projects/app-publishing-amazonmq/README.md
+++ b/terraform/projects/app-publishing-amazonmq/README.md
@@ -61,6 +61,7 @@ No modules.
 | [random_password.publishing_api](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.root](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.search_api](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.search_api_v2](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [archive_file.artefact_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_acm_certificate.internal_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
 | [aws_iam_policy.lambda_vpc_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |

--- a/terraform/projects/app-publishing-amazonmq/main.tf
+++ b/terraform/projects/app-publishing-amazonmq/main.tf
@@ -49,6 +49,10 @@ resource "random_password" "search_api" {
   length  = 24
   special = false
 }
+resource "random_password" "search_api_v2" {
+  length  = 24
+  special = false
+}
 resource "random_password" "content_data_api" {
   length  = 24
   special = false
@@ -64,6 +68,7 @@ locals {
     monitoring          = random_password.monitoring.result
     publishing_api      = random_password.publishing_api.result
     search_api          = random_password.search_api.result
+    search_api_v2       = random_password.search_api_v2.result
     content_data_api    = random_password.content_data_api.result
     email_alert_service = random_password.email_alert_service.result
   }

--- a/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
+++ b/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
@@ -25,6 +25,11 @@
       "name": "search_api",
       "password": "${publishing_amazonmq_passwords["search_api"]}",
       "tags": ""
+    },
+    {
+      "name": "search_api_v2",
+      "password": "${publishing_amazonmq_passwords["search_api_v2"]}",
+      "tags": ""
     }
   ],
   "vhosts": [
@@ -53,6 +58,13 @@
       "configure": "^(amq\\.gen.*|search_api_to_be_indexed|search_api_govuk_index)$",
       "write": "^(amq\\.gen.*|search_api_to_be_indexed|search_api_govuk_index)$",
       "read": "^(amq\\.gen.*|search_api_to_be_indexed|search_api_govuk_index|search_api_bulk_reindex|published_documents)$"
+    },
+    {
+      "user": "search_api_v2",
+      "vhost": "publishing",
+      "configure": "^(amq\\.gen.*|search_api_v2_published_documents)$",
+      "write": "^(amq\\.gen.*|search_api_v2_published_documents)$",
+      "read": "^(amq\\.gen.*|search_api_v2_published_documents|published_documents)$"
     },
     {
       "user": "monitoring",
@@ -173,6 +185,13 @@
       "arguments": {}
     },
     {
+      "name": "search_api_v2_published_documents",
+      "vhost": "publishing",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    },
+    {
       "name": "email_unpublishing",
       "vhost": "publishing",
       "durable": true,
@@ -213,6 +232,14 @@
       "source": "published_documents",
       "vhost": "publishing",
       "destination": "search_api_govuk_index",
+      "destination_type": "queue",
+      "routing_key": "*.*",
+      "arguments": {}
+    },
+    {
+      "source": "published_documents",
+      "vhost": "publishing",
+      "destination": "search_api_v2_published_documents",
       "destination_type": "queue",
       "routing_key": "*.*",
       "arguments": {}


### PR DESCRIPTION
- Add a new RabbitMQ user for `search-api-v2` with relevant permissions
- Add a `search_api_v2_published_documents` queue and binding to the `published_documents` exchange