### PR TITLE
Chat listen to links queue

### DIFF
--- a/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
+++ b/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl
@@ -306,6 +306,14 @@
     {
       "source": "published_documents",
       "vhost": "publishing",
+      "destination": "govuk_chat_published_documents",
+      "destination_type": "queue",
+      "routing_key": "*.links",
+      "arguments": {}
+    },
+    {
+      "source": "published_documents",
+      "vhost": "publishing",
       "destination": "search_api_to_be_indexed",
       "destination_type": "queue",
       "routing_key": "*.links",


### PR DESCRIPTION
Previously we didn't need to listen to this queue as chat didn't utilise any decisions based on the contents of RabbitMQ links. However the new features we're planning require this (checking history mode, parent document type) and thus I'm adding this.

This will result in a higher drastically higher quantity of content being ingested as the links queue is quite noisy.