### PR TITLE
Tag elasticsearch resources with GOV.UK - Search

### DIFF
--- a/terraform/projects/app-elasticsearch6/main.tf
+++ b/terraform/projects/app-elasticsearch6/main.tf
@@ -25,6 +25,7 @@ provider "aws" {
     tags = {
       terraform_deployment = basename(abspath(path.root))
       aws_environment      = var.aws_environment
+      project              = "GOV.UK - Search"
     }
   }
 }


### PR DESCRIPTION
One slightly unfortunate gotcha here is that the Project tag (note: capital P) is already used for "blue" or "govuk" stacks, alongside the "aws_stackname" tag.

Tags are case sensitive in AWS, so Project != project.

project with a lower case "p" is set as a cost allocation tag, while Project with an upper case "P" is not.

Having them both is probably a bit confusing, but I don't want to go too far down the rabbit hole here.

Eventually we should probably just remove the Project = blue / govuk tags from everything.