### PR TITLE
Refactor fastly-datagovuk to standard structure

### DIFF
--- a/terraform/projects/fastly-datagovuk/main.tf
+++ b/terraform/projects/fastly-datagovuk/main.tf
@@ -3,46 +3,6 @@
 *
 * Manages the Fastly service for data.gov.uk
 */
-variable "aws_region" {
-  type        = string
-  description = "AWS region"
-  default     = "eu-west-1"
-}
-
-variable "stackname" {
-  type        = string
-  description = "Stackname"
-}
-
-variable "aws_environment" {
-  type        = string
-  description = "AWS Environment"
-}
-
-variable "fastly_api_key" {
-  type        = string
-  description = "API key to authenticate with Fastly"
-}
-
-variable "logging_aws_access_key_id" {
-  type        = string
-  description = "IAM key ID with access to put logs into the S3 bucket"
-}
-
-variable "logging_aws_secret_access_key" {
-  type        = string
-  description = "IAM secret key with access to put logs into the S3 bucket"
-}
-
-variable "domain" {
-  type        = string
-  description = "The domain of the data.gov.uk service to manage"
-}
-
-variable "backend_domain" {
-  type        = string
-  description = "The domain of the data.gov.uk PaaS instance to forward requests to"
-}
 
 # Resources
 # --------------------------------------------------------------

--- a/terraform/projects/fastly-datagovuk/variables.tf
+++ b/terraform/projects/fastly-datagovuk/variables.tf
@@ -1,0 +1,40 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "stackname" {
+  type        = string
+  description = "Stackname"
+}
+
+variable "aws_environment" {
+  type        = string
+  description = "AWS Environment"
+}
+
+variable "fastly_api_key" {
+  type        = string
+  description = "API key to authenticate with Fastly"
+}
+
+variable "logging_aws_access_key_id" {
+  type        = string
+  description = "IAM key ID with access to put logs into the S3 bucket"
+}
+
+variable "logging_aws_secret_access_key" {
+  type        = string
+  description = "IAM secret key with access to put logs into the S3 bucket"
+}
+
+variable "domain" {
+  type        = string
+  description = "The domain of the data.gov.uk service to manage"
+}
+
+variable "backend_domain" {
+  type        = string
+  description = "The domain of the data.gov.uk PaaS instance to forward requests to"
+}


### PR DESCRIPTION
The variables now sit in variables.tf, as covered in https://developer.hashicorp.com/terraform/language/modules/develop/structure

I've tested the changed with a [plan](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/5453/console) and the output looks fine.