### PR TITLE
Make infra-security module deployable again.

### DIFF
--- a/terraform/modules/aws/iam/gds_user_role/README.md
+++ b/terraform/modules/aws/iam/gds_user_role/README.md
@@ -30,7 +30,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_office_ips"></a> [office\_ips](#input\_office\_ips) | An array of CIDR blocks that will be allowed offsite access. | `list` | n/a | yes |
+| <a name="input_office_ips"></a> [office\_ips](#input\_office\_ips) | DEPRECATED: list of trusted CIDR netblocks | `list(string)` | `[]` | no |
 | <a name="input_restrict_to_gds_ips"></a> [restrict\_to\_gds\_ips](#input\_restrict\_to\_gds\_ips) | n/a | `bool` | `false` | no |
 | <a name="input_role_policy_arns"></a> [role\_policy\_arns](#input\_role\_policy\_arns) | List of ARNs of policies to attach to the role | `list` | `[]` | no |
 | <a name="input_role_suffix"></a> [role\_suffix](#input\_role\_suffix) | Suffix of the role name | `string` | n/a | yes |

--- a/terraform/modules/aws/iam/gds_user_role/main.tf
+++ b/terraform/modules/aws/iam/gds_user_role/main.tf
@@ -30,8 +30,9 @@ variable "restrict_to_gds_ips" {
 }
 
 variable "office_ips" {
-  type        = list
-  description = "An array of CIDR blocks that will be allowed offsite access."
+  type        = list(string)
+  description = "DEPRECATED: list of trusted CIDR netblocks"
+  default     = []
 }
 
 # Resources


### PR DESCRIPTION
Looks like this root module broke when a variable was removed in fc66fe83, but the iam/gds_user_role module required a value for that variable even though it wasn't in use.

Tested: plans locally, null diff.