### PR TITLE
Log all requests through backend_public WAF ACL

### DIFF
--- a/terraform/projects/infra-public-wafs/backend_public_rule.tf
+++ b/terraform/projects/infra-public-wafs/backend_public_rule.tf
@@ -213,26 +213,4 @@ resource "aws_cloudwatch_log_group" "public_backend_waf" {
 resource "aws_wafv2_web_acl_logging_configuration" "public_backend_waf" {
   log_destination_configs = [aws_cloudwatch_log_group.public_backend_waf.arn]
   resource_arn            = aws_wafv2_web_acl.backend_public.arn
-
-  logging_filter {
-    default_behavior = "DROP"
-
-    filter {
-      behavior = "KEEP"
-
-      condition {
-        action_condition {
-          action = "COUNT"
-        }
-      }
-
-      condition {
-        action_condition {
-          action = "BLOCK"
-        }
-      }
-
-      requirement = "MEETS_ANY"
-    }
-  }
 }


### PR DESCRIPTION
[Trello card](https://trello.com/c/5nkX83ng/3404-3-implement-ja3-fingerprinting-on-the-waf-acl-used-by-our-publishing-apps)

Rationale: We recently added support (#1819) for JA3 denylisting on the backend_public ACL, but the only place we currently log JA3 fingerprints is in the WAF logs. Currently the backend_public ACL is configured to only log requests that were blocked or counted, so we have no way to find the JA3 fingerprints of traffic that was allowed, but that we want to add to the JA3 denylist.

This will increase the number of requests being logged by this ACL, but the amount is around the same order of magnitude as the volume of requests we already block (and therefore log) in the cache_public ACL. The `aws-waf-logs-backend-public-production` log group only has 1 month of retention.