### PR TITLE
Further cleanup in MQ module.

### DIFF
--- a/terraform/lambda/PostConfigToAmazonMQ/post_config_to_amazonmq.py
+++ b/terraform/lambda/PostConfigToAmazonMQ/post_config_to_amazonmq.py
@@ -5,30 +5,34 @@ import urllib.error
 
 from urllib import request
 
+
 def raise_if_not_an_amazonmq_url(url):
     if re.fullmatch(r'.*\.mq\.[a-z0-9_-]+\.amazonaws\.com/.*', url) is None:
         raise ValueError(f'Not a valid AmazonMQ URL: {url}')
 
+
 def auth_digest(username, password):
-    credentials = "%s:%s" % (username, password)
+    credentials = f'{username}:{password}'
     return base64.b64encode(credentials.encode('UTF8'))
 
+
 def add_headers(req, event):
-    auth_header_value = b'Basic ' + auth_digest(event['username'], event['password'])
+    auth_header_value = b'Basic ' + \
+        auth_digest(event['username'], event['password'])
     req.add_header('Authorization', auth_header_value)
-
     req.add_header('Content-type', 'application/json')
-
     return req
 
-def lambda_handler(event, context):
+
+def lambda_handler(event, _):
     raise_if_not_an_amazonmq_url(event['url'])
 
     raw_json = base64.b64decode(event['json_b64'])
-    req = request.Request(event['url'], data=raw_json, method='POST', unverifiable=True)
+    req = request.Request(event['url'], data=raw_json,
+                          method='POST', unverifiable=True)
     add_headers(req, event)
 
-    print('Posting json to ', event['url'])
+    print('Posting JSON to ', event['url'])
     try:
         resp = request.urlopen(req)
         status = resp.status

--- a/terraform/lambda/PostConfigToAmazonMQ/post_config_to_amazonmq.py
+++ b/terraform/lambda/PostConfigToAmazonMQ/post_config_to_amazonmq.py
@@ -1,6 +1,7 @@
 import base64
 
 import re
+import urllib.error
 
 from urllib import request
 
@@ -28,13 +29,18 @@ def lambda_handler(event, context):
     add_headers(req, event)
 
     print('Posting json to ', event['url'])
-    resp = request.urlopen(req)
+    try:
+        resp = request.urlopen(req)
+        status = resp.status
+        response_body = resp.read()
+    except urllib.error.HTTPError as e:
+        status = e.status
+        response_body = e.read().decode()
 
-    print('Posted - status_code = ', resp.status)
-    response_body = resp.read()
-    print('Response body: (only present if an error occurred)', response_body)
+    print('response status: ', status)
+    print('response body: ', response_body)
 
     return {
-        'statusCode': resp.status,
+        'statusCode': status,
         'body': response_body
     }

--- a/terraform/projects/app-publishing-amazonmq/main.tf
+++ b/terraform/projects/app-publishing-amazonmq/main.tf
@@ -309,7 +309,7 @@ resource "aws_lambda_function" "post_config_to_amazonmq" {
   source_code_hash = data.archive_file.artefact_lambda.output_base64sha256
 
   function_name = "govuk-${var.aws_environment}-post_config_to_amazonmq"
-  role          = aws_iam_role.post_config_to_amazonmq_role.arn
+  role          = aws_iam_role.post_config_to_amazonmq.arn
   handler       = "post_config_to_amazonmq.lambda_handler"
   runtime       = "python3.8"
 
@@ -319,27 +319,23 @@ resource "aws_lambda_function" "post_config_to_amazonmq" {
   }
 }
 
-resource "aws_iam_role" "post_config_to_amazonmq_role" {
-  name               = "post_config_to_amazonmq_role"
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
+data "aws_iam_policy_document" "lambda_assumerole" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
     }
-  ]
+  }
 }
-EOF
+
+resource "aws_iam_role" "post_config_to_amazonmq" {
+  name               = "post_config_to_amazonmq"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assumerole.json
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_role_policy" {
-  role       = aws_iam_role.post_config_to_amazonmq_role.name
+  role       = aws_iam_role.post_config_to_amazonmq.name
   policy_arn = data.aws_iam_policy.lambda_vpc_access.arn
 }
 

--- a/terraform/projects/app-publishing-amazonmq/main.tf
+++ b/terraform/projects/app-publishing-amazonmq/main.tf
@@ -18,10 +18,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
-    dns = {
-      source  = "hashicorp/dns"
-      version = "~> 3.4"
-    }
     local = {
       source  = "hashicorp/local"
       version = "~> 2.5"

--- a/terraform/projects/app-publishing-amazonmq/main.tf
+++ b/terraform/projects/app-publishing-amazonmq/main.tf
@@ -311,7 +311,7 @@ resource "aws_lambda_function" "post_config_to_amazonmq" {
   function_name = "govuk-${var.aws_environment}-post_config_to_amazonmq"
   role          = aws_iam_role.post_config_to_amazonmq.arn
   handler       = "post_config_to_amazonmq.lambda_handler"
-  runtime       = "python3.8"
+  runtime       = "python3.12"
 
   vpc_config {
     subnet_ids         = aws_mq_broker.publishing_amazonmq.subnet_ids

--- a/terraform/projects/app-publishing-amazonmq/outputs.tf
+++ b/terraform/projects/app-publishing-amazonmq/outputs.tf
@@ -22,7 +22,7 @@ output "internal_domain_name" {
 output "publishing_amazonmq_passwords" {
   description = "Generated passwords for each RabbitMQ user account. Use `terraform output -json | jq '.publishing_amazonmq_passwords.value'` to retrieve the values."
   sensitive   = true
-  value       = local.publishing_amazonmq_passwords
+  value       = { for user, pw in random_password.mq_user : user => pw.result }
 }
 
 output "lambda_function_name" {

--- a/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
+++ b/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
@@ -86,7 +86,7 @@
       "configure": ".*",
       "write": ".*",
       "read": ".*"
-    },
+    }
   ],
   "parameters": [],
   "global_parameters": [

--- a/terraform/projects/app-publishing-amazonmq/variables.tf
+++ b/terraform/projects/app-publishing-amazonmq/variables.tf
@@ -51,19 +51,6 @@ variable "publishing_amazonmq_broker_name" {
   default     = "PublishingMQ"
 }
 
-# We need to use count when creating load balancer target group attachments
-# This must be defined before apply, which means it can't be derived from the 
-# outputs of the broker, if the broker doesn't already exist. 
-# The only alternatives are 
-# a) run terraform with -target to create the broker first, before any other run
-# b) define the number of instances in advance
-# We chose b) as the least-worst option
-variable "publishing_amazonmq_instance_count" {
-  type        = number
-  description = "Number of instances the broker has/should have. This would normally be 1 for a deployment_mode of SINGLE_INSTANCE, 2 for ACTIVE_STANDBY_MULTI_AZ, 3 for CLUSTER_MULTI_AZ. Defaults to 1."
-  default     = 1
-}
-
 variable "elb_internal_certname" {
   type        = string
   description = "The ACM cert domain name to find the ARN of, so that it can be applied to the Network Load Balancer"


### PR DESCRIPTION
- Use an up-to-date Python runtime for the config Lambda.
- Use `aws_iam_policy_document` for better ahead-of-time checking.
- Fix the HTTP error handling in the lambda that uploads the config to RabbitMQ.
- Fix a JSON syntax error in the config template which was causing RabbitMQ 3.11 to reject the config.
- Use a map for the random_password resources, since we were putting them in a map for the template anyway.
- Eliminate the `publishing_amazonmq_instance_count` parameter.
- Remove unused provider declaration.
- Remove redundant comments.

Tested: applied in the integration and staging accounts.

https://github.com/alphagov/govuk-infrastructure/issues/1267