### PR TITLE
Make RDS Perf Insights configurable per instance.

### DIFF
--- a/terraform/projects/app-govuk-rds/rds.tf
+++ b/terraform/projects/app-govuk-rds/rds.tf
@@ -46,8 +46,8 @@ resource "aws_db_instance" "instance" {
   ca_cert_identifier      = "rds-ca-rsa2048-g1"
   apply_immediately       = var.aws_environment != "production"
 
-  performance_insights_enabled          = true
-  performance_insights_retention_period = 7
+  performance_insights_enabled          = each.value.performance_insights_enabled
+  performance_insights_retention_period = each.value.performance_insights_enabled ? 7 : 0
 
   timeouts {
     create = var.terraform_create_rds_timeout


### PR DESCRIPTION
Mostly for https://github.com/alphagov/govuk-aws-data/pull/1272 so we can use micro instances for some databases that are really tiny (and quiet).

Tested: applied in integration and staging, plans cleanly in prod.