### PR TITLE
Remove references to sg_management_id

### DIFF
--- a/terraform/projects/app-elasticsearch6/main.tf
+++ b/terraform/projects/app-elasticsearch6/main.tf
@@ -124,7 +124,6 @@ resource "aws_elasticsearch_domain" "elasticsearch6" {
     )
     security_group_ids = [
       data.terraform_remote_state.infra_security_groups.outputs.sg_elasticsearch6_id,
-      data.terraform_remote_state.infra_security_groups.outputs.sg_management_id,
     ]
   }
 

--- a/terraform/projects/app-related-links/main.tf
+++ b/terraform/projects/app-related-links/main.tf
@@ -329,7 +329,6 @@ resource "aws_launch_template" "related-links-ingestion_launch-template" {
 
   vpc_security_group_ids = [
     "${data.terraform_remote_state.infra_security_groups.sg_related-links_id}",
-    "${data.terraform_remote_state.infra_security_groups.sg_management_id}",
   ]
 
   key_name = aws_key_pair.jenkins_public_key.key_name

--- a/terraform/projects/app-search/main.tf
+++ b/terraform/projects/app-search/main.tf
@@ -26,7 +26,6 @@ module "search" {
   instance_subnet_ids = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
   instance_security_group_ids = [
     data.terraform_remote_state.infra_security_groups.outputs.sg_search_id,
-    data.terraform_remote_state.infra_security_groups.outputs.sg_management_id
   ]
   instance_type                 = var.instance_type
   instance_additional_user_data = join("\n", null_resource.user_data.*.triggers.snippet)


### PR DESCRIPTION
This was the security group that let us SSH into instances in the pre-replatforming world.

It no longer exists, but its ID is still in the now deleted infra-security-groups project's statefile.

None of these projects have been applied since the security group was deleted, but clearly they've all been removed from the security group (since it no longer exists). Or in the case of related links, they're probably just not applied at all.

This commit at least fixes an obviously broken bit of config, making it slightly more likely that we'd be able to apply these projects if we wanted to.

It's enough to fix app-elasticsearch6, which is the one I care about right now.