### PR TITLE
Add govuk_chat_published_documents queue to rabbitmq

### DIFF
--- a/terraform/projects/app-publishing-amazonmq/main.tf
+++ b/terraform/projects/app-publishing-amazonmq/main.tf
@@ -54,6 +54,7 @@ resource "random_password" "mq_user" {
     "root",
     "content_data_api",
     "email_alert_service",
+    "govuk_chat",
     "monitoring",
     "publishing_api",
     "search_api",

--- a/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
+++ b/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
@@ -17,6 +17,11 @@
       "tags": ""
     },
     {
+      "name": "govuk_chat",
+      "password": "${publishing_amazonmq_passwords["govuk_chat"]}",
+      "tags": ""
+    },
+    {
       "name": "monitoring",
       "password": "${publishing_amazonmq_passwords["monitoring"]}",
       "tags": "monitoring"
@@ -44,6 +49,13 @@
       "configure": "^(amq\\.gen.*|email_alert_service|email_unpublishing|subscriber_list_details_update_minor|subscriber_list_details_update_major)$",
       "write": "^(amq\\.gen.*|email_alert_service|email_unpublishing|subscriber_list_details_update_minor|subscriber_list_details_update_major)$",
       "read": "^(amq\\.gen.*|email_alert_service|email_unpublishing|subscriber_list_details_update_minor|subscriber_list_details_update_major|published_documents)$"
+    },
+    {
+      "user": "govuk_chat",
+      "vhost": "publishing",
+      "configure": "^govuk_chat_published_documents$",
+      "write": "^$",
+      "read": "^govuk_chat_published_documents$"
     },
     {
       "user": "content_data_api",
@@ -192,6 +204,13 @@
       "arguments": {}
     },
     {
+      "name": "govuk_chat_published_documents",
+      "vhost": "publishing",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    },
+    {
       "name": "email_unpublishing",
       "vhost": "publishing",
       "durable": true,
@@ -271,6 +290,14 @@
     {
       "source": "published_documents",
       "vhost": "publishing",
+      "destination": "govuk_chat_published_documents",
+      "destination_type": "queue",
+      "routing_key": "*.bulk.govuk-chat-sync",
+      "arguments": {}
+    },
+    {
+      "source": "published_documents",
+      "vhost": "publishing",
       "destination": "content_data_api",
       "destination_type": "queue",
       "routing_key": "*.links",
@@ -288,6 +315,14 @@
       "source": "published_documents",
       "vhost": "publishing",
       "destination": "content_data_api",
+      "destination_type": "queue",
+      "routing_key": "*.major",
+      "arguments": {}
+    },
+    {
+      "source": "published_documents",
+      "vhost": "publishing",
+      "destination": "govuk_chat_published_documents",
       "destination_type": "queue",
       "routing_key": "*.major",
       "arguments": {}
@@ -319,6 +354,14 @@
     {
       "source": "published_documents",
       "vhost": "publishing",
+      "destination": "govuk_chat_published_documents",
+      "destination_type": "queue",
+      "routing_key": "*.minor",
+      "arguments": {}
+    },
+    {
+      "source": "published_documents",
+      "vhost": "publishing",
       "destination": "subscriber_list_details_update_minor",
       "destination_type": "queue",
       "routing_key": "*.minor.#",
@@ -335,7 +378,23 @@
     {
       "source": "published_documents",
       "vhost": "publishing",
+      "destination": "govuk_chat_published_documents",
+      "destination_type": "queue",
+      "routing_key": "*.republish",
+      "arguments": {}
+    },
+    {
+      "source": "published_documents",
+      "vhost": "publishing",
       "destination": "content_data_api",
+      "destination_type": "queue",
+      "routing_key": "*.unpublish",
+      "arguments": {}
+    },
+    {
+      "source": "published_documents",
+      "vhost": "publishing",
+      "destination": "govuk_chat_published_documents",
       "destination_type": "queue",
       "routing_key": "*.unpublish",
       "arguments": {}

--- a/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
+++ b/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
@@ -53,7 +53,7 @@
     {
       "user": "govuk_chat",
       "vhost": "publishing",
-      "configure": "^govuk_chat_published_documents$",
+      "configure": "^$",
       "write": "^$",
       "read": "^govuk_chat_published_documents$"
     },

--- a/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
+++ b/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
@@ -292,7 +292,7 @@
       "vhost": "publishing",
       "destination": "govuk_chat_published_documents",
       "destination_type": "queue",
-      "routing_key": "*.bulk.govuk-chat-sync",
+      "routing_key": "*.bulk.govuk_chat_sync",
       "arguments": {}
     },
     {


### PR DESCRIPTION
We need a new queue in rabbitmq for the govuk chat app to consume new published document in order to update its vector database as soon as a new document is published in GOV.UK