### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: terraform
+  directory: "/"
+  schedule:
+    interval: daily
+# We exclude pip because our Python-based lambdas in /terraform/lambda are not tested as part of CI


### PR DESCRIPTION
By default Dependabot is raising PRs to update the pip dependencies for our lambdas. These lambdas are not tested as part of CI, and deploying them involves an additional build step which is not automated. For these reasons, I don't think it's appropriate for Dependabot to raise PRs for them.

This commit adds a Dependabot config that excludes pip.