### PR TITLE
Move protocol column to the end of the list

### DIFF
--- a/terraform/projects/infra-fastly-logs/main.tf
+++ b/terraform/projects/infra-fastly-logs/main.tf
@@ -248,11 +248,6 @@ resource "aws_glue_catalog_table" "govuk_www" {
       comment = "HTTP status code returned"
     }
     columns {
-      name    = "protocol"
-      type    = "string"
-      comment = "HTTP version used"
-    }
-    columns {
       name    = "request_time"
       type    = "double"
       comment = "Time until user received full response in seconds"
@@ -308,6 +303,11 @@ resource "aws_glue_catalog_table" "govuk_www" {
     columns {
       name = "client_ja3"
       type = "string"
+    }
+    columns {
+      name    = "protocol"
+      type    = "string"
+      comment = "HTTP version used"
     }
   }
 
@@ -442,11 +442,6 @@ resource "aws_glue_catalog_table" "govuk_assets" {
       comment = "HTTP status code returned"
     }
     columns {
-      name    = "protocol"
-      type    = "string"
-      comment = "HTTP version used"
-    }
-    columns {
       name    = "request_time"
       type    = "double"
       comment = "Time until user received full response in seconds"
@@ -502,6 +497,11 @@ resource "aws_glue_catalog_table" "govuk_assets" {
     columns {
       name = "client_ja3"
       type = "string"
+    }
+    columns {
+      name    = "protocol"
+      type    = "string"
+      comment = "HTTP version used"
     }
   }
 


### PR DESCRIPTION
Terraform identifies these columns by their position in the list, so if we add a new one in the middle of the list it ends up renaming all the subsequent columns (so request_time gets renamed to be protocol, and so on), before adding a new column for the last one in the list.

This is not what we want, and it causes problems for Athena, which gets confused about the types of columns.

We can make our lives a lot easier by just adding the column to the end of the list, so terraform will just add the one we want.