### PR TITLE
Add licensify frontend waf rate limit

### DIFF
--- a/terraform/projects/infra-public-wafs/licensify_frontend_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/licensify_frontend_public_rule.tf
@@ -1,0 +1,193 @@
+resource "aws_wafv2_web_acl" "licensify_frontend_public" {
+  name  = "licensify_frontend_public_web_acl"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  # this rule matches any request that contains the header X-Always-Block: true
+  # we use it as a simple sanity check / acceptance test from smokey to ensure that
+  # the waf is enabled and processing requests
+  rule {
+    name     = "x-always-block_web_acl_rule"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      rule_group_reference_statement {
+        arn = aws_wafv2_rule_group.x_always_block.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "x-always-block-rule-group"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # this rule matches any request from our NAT gateway IPs and allows it.
+  rule {
+    name     = "allow-govuk-infra"
+    priority = 2
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.govuk_requesting_ips.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "govuk-infra-frontend-requests"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # This rule is intended for monitoring only
+  # set a base rate limit per IP looking back over the last 5 minutes
+  # this is checked every 30s
+  rule {
+    name     = "licensify-frontend-public-base-rate-warning"
+    priority = 9
+
+    action {
+      count {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.licensify_frontend_public_base_rate_warning
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "licensify-frontend-public-base-rate-warning"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # set a base rate limit per IP looking back over the last 5 minutes
+  # this is checked every 30s
+  rule {
+    name     = "licensify-frontend-public-base-rate-limit"
+    priority = 10
+
+    action {
+      count {}
+      # TODO: remove the above `count {}` statement and uncomment the below `block { ... }`
+      # statement once we're happy
+      #
+      # block {
+      #   custom_response {
+      #     response_code = 429
+
+      #     response_header {
+      #       name  = "Retry-After"
+      #       value = 30
+      #     }
+
+      #     response_header {
+      #       name  = "Cache-Control"
+      #       value = "max-age=0, private"
+      #     }
+
+      #     custom_response_body_key = "frontend-public-rule-429"
+      #   }
+      # }
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.licensify_frontend_public_base_rate_limit
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "licensify-frontend-public-base-rate-limit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  custom_response_body {
+    key     = "frontend-public-rule-429"
+    content = <<HTML
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>Sorry, there have been too many attempts to access this page.</p>
+          <p>Try again in a few minutes.</p>
+        </body>
+      </html>
+      HTML
+
+    content_type = "TEXT_HTML"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "licensify-frontend-public-web-acl"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_cloudwatch_log_group" "licensify_frontend_public_waf" {
+  # the name must start with aws-waf-logs
+  # https://docs.aws.amazon.com/waf/latest/developerguide/logging-cw-logs.html#logging-cw-logs-naming
+  name              = "aws-waf-logs-licensify-frontend-public-${var.aws_environment}"
+  retention_in_days = var.waf_log_retention_days
+
+  tags = {
+    Project       = var.stackname
+    aws_stackname = var.stackname
+  }
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "licensify_frontend_public_waf" {
+  log_destination_configs = [aws_cloudwatch_log_group.licensify_frontend_public_waf.arn]
+  resource_arn            = aws_wafv2_web_acl.licensify_frontend_public.arn
+
+  logging_filter {
+    default_behavior = "DROP"
+
+    filter {
+      behavior = "KEEP"
+
+      condition {
+        action_condition {
+          action = "COUNT"
+        }
+      }
+
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+
+      requirement = "MEETS_ANY"
+    }
+  }
+}

--- a/terraform/projects/infra-public-wafs/standard_config.tf
+++ b/terraform/projects/infra-public-wafs/standard_config.tf
@@ -47,7 +47,7 @@ resource "aws_shield_protection" "licensify_frontend_public_lb" {
 
 resource "aws_wafv2_web_acl_association" "licensify_frontend_web_acl" {
   resource_arn = data.terraform_remote_state.infra_public_services.outputs.licensify_frontend_public_lb_id
-  web_acl_arn  = aws_wafv2_web_acl.default.arn
+  web_acl_arn  = aws_wafv2_web_acl.licensify_frontend_public.arn
 }
 
 resource "aws_shield_protection" "monitoring_public_lb" {

--- a/terraform/projects/infra-public-wafs/variables.tf
+++ b/terraform/projects/infra-public-wafs/variables.tf
@@ -85,6 +85,16 @@ variable "licensify_backend_public_base_rate_limit" {
   description = "For the licensify backend ALB. Number of requests to allow in a 5 minute period before rate limiting is applied."
 }
 
+variable "licensify_frontend_public_base_rate_warning" {
+  type        = number
+  description = "For the licensify frontend ALB. Allows us to configure a warning level to detect what happens if we reduce the limit."
+}
+
+variable "licensify_frontend_public_base_rate_limit" {
+  type        = number
+  description = "For the licensify frontend ALB. Number of requests to allow in a 5 minute period before rate limiting is applied."
+}
+
 variable "traffic_replay_ips" {
   type        = list(string)
   description = "An array of CIDR blocks that will replay traffic against an environment"


### PR DESCRIPTION
This is mostly copied from the cache_public WAF.

We retain the x-always-block rule. This is the easiest way for Smokey to determine
that a WAF is applied.

We keep a warning/count rate limit rule.

We'll set the "blocking" rule to count for now while we confirm that the rest works as
expected.

For the rules we retain we do not need to parse the True-Client-IP header to
identify the IP of the client. We have therefore switched aggregate key types
from "FORWARDED_IP" (with some additional configuration) to "IP". The different
rules have slightly different ways of configuring this:

[rate based statement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl.html#rate-based-statement)
[IP set reference statement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl.html#ip-set-reference-statement)

Trello: https://trello.com/c/RkCyn4Ot/3178-create-waf-for-the-licensify-frontend-public-load-balancer-3