### PR TITLE
Roll out RabbitMQ 3.11 to production.

### DIFF
--- a/terraform/projects/app-publishing-amazonmq/main.tf
+++ b/terraform/projects/app-publishing-amazonmq/main.tf
@@ -87,7 +87,7 @@ data "aws_network_interface" "mq" {
 resource "aws_mq_broker" "publishing_amazonmq" {
   broker_name = var.publishing_amazonmq_broker_name
 
-  engine_type         = var.engine_type
+  engine_type         = "RabbitMQ"
   engine_version      = var.engine_version
   deployment_mode     = var.deployment_mode
   host_instance_type  = var.host_instance_type

--- a/terraform/projects/app-publishing-amazonmq/variables.tf
+++ b/terraform/projects/app-publishing-amazonmq/variables.tf
@@ -9,16 +9,10 @@ variable "aws_environment" {
   description = "AWS Environment"
 }
 
-variable "engine_type" {
-  type        = string
-  description = "ActiveMQ or RabbitMQ"
-  default     = "RabbitMQ"
-}
-
 variable "engine_version" {
   type        = string
-  description = "broker engine version"
-  default     = "3.9.27"
+  description = "Broker engine version. https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/rabbitmq-version-management"
+  default     = "3.11.28"
 }
 
 variable "deployment_mode" {


### PR DESCRIPTION
Make RabbitMQ 3.11.28 the default version. 3.11.28 is currently the latest version that Amazon MQ supports.

This has been soaking in integration and staging for a couple of days now.

Also get rid of the engine_type parameter; it's not useful as-is.

Rollout: I'm not gonna do the actual rollout via Terraform; this PR is just to update the stored config to match once we're done. https://github.com/alphagov/govuk-aws-data/pull/1286 reflects the intermediate 3.10 rollout.

https://github.com/alphagov/govuk-infrastructure/issues/1267