### PR TITLE
Add binding for search-api-v2 bulk sync

### DIFF
--- a/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
+++ b/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
@@ -247,6 +247,14 @@
     {
       "source": "published_documents",
       "vhost": "publishing",
+      "destination": "search_api_v2_published_documents",
+      "destination_type": "queue",
+      "routing_key": "*.bulk.search_api_v2_sync",
+      "arguments": {}
+    },
+    {
+      "source": "published_documents",
+      "vhost": "publishing",
       "destination": "content_data_api_govuk_importer",
       "destination_type": "queue",
       "routing_key": "*.bulk.data-warehouse",


### PR DESCRIPTION
Like the existing functionality in `search-api`, we want to add the
ability to enqueue a "bulk reindex/sync" for `search-api-v2`. This
deliberately listens to a different routing key from `search-api` to
avoid pointlessly reindexing documents there as part of any v2 work, and
uses the same queue as regular indexing for simplicity.