### PR TITLE
Remove outdated warning

### DIFF
--- a/terraform/projects/app-publishing-amazonmq/README.md
+++ b/terraform/projects/app-publishing-amazonmq/README.md
@@ -6,10 +6,6 @@ It uses remote state from the infra-vpc and infra-security-groups modules.
 The Terraform provider will only allow us to create a single user, so all
 other users must be added from the RabbitMQ web admin UI or REST API.
 
-DO NOT USE IN PRODUCTION YET - this version is integration-only, as it
-implicitly assumes a single instance, and will need reworking for a
-highly-available cluster setup
-
 ## Requirements
 
 | Name | Version |

--- a/terraform/projects/app-publishing-amazonmq/main.tf
+++ b/terraform/projects/app-publishing-amazonmq/main.tf
@@ -6,10 +6,6 @@
  *
  * The Terraform provider will only allow us to create a single user, so all 
  * other users must be added from the RabbitMQ web admin UI or REST API.
- * 
- * DO NOT USE IN PRODUCTION YET - this version is integration-only, as it
- * implicitly assumes a single instance, and will need reworking for a 
- * highly-available cluster setup 
  */
 terraform {
   backend "s3" {}


### PR DESCRIPTION
Quoth @aldavidson: "This is outdated and should be removed, as the TF was used in production 6 months ago".

[Trello](https://trello.com/c/lZp7YWgu/837-remove-the-do-not-use-in-production-yet-warning-from-the-amazonmq-terraform-projects-readme)