### PR TITLE
Switch from rds-ca-2019 to rds-ca-rsa2048-g1.

### DIFF
--- a/terraform/projects/app-govuk-rds/rds.tf
+++ b/terraform/projects/app-govuk-rds/rds.tf
@@ -43,6 +43,7 @@ resource "aws_db_instance" "instance" {
   monitoring_interval     = 60
   monitoring_role_arn     = data.terraform_remote_state.infra_monitoring.outputs.rds_enhanced_monitoring_role_arn
   vpc_security_group_ids  = [aws_security_group.rds[each.key].id]
+  ca_cert_identifier      = "rds-ca-rsa2048-g1"
   apply_immediately       = var.aws_environment != "production"
 
   performance_insights_enabled          = true


### PR DESCRIPTION
Context: https://aws.amazon.com/blogs/aws/rotate-your-ssl-tls-certificates-now-amazon-rds-and-amazon-aurora-expire-in-2024/

Tested: applied in staging, no sign of any apps failing to talk to databases, app probes all passing etc.