### PR TITLE
Allow access to DGU buckets from www.{environment}

### DIFF
--- a/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
+++ b/terraform/projects/infra-datagovuk-organogram-bucket/main.tf
@@ -59,8 +59,8 @@ resource "aws_s3_bucket_cors_configuration" "datagovuk_organogram" {
     allowed_methods = ["GET"]
     allowed_origins = [
       var.domain,
-      "https://staging.data.gov.uk",
-      "https://integration.data.gov.uk",
+      "https://www.staging.data.gov.uk",
+      "https://www.integration.data.gov.uk",
       "https://find.eks.production.govuk.digital",
       "https://find.eks.integration.govuk.digital",
       "https://find.eks.staging.govuk.digital"


### PR DESCRIPTION
As all requests to data.gov.uk get re-routed to www, update the allowed_origins to reflect this

## Reference 

https://trello.com/c/2qXYzZYb/1239-switchover-paas-apps-to-k8s-cluster