### PR TITLE
`poweruser` roles should only allow rotating the user's own keys.

### DIFF
--- a/terraform/projects/infra-security/main.tf
+++ b/terraform/projects/infra-security/main.tf
@@ -260,9 +260,7 @@ data "aws_iam_policy_document" "allow-iam-key-rotation" {
       "iam:ListAccessKeys",
       "iam:UpdateAccessKey",
     ]
-
-    effect    = "Allow"
-    resources = ["*"]
+    resources = ["arn:aws:iam::*:user/&{aws:username}"]
   }
 }
 


### PR DESCRIPTION
This came out of a [recent security review](https://docs.google.com/document/d/1B2UM7FTe8goAiZUivTT_-9DIeC7tEvQ3ck19j_t27Ns/edit#heading=h.35nkun2) (access probably limited but it's not very exciting).

Also kinda moot right now cos pretty much everyone who has one of these "poweruser" roles also has a full admin role, but hopefully that won't be the case for too much longer.

Also "poweruser" should be "developer" but that's another issue.