### PR TITLE
Allow integration and staging access to prod S3

### DIFF
--- a/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
@@ -60,7 +60,10 @@ resource "aws_s3_bucket_cors_configuration" "datagovuk_organogram" {
     allowed_origins = [
       var.domain,
       "https://staging.data.gov.uk",
-      "https://find.eks.${var.aws_environment}.govuk.digital"
+      "https://integration.data.gov.uk",
+      "https://find.eks.production.govuk.digital",
+      "https://find.eks.integration.govuk.digital",
+      "https://find.eks.staging.govuk.digital"
     ]
   }
 }


### PR DESCRIPTION
This is because when the data is synced between production and other environments, any organograms uploaded are referred to on the production s3 bucket which is not currently synced between environments.

## Reference

https://trello.com/c/2qXYzZYb/1239-switchover-paas-apps-to-k8s-cluster